### PR TITLE
Add support for @Headers('property') parameter decorator.

### DIFF
--- a/lib/explorers/api-parameters.explorer.ts
+++ b/lib/explorers/api-parameters.explorer.ts
@@ -136,6 +136,7 @@ const mapParamType = (key: string): string => {
         case RouteParamtypes.BODY: return 'body';
         case RouteParamtypes.PARAM: return 'path';
         case RouteParamtypes.QUERY: return 'query';
+        case RouteParamtypes.HEADERS: return 'header';
         default: return DEFAULT_PARAM_TOKEN;
     }
 };


### PR DESCRIPTION
@kamilmysliwiec it is a simple change and works perfectly. Is there any reason for not including it to the map?

![image](https://user-images.githubusercontent.com/787495/36743325-50dff2d8-1bea-11e8-8805-dbf974a1dac7.png)
