### PR TITLE
Added Support for enum and format properties for ApiModelProperty

### DIFF
--- a/lib/decorators/api-implicit-query.decorator.ts
+++ b/lib/decorators/api-implicit-query.decorator.ts
@@ -12,6 +12,7 @@ export const ApiImplicitQuery = (metadata: {
     description?: string;
     required?: boolean;
     type?: 'String' | 'Number' | 'Boolean' | any;
+    enum?: string[]
 }): MethodDecorator => {
     const param = {
         name: isNil(metadata.name) ? initialMetadata.name : metadata.name,

--- a/lib/decorators/api-model-property.decorator.ts
+++ b/lib/decorators/api-model-property.decorator.ts
@@ -7,6 +7,7 @@ export const ApiModelProperty = (metadata: {
     required?: boolean;
     type?: any;
     isArray?: boolean;
+    enum?: string[];
     default?: any;
 } = {}): PropertyDecorator => {
     return createPropertyDecorator(DECORATORS.API_MODEL_PROPERTIES, metadata);
@@ -16,6 +17,7 @@ export const ApiModelPropertyOptional = (metadata: {
     description?: string;
     type?: any;
     isArray?: boolean;
+    enum?: string[]
     default?: any;
 } = {}): PropertyDecorator => ApiModelProperty({
     ...metadata,

--- a/lib/decorators/api-model-property.decorator.ts
+++ b/lib/decorators/api-model-property.decorator.ts
@@ -9,6 +9,7 @@ export const ApiModelProperty = (metadata: {
     isArray?: boolean;
     enum?: string[];
     default?: any;
+    format?: string;
 } = {}): PropertyDecorator => {
     return createPropertyDecorator(DECORATORS.API_MODEL_PROPERTIES, metadata);
 };
@@ -19,6 +20,7 @@ export const ApiModelPropertyOptional = (metadata: {
     isArray?: boolean;
     enum?: string[]
     default?: any;
+    format?: string;
 } = {}): PropertyDecorator => ApiModelProperty({
     ...metadata,
     required: false,


### PR DESCRIPTION
Create support for Swagger enum property on ApiImplicitQuery and ApiMpodelProperty Decorators.  See [Swgger Enums](https://swagger.io/docs/specification/2-0/enums/) for more info on the Swagger spec.