### PR TITLE
added easier enum declaration, corrected wrong swagger for enum arrays

### DIFF
--- a/lib/decorators/api-model-property.decorator.ts
+++ b/lib/decorators/api-model-property.decorator.ts
@@ -1,6 +1,7 @@
 import { DECORATORS } from '../constants';
 import { createMethodDecorator, createPropertyDecorator } from './helpers';
 import { pickBy, isNil, negate, isUndefined } from 'lodash';
+import { SwaggerEnumType } from '../types/swagger-enum.type';
 
 export const ApiModelProperty = (
   metadata: {
@@ -9,7 +10,7 @@ export const ApiModelProperty = (
     type?: any;
     isArray?: boolean;
     default?: any;
-    enum?: string[] | number[] | (string | number)[];
+    enum?: SwaggerEnumType;
     format?: string;
     multipleOf?: number;
     maximum?: number;
@@ -38,7 +39,7 @@ export const ApiModelPropertyOptional = (
     type?: any;
     isArray?: boolean;
     default?: any;
-    enum?: string[] | number[] | (string | number)[];
+    enum?: SwaggerEnumType;
     format?: string;
     multipleOf?: number;
     maximum?: number;

--- a/lib/interfaces/swagger-enum.interface.ts
+++ b/lib/interfaces/swagger-enum.interface.ts
@@ -1,0 +1,3 @@
+export interface SwaggerEnum {
+  [key: number]: string;
+}

--- a/lib/types/swagger-enum.type.ts
+++ b/lib/types/swagger-enum.type.ts
@@ -1,0 +1,7 @@
+import { SwaggerEnum } from '../interfaces/swagger-enum.interface';
+
+export type SwaggerEnumType =
+  | string[]
+  | number[]
+  | (string | number)[]
+  | SwaggerEnum;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nestjs/swagger",
-  "version": "1.1.4",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
The current solution for enums doesn't generate the correct swagger specification when they are used as arrays.

```
@ApiModelProperty({
    enum: EDummyEnum,
    isArray: true
})
```
Would produce:
```
"type": "array",
"enum": [ 
    "Test1",
    "Test2"
],
"items": {`
    "type": "array"
}
```

but it should be:
```
"type": "array",
"enum": [ 
    "Test1",
    "Test2"
],
"items": {`
    "type": "string"
}
```

This Pull Request has a fix for that and it also allows to use enum as a type in the `ApiModelPorperty` rather that defining all enum values.