### PR TITLE
Add support for arrays in ApiImplicitQuery

### DIFF
--- a/lib/decorators/api-implicit-query.decorator.ts
+++ b/lib/decorators/api-implicit-query.decorator.ts
@@ -11,10 +11,8 @@ export const ApiImplicitQuery = (metadata: {
   name: string;
   description?: string;
   required?: boolean;
-  type?: 'String' | 'Number' | 'Boolean' | 'Array' | any;
-  items?: {
-    type: 'String' | 'Number' | 'Boolean' | any;
-  };
+  type?: 'String' | 'Number' | 'Boolean' | any;
+  isArray?: boolean;
 }): MethodDecorator => {
   const param = {
     name: isNil(metadata.name) ? initialMetadata.name : metadata.name,
@@ -22,7 +20,13 @@ export const ApiImplicitQuery = (metadata: {
     description: metadata.description,
     required: metadata.required,
     type: metadata.type,
-    items: metadata.items,
+    items: undefined,
   };
+  if (metadata.isArray) {
+    param.type = Array;
+    param.items = {
+      type: param.type,
+    };
+  }
   return createParamDecorator(param, initialMetadata);
 };

--- a/lib/decorators/api-implicit-query.decorator.ts
+++ b/lib/decorators/api-implicit-query.decorator.ts
@@ -11,7 +11,10 @@ export const ApiImplicitQuery = (metadata: {
   name: string;
   description?: string;
   required?: boolean;
-  type?: 'String' | 'Number' | 'Boolean' | any;
+  type?: 'String' | 'Number' | 'Boolean' | 'Array' | any;
+  items?: {
+    type: 'String' | 'Number' | 'Boolean' | any;
+  };
 }): MethodDecorator => {
   const param = {
     name: isNil(metadata.name) ? initialMetadata.name : metadata.name,
@@ -19,6 +22,7 @@ export const ApiImplicitQuery = (metadata: {
     description: metadata.description,
     required: metadata.required,
     type: metadata.type,
+    items: metadata.items,
   };
   return createParamDecorator(param, initialMetadata);
 };


### PR DESCRIPTION
Conforms to swagger 2.0 spec for array definitions - should help clean up docs and make testing easier through the swagger ui:

![image](https://user-images.githubusercontent.com/20047251/38154791-131254c6-3442-11e8-90a4-2743c6c6591e.png)
