### PR TITLE
Add `isArray` support for ApiImplicitBody decorator

### DIFF
--- a/lib/decorators/api-implicit-body.decorator.ts
+++ b/lib/decorators/api-implicit-body.decorator.ts
@@ -12,6 +12,7 @@ export const ApiImplicitBody = (metadata: {
     description?: string;
     required?: boolean;
     type?: any;
+    isArray?: boolean;
 }): MethodDecorator => {
     const param = {
         name: isNil(metadata.name) ? initialMetadata.name : metadata.name,
@@ -19,6 +20,7 @@ export const ApiImplicitBody = (metadata: {
         description: metadata.description,
         required: metadata.required,
         type: metadata.type,
+        isArray: metadata.isArray
     };
     return createParamDecorator(param, initialMetadata);
 };

--- a/lib/explorers/api-parameters.explorer.ts
+++ b/lib/explorers/api-parameters.explorer.ts
@@ -180,7 +180,7 @@ const mapModelsToDefinitons = (parameters, definitions) => {
         const schema = {
             $ref: getDefinitionPath(modelName),
         };
-        if (param.isArray === true) {
+        if (param.isArray) {
             return {
                 ...param,
                 name,

--- a/lib/explorers/api-parameters.explorer.ts
+++ b/lib/explorers/api-parameters.explorer.ts
@@ -177,12 +177,23 @@ const mapModelsToDefinitons = (parameters, definitions) => {
         }
         const modelName = exploreModelDefinition(param.type, definitions);
         const name = param.name ? param.name : modelName;
+        const schema = {
+            $ref: getDefinitionPath(modelName),
+        };
+        if (param.isArray === true) {
+            return {
+                ...param,
+                name,
+                schema: {
+                    type: "array",
+                    items: schema
+                }
+            }
+        }
         return {
             ...param,
             name,
-            schema: {
-              $ref: getDefinitionPath(modelName),
-            },
+            schema
         };
     });
 };


### PR DESCRIPTION
Add `isArray` support for ApiImplicitBody decorator
```
class Pet {
  @ApiModelProperty()
  readonly name: string;
}

@Controller("pets")
class PetsController {
  @ApiImplicitBody({ type: Pet, isArray: true, name: "Object" })
  addMany(@Body() pets: Pet[]) {
  }
}
```