### PR TITLE
Correctly referencing an array of complex object

### DIFF
--- a/lib/swagger-explorer.ts
+++ b/lib/swagger-explorer.ts
@@ -1,20 +1,21 @@
-import { MetadataScanner } from '@nestjs/core/metadata-scanner';
+import { METHOD_METADATA, PATH_METADATA } from '@nestjs/common/constants';
+import {
+  exploreApiBearerMetadata,
+  exploreGlobalApiBearerMetadata,
+} from './explorers/api-bearer.explorer';
+import { exploreApiConsumesMetadata, exploreGlobalApiConsumesMetadata } from './explorers/api-consumes.explorer';
+import { exploreApiProducesMetadata, exploreGlobalApiProducesMetadata } from './explorers/api-produces.explorer';
+import { exploreApiResponseMetadata, exploreGlobalApiResponseMetadata } from './explorers/api-response.explorer';
+import { exploreApiUseTagsMetadata, exploreGlobalApiUseTagsMetadata } from './explorers/api-use-tags.explorer';
+import { isArray, isEmpty, mapValues, omitBy } from 'lodash';
+import { isUndefined, validatePath } from '@nestjs/common/utils/shared.utils';
+
 import { Controller } from '@nestjs/common/interfaces';
 import { InstanceWrapper } from '@nestjs/core/injector/container';
-import { isUndefined, validatePath } from '@nestjs/common/utils/shared.utils';
-import { PATH_METADATA, METHOD_METADATA } from '@nestjs/common/constants';
+import { MetadataScanner } from '@nestjs/core/metadata-scanner';
 import { RequestMethod } from '@nestjs/common';
-import { mapValues, omitBy, isEmpty, isArray } from 'lodash';
 import { exploreApiOperationMetadata } from './explorers/api-operation.explorer';
-import { exploreGlobalApiProducesMetadata, exploreApiProducesMetadata } from './explorers/api-produces.explorer';
-import { exploreGlobalApiUseTagsMetadata, exploreApiUseTagsMetadata } from './explorers/api-use-tags.explorer';
-import { exploreApiResponseMetadata, exploreGlobalApiResponseMetadata } from './explorers/api-response.explorer';
 import { exploreApiParametersMetadata } from './explorers/api-parameters.explorer';
-import { exploreApiConsumesMetadata, exploreGlobalApiConsumesMetadata } from './explorers/api-consumes.explorer';
-import {
-  exploreGlobalApiBearerMetadata,
-  exploreApiBearerMetadata,
-} from './explorers/api-bearer.explorer';
 
 export class SwaggerExplorer {
     private readonly metadataScanner = new MetadataScanner();
@@ -106,7 +107,7 @@ export class SwaggerExplorer {
         if (isUndefined(path)) {
             return '';
         }
-        const pathWithParams = path.replace(/([:].*?[^\/]*)/, (str) => {
+        const pathWithParams = path.replace(/([:].*?[^\/]*)/g, (str) => {
             return `{${str.slice(1, str.length)}}`;
         });
         return pathWithParams === '/' ? '' : validatePath(pathWithParams);


### PR DESCRIPTION
Fixing an issue where nested model wasn't being correctly referenced in a model definition.
```typescript
class B {
  @ApiModelProperty()
  prop1: string;
}
class A {
  @ApiModelProperty({ type: B, isArray: true })
  nestedB: B[];
}
```
returned:
```json
{
  "B": {
    "type": "object",
    "properties": {
      "prop1": {
        "type": "string"
      }
    }
  },
  "A": {
    "type": "object",
    "properties": {
      "nestedB": {
        "$ref": "#/definitions/B"
      }
    }
  }
}
```
instead of:
```json
{
  "A": {
    "type": "object",
   "properties": {
      "nestedB": {
        "type": "array",
        "items": {
          "$ref": "#/definitions/B"
        }
      }
    }
  }
}
```

Decorating a complex object without explicitly stating it as an array doesn't work because of https://github.com/Microsoft/TypeScript/issues/7169