### PR TITLE
Fix crash when encoutering modules that have not routes

### DIFF
--- a/lib/swagger-transformer.ts
+++ b/lib/swagger-transformer.ts
@@ -1,8 +1,13 @@
+import * as _ from 'lodash';
 import { groupBy, keyBy, mapValues, omit } from 'lodash';
 
 export class SwaggerTransformer {
     public normalizePaths(denormalizedDoc) {
-        const groupedByPath = groupBy(denormalizedDoc, ({ root }) => root.path);
+        const groupedByPath = _(denormalizedDoc)
+          .filter(r => r.root)
+          .groupBy(({ root }) => root.path)
+          .value();
+
         const paths = mapValues(groupedByPath, (routes) => {
             const keyByMethod = keyBy(routes, ({ root }) => root.method);
             return mapValues(keyByMethod, (route: any) => {


### PR DESCRIPTION
This is for usage with NestJS 4.

A bit of a hack though, I would have preferred to be able to only get the Controllers modules before reaching this code but I couldn't find a way to accomplish this. Any pointers welcome if this is possible in a better manner :smile:. 
