### PR TITLE
Add support for swagger customization options

### DIFF
--- a/lib/interfaces/index.ts
+++ b/lib/interfaces/index.ts
@@ -1,2 +1,3 @@
 export * from './swagger-base-config.interface';
 export * from './swagger-document.interface';
+export * from './swagger-custom-options.interface';

--- a/lib/interfaces/swagger-custom-options.interface.ts
+++ b/lib/interfaces/swagger-custom-options.interface.ts
@@ -1,0 +1,9 @@
+export interface SwaggerCustomOptions {
+  explorer?: boolean;
+  swaggerOptions?: any;
+  customCss?: string;
+  customJs?: string;
+  customfavIcon?: string;
+  swaggerUrl?: string;
+  customSiteTitle?: string;
+}

--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -1,6 +1,6 @@
 import * as swaggerUi from 'swagger-ui-express';
 import { INestApplication } from '@nestjs/common';
-import { SwaggerBaseConfig, SwaggerDocument } from './interfaces';
+import { SwaggerBaseConfig, SwaggerDocument, SwaggerCustomOptions } from './interfaces';
 import { SwaggerScanner } from './swagger-scanner';
 
 export class SwaggerModule {
@@ -19,7 +19,8 @@ export class SwaggerModule {
         path: string,
         app: INestApplication,
         document: SwaggerDocument,
+        options?: SwaggerCustomOptions
     ) {
-        app.use(path, swaggerUi.serve, swaggerUi.setup(document));
+        app.use(path, swaggerUi.serve, swaggerUi.setup(document, options));
     }
 }


### PR DESCRIPTION
**TLDR;** This should resolve https://github.com/nestjs/swagger/issues/42

---

This PR adds the support for the `swagger-ui-express` customization options defined here: https://github.com/scottie1984/swagger-ui-express/blob/master/index.js#L13

You should now, for example, be able to customize your SwaggerUI CSS:
```js
import { NestFactory } from '@nestjs/core';
import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
import { ApplicationModule } from './app.module';

async function bootstrap() {
  const app = await NestFactory.create(ApplicationModule);

  const options = new DocumentBuilder()
    .setTitle('Cats example')
    .setDescription('The cats API description')
    .setVersion('1.0')
    .addTag('cats')
    .build();
  const document = SwaggerModule.createDocument(app, options);
  SwaggerModule.setup('/api', app, document, {
    customCss: "<your CSS rules>"
  });

  await app.listen(3001);
}
bootstrap();
```

I may add some documentation to the code in the days to come.