### PR TITLE
Parse all in path parameters

### DIFF
--- a/lib/swagger-explorer.ts
+++ b/lib/swagger-explorer.ts
@@ -106,7 +106,7 @@ export class SwaggerExplorer {
         if (isUndefined(path)) {
             return '';
         }
-        const pathWithParams = path.replace(/([:].*?[^\/]*)/, (str) => {
+        const pathWithParams = path.replace(/([:].*?[^\/]*)/g, (str) => {
             return `{${str.slice(1, str.length)}}`;
         });
         return pathWithParams === '/' ? '' : validatePath(pathWithParams);


### PR DESCRIPTION
Fixed an issue having multiple in path parameters. Only the first encountered was being replaced.