### PR TITLE
Set swagger version

### DIFF
--- a/lib/interfaces/swagger-base-config.interface.ts
+++ b/lib/interfaces/swagger-base-config.interface.ts
@@ -1,4 +1,5 @@
 export interface SwaggerBaseConfig {
+    swagger?: string,
     info?: {
         description?: string;
         version?: string;

--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -11,6 +11,7 @@ export class SwaggerModule {
         return {
             ...config,
             ...document,
+            ...{ swagger: "2.0" }
         };
     }
 

--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -11,7 +11,7 @@ export class SwaggerModule {
         return {
             ...config,
             ...document,
-            ...{ swagger: "2.0" }
+            swagger: "2.0"
         };
     }
 


### PR DESCRIPTION
Set the swagger version to 2.0 as described on [the doc](https://swagger.io/docs/specification/2-0/basic-structure/)

I assume the format is in swagger 2.0 due to how the `body` parameters are reported which I think isn't valid for swagger 3.0.