### PR TITLE
Update validateRoutePath to use Express's path-to-regexp lib

### DIFF
--- a/lib/swagger-explorer.ts
+++ b/lib/swagger-explorer.ts
@@ -28,6 +28,7 @@ import { MetadataScanner } from '@nestjs/core/metadata-scanner';
 import { RequestMethod } from '@nestjs/common';
 import { exploreApiOperationMetadata } from './explorers/api-operation.explorer';
 import { exploreApiParametersMetadata } from './explorers/api-parameters.explorer';
+import * as pathToRegexp from 'path-to-regexp';
 
 export class SwaggerExplorer {
   private readonly metadataScanner = new MetadataScanner();
@@ -159,10 +160,14 @@ export class SwaggerExplorer {
     if (isUndefined(path)) {
       return '';
     }
-    const pathWithParams = path.replace(/([:].*?[^\/]*)/g, str => {
-      str = str.replace(/\(.*\)$/, ''); // remove any regex in the param
-      return `{${str.slice(1, str.length)}}`;
-    });
+    let pathWithParams = '';
+    for (const item of pathToRegexp.parse(path)) {
+      if (typeof item === 'string') {
+        pathWithParams += item;
+      } else {
+        pathWithParams += `${item.prefix}{${item.name}}`;
+      }
+    }
     return pathWithParams === '/' ? '' : validatePath(pathWithParams);
   }
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "lodash": "^4.17.4",
+    "path-to-regexp": "^2.2.1",
     "swagger-ui-express": "^3.0.8"
   },
   "devDependencies": {


### PR DESCRIPTION
Right now the [Express docs][route-parameters] contain paths which are not properly handled by this swagger extension, for example:

>      Route path: /plantae/:genus.:species
>      Request URL: http://localhost:3000/plantae/Prunus.persica
>      req.params: { "genus": "Prunus", "species": "persica" }
 
generates an OpenAPI doc for the path `/plantae/{genus.:species}`. The Express route still works but tools like `swagger-ui` have problems.

The underlying Express code [indicates that this responsibility was packaged into its own library][document-import], the package [path-to-regexp](https://www.npmjs.com/package/path-to-regexp), which already does all of the "remove the trailing regexp" difficult stuff for you. It seems like the proper way for this project to proceed is, rather than trying to hack up something which does what Express does, to just depend on this library as well and use *it* to break up the path string, then turn *that* into a proper Swagger path. This PR contains a first stab at that.

[route-parameters]: https://expressjs.com/en/guide/routing.html#route-parameters
[document-import]: https://github.com/expressjs/express/blob/master/lib/router/layer.js#L16