### PR TITLE
Fix OpenAPI Specification inconsistencies

### DIFF
--- a/lib/document-builder.ts
+++ b/lib/document-builder.ts
@@ -44,7 +44,7 @@ export class DocumentBuilder {
   }
 
   public setBasePath(basePath: string): this {
-    this.document.basePath = /^\/.*/.test(basePath) ? basePath : '/' + basePath;
+    this.document.basePath = basePath.startsWith('/') ? basePath : '/' + basePath;
     return this;
   }
 

--- a/lib/document-builder.ts
+++ b/lib/document-builder.ts
@@ -1,8 +1,9 @@
-import { documentBase } from './fixtures/document.base';
 import {
   SwaggerBaseConfig,
   SwaggerScheme,
 } from './interfaces/swagger-base-config.interface';
+
+import { documentBase } from './fixtures/document.base';
 
 export class DocumentBuilder {
   private readonly document: SwaggerBaseConfig = documentBase;
@@ -43,7 +44,7 @@ export class DocumentBuilder {
   }
 
   public setBasePath(basePath: string): this {
-    this.document.basePath = basePath;
+    this.document.basePath = /^\/.*/.test(basePath) ? basePath : '/' + basePath;
     return this;
   }
 

--- a/lib/explorers/api-parameters.explorer.ts
+++ b/lib/explorers/api-parameters.explorer.ts
@@ -111,14 +111,21 @@ export const exploreModelDefinition = (type, definitions) => {
             type: swaggerType,
         };
     });
+    const typeDefinition = {
+        type: 'object',
+        properties: mapValues(
+            keyBy(propertiesWithType, 'name'),
+            (property) => omit(property, ['name', 'isArray', 'required']),
+        )
+    };
+    const typeDefinitionRequiredFields = propertiesWithType
+        .filter((property) => property.required != false)
+        .map((property) => property.name);
+    if (typeDefinitionRequiredFields.length > 0) {
+        typeDefinition['required'] = typeDefinitionRequiredFields;
+    }
     definitions.push({
-        [type.name]: {
-            type: 'object',
-            properties: mapValues(
-                keyBy(propertiesWithType, 'name'),
-                (property) => omit(property, ['name', 'isArray']),
-            ),
-        },
+        [type.name]: typeDefinition
     });
     return type.name;
 };

--- a/lib/explorers/api-response.explorer.ts
+++ b/lib/explorers/api-response.explorer.ts
@@ -1,6 +1,7 @@
-import { DECORATORS } from '../constants';
-import { mapValues } from 'lodash';
 import { exploreModelDefinition, mapTypesToSwaggerTypes } from './api-parameters.explorer';
+import { mapValues, omit } from 'lodash';
+
+import { DECORATORS } from '../constants';
 import { isFunction } from '@nestjs/common/utils/shared.utils';
 
 export const exploreGlobalApiResponseMetadata = (definitions, metatype) => {
@@ -20,6 +21,7 @@ export const exploreApiResponseMetadata = (definitions, instance, prototype, met
 
 const mapResponsesToSwaggerResponses = (responses, definitions) => mapValues(responses, (response) => {
     const { type, isArray } = response;
+    response = omit(response, ['isArray']);
     // tslint:disable-next-line:curly
     if (!type) return response;
     const defaultTypes = [String, Boolean, Number, Object, Array];

--- a/lib/fixtures/document.base.ts
+++ b/lib/fixtures/document.base.ts
@@ -7,7 +7,7 @@ export const documentBase = {
     version: '1.0.0',
     title: '',
   },
-  basePath: '',
+  basePath: '/',
   tags: [],
   schemes: ['http'] as SwaggerScheme[],
 };

--- a/lib/swagger-explorer.ts
+++ b/lib/swagger-explorer.ts
@@ -1,20 +1,21 @@
-import { MetadataScanner } from '@nestjs/core/metadata-scanner';
+import { METHOD_METADATA, PATH_METADATA } from '@nestjs/common/constants';
+import {
+  exploreApiBearerMetadata,
+  exploreGlobalApiBearerMetadata,
+} from './explorers/api-bearer.explorer';
+import { exploreApiConsumesMetadata, exploreGlobalApiConsumesMetadata } from './explorers/api-consumes.explorer';
+import { exploreApiProducesMetadata, exploreGlobalApiProducesMetadata } from './explorers/api-produces.explorer';
+import { exploreApiResponseMetadata, exploreGlobalApiResponseMetadata } from './explorers/api-response.explorer';
+import { exploreApiUseTagsMetadata, exploreGlobalApiUseTagsMetadata } from './explorers/api-use-tags.explorer';
+import { isArray, isEmpty, mapValues, omitBy } from 'lodash';
+import { isUndefined, validatePath } from '@nestjs/common/utils/shared.utils';
+
 import { Controller } from '@nestjs/common/interfaces';
 import { InstanceWrapper } from '@nestjs/core/injector/container';
-import { isUndefined, validatePath } from '@nestjs/common/utils/shared.utils';
-import { PATH_METADATA, METHOD_METADATA } from '@nestjs/common/constants';
+import { MetadataScanner } from '@nestjs/core/metadata-scanner';
 import { RequestMethod } from '@nestjs/common';
-import { mapValues, omitBy, isEmpty, isArray } from 'lodash';
 import { exploreApiOperationMetadata } from './explorers/api-operation.explorer';
-import { exploreGlobalApiProducesMetadata, exploreApiProducesMetadata } from './explorers/api-produces.explorer';
-import { exploreGlobalApiUseTagsMetadata, exploreApiUseTagsMetadata } from './explorers/api-use-tags.explorer';
-import { exploreApiResponseMetadata, exploreGlobalApiResponseMetadata } from './explorers/api-response.explorer';
 import { exploreApiParametersMetadata } from './explorers/api-parameters.explorer';
-import { exploreApiConsumesMetadata, exploreGlobalApiConsumesMetadata } from './explorers/api-consumes.explorer';
-import {
-  exploreGlobalApiBearerMetadata,
-  exploreApiBearerMetadata,
-} from './explorers/api-bearer.explorer';
 
 export class SwaggerExplorer {
     private readonly metadataScanner = new MetadataScanner();
@@ -106,7 +107,7 @@ export class SwaggerExplorer {
         if (isUndefined(path)) {
             return '';
         }
-        const pathWithParams = path.replace(/([:].*?[^\/]*)/, (str) => {
+        const pathWithParams = path.replace(/([:].*?[^\/]*)/g, (str) => {
             return `{${str.slice(1, str.length)}}`;
         });
         return pathWithParams === '/' ? '' : validatePath(pathWithParams);


### PR DESCRIPTION
According to OpenAPI Specification:
1. basePath must start with "/".
2. response should not contain additional properties (isArray).
3. required fields should be an array in Schema Object (resolves #24).