### PR TITLE
Add support of collectionFormat property

### DIFF
--- a/lib/decorators/api-model-property.decorator.ts
+++ b/lib/decorators/api-model-property.decorator.ts
@@ -8,6 +8,7 @@ export const ApiModelProperty = (
     required?: boolean;
     type?: any;
     isArray?: boolean;
+    collectionFormat?: string;
     default?: any;
     enum?: string[] | number[] | (string | number)[];
     format?: string;
@@ -37,6 +38,7 @@ export const ApiModelPropertyOptional = (
     description?: string;
     type?: any;
     isArray?: boolean;
+    collectionFormat?: string;
     default?: any;
     enum?: string[] | number[] | (string | number)[];
     format?: string;


### PR DESCRIPTION
The parameter allows to change serialisation strategy, which is useful for passing arrays in a querystring. It is documented on https://swagger.io/docs/specification/2-0/describing-parameters/ under "Array and Multi-Value Parameters" header
before:
![image](https://user-images.githubusercontent.com/2871245/39577177-3e4432e2-4ee9-11e8-83e4-175fd1f1f4e6.png)
after I added `collectionFormat: 'multi'`:
![image](https://user-images.githubusercontent.com/2871245/39577243-6c9c253c-4ee9-11e8-921f-909609de9c7f.png)
