### PR TITLE
Add JSON Schema Object properties support to the ApiModelProperty decorator

### DIFF
--- a/lib/decorators/api-model-property.decorator.ts
+++ b/lib/decorators/api-model-property.decorator.ts
@@ -8,6 +8,7 @@ export const ApiModelProperty = (metadata: {
     type?: any;
     isArray?: boolean;
     default?: any;
+    enum?: string[] | number[] | (string|number)[];
 } = {}): PropertyDecorator => {
     return createPropertyDecorator(DECORATORS.API_MODEL_PROPERTIES, metadata);
 };
@@ -17,6 +18,7 @@ export const ApiModelPropertyOptional = (metadata: {
     type?: any;
     isArray?: boolean;
     default?: any;
+    enum?: string[] | number[] | (string|number)[];
 } = {}): PropertyDecorator => ApiModelProperty({
     ...metadata,
     required: false,

--- a/lib/decorators/api-model-property.decorator.ts
+++ b/lib/decorators/api-model-property.decorator.ts
@@ -9,6 +9,22 @@ export const ApiModelProperty = (metadata: {
     isArray?: boolean;
     default?: any;
     enum?: string[] | number[] | (string|number)[];
+    format?: string;
+    multipleOf?: number;
+    maximum?: number;
+    exclusiveMaximum?: number;
+    minimum?: number;
+    exclusiveMinimum?: number;
+    maxLength?: number;
+    minLength?: number;
+    pattern?: string;
+    maxItems?: number;
+    minItems?: number;
+    uniqueItems?: boolean;
+    maxProperties?: number;
+    minProperties?: number;
+    readOnly?: boolean;
+    xml?: any;
 } = {}): PropertyDecorator => {
     return createPropertyDecorator(DECORATORS.API_MODEL_PROPERTIES, metadata);
 };
@@ -19,6 +35,22 @@ export const ApiModelPropertyOptional = (metadata: {
     isArray?: boolean;
     default?: any;
     enum?: string[] | number[] | (string|number)[];
+    format?: string;
+    multipleOf?: number;
+    maximum?: number;
+    exclusiveMaximum?: number;
+    minimum?: number;
+    exclusiveMinimum?: number;
+    maxLength?: number;
+    minLength?: number;
+    pattern?: string;
+    maxItems?: number;
+    minItems?: number;
+    uniqueItems?: boolean;
+    maxProperties?: number;
+    minProperties?: number;
+    readOnly?: boolean;
+    xml?: any;
 } = {}): PropertyDecorator => ApiModelProperty({
     ...metadata,
     required: false,

--- a/lib/explorers/api-parameters.explorer.ts
+++ b/lib/explorers/api-parameters.explorer.ts
@@ -108,7 +108,7 @@ export const exploreModelDefinition = (type, definitions) => {
         return {
             ...metadata,
             name: key,
-            type: swaggerType,
+            type: metadata.enum ? getEnumType(metadata.enum) : swaggerType,
         };
     });
     const typeDefinition = {
@@ -128,6 +128,11 @@ export const exploreModelDefinition = (type, definitions) => {
         [type.name]: typeDefinition
     });
     return type.name;
+};
+
+const getEnumType = (values: string[] | number[] | (string|number)[]): 'string' | 'number' => {
+    const hasString = values.filter(isString).length > 0;
+    return hasString ? 'string' : 'number';
 };
 
 const mapParamType = (key: string): string => {


### PR DESCRIPTION
~~**DISCLAIMER** Looks like a duplicate of https://github.com/nestjs/swagger/pull/44~~

**TLDR;** This PR adds the `enum` property to the `@ApiModelProperty()` decorator

_This PR might also solve https://github.com/nestjs/swagger/issues/19_

---

This PR slightly updates the `@ApiModelProperty()` options by adding the `enum?: string[] | number[] | (string|number)[]`.

Here is a pretty self explanatory example:
```js
export class SampleDto {

  @ApiModelProperty({
    enum: ["String1", "String2"]
  })
  prop1: string;

  @ApiModelProperty({
    enum: ["String1", 2]
  })
  prop2: string;

  @ApiModelProperty({
    enum: [1, 2]
  })
  prop3: number;

}
```

![image](https://user-images.githubusercontent.com/5467696/36052612-baf4c68a-0dee-11e8-82ed-e8ed71187c22.png)
