### PR TITLE
Add extended support for model definitions and response

### DIFF
--- a/lib/decorators/api-model-property.decorator.ts
+++ b/lib/decorators/api-model-property.decorator.ts
@@ -1,5 +1,5 @@
 import { DECORATORS } from '../constants';
-import { createMethodDecorator, createPropertyDecorator } from './helpers';
+import { createPropertyDecorator } from './helpers';
 import { pickBy, isNil, negate, isUndefined } from 'lodash';
 
 export const ApiModelProperty = (metadata: {
@@ -8,7 +8,20 @@ export const ApiModelProperty = (metadata: {
     type?: any;
     isArray?: boolean;
     default?: any;
+    enum?: any;
+    format?: string;
     example?: any;
+    maximum?: number;
+    exclusiveMaximum?: boolean;
+    minimum?: number;
+    exclusiveMinimum?: number;
+    maxLength?: number;
+    minLength?: number;
+    pattern?: string;
+    maxItems?: number;
+    minItems?: number;
+    uniqueItems?: boolean;
+    multipleOf?: number;
 } = {}): PropertyDecorator => {
     return createPropertyDecorator(DECORATORS.API_MODEL_PROPERTIES, metadata);
 };
@@ -18,7 +31,20 @@ export const ApiModelPropertyOptional = (metadata: {
     type?: any;
     isArray?: boolean;
     default?: any;
+    enum?: any;
+    format?: string;
     example?: any;
+    maximum?: number;
+    exclusiveMaximum?: boolean;
+    minimum?: number;
+    exclusiveMinimum?: number;
+    maxLength?: number;
+    minLength?: number;
+    pattern?: string;
+    maxItems?: number;
+    minItems?: number;
+    uniqueItems?: boolean;
+    multipleOf?: number;
 } = {}): PropertyDecorator => ApiModelProperty({
     ...metadata,
     required: false,

--- a/lib/decorators/api-response.decorator.ts
+++ b/lib/decorators/api-response.decorator.ts
@@ -1,11 +1,11 @@
 import { DECORATORS } from '../constants';
-import { createMethodDecorator } from './helpers';
 import { omit } from 'lodash';
 
 const initialMetadata = {
   status: 0,
   type: String,
   isArray: false,
+  examples: '',
 };
 
 export const ApiResponse = (metadata: {
@@ -13,6 +13,7 @@ export const ApiResponse = (metadata: {
   description?: string;
   type?: any;
   isArray?: boolean;
+  examples?: any;
 }) => {
   metadata.description = metadata.description ? metadata.description : '';
   const groupedMetadata = { [metadata.status]: omit(metadata, 'status') };


### PR DESCRIPTION
# Add extended support for model definitions and response

- Added all supported properties for api-model-property decorator
- Added support for Api response `example` field

This changes takes ability to create completely supported Swagger definitions(used in production on our project). Will be helpful using not forked version of `@nest/swagger`