### PR TITLE
Added various ApiResponses decorators based on HttpStatus

### DIFF
--- a/lib/decorators/api-response.decorator.ts
+++ b/lib/decorators/api-response.decorator.ts
@@ -1,11 +1,18 @@
 import { omit } from 'lodash';
 import { DECORATORS } from '../constants';
+import { HttpStatus } from '@nestjs/common/enums/http-status.enum';
 
 const initialMetadata = {
   status: 0,
   type: String,
   isArray: false
 };
+
+export interface responseMetadata {
+  description?: string;
+  type?: any;
+  isArray?: boolean;
+}
 
 export const ApiResponse = (metadata: {
   status: number;
@@ -42,3 +49,105 @@ export const ApiResponse = (metadata: {
     return target;
   };
 };
+
+export const ApiOkResponse = (metadata: responseMetadata) =>
+  ApiResponse({
+    ...metadata,
+    status: HttpStatus.OK
+  });
+
+export const ApiCreatedResponse = (metadata: responseMetadata) =>
+  ApiResponse({
+    ...metadata,
+    status: HttpStatus.CREATED
+  });
+
+export const ApiBadRequestResponse = (metadata: responseMetadata) =>
+  ApiResponse({
+    ...metadata,
+    status: HttpStatus.BAD_REQUEST
+  });
+
+export const ApiInternalServerErrorResponse = (metadata: responseMetadata) =>
+  ApiResponse({
+    ...metadata,
+    status: HttpStatus.INTERNAL_SERVER_ERROR
+  });
+
+export const ApiBadGatewayResponse = (metadata: responseMetadata) =>
+  ApiResponse({
+    ...metadata,
+    status: HttpStatus.BAD_GATEWAY
+  });
+
+export const ApiConflictResponse = (metadata: responseMetadata) =>
+  ApiResponse({
+    ...metadata,
+    status: HttpStatus.CONFLICT
+  });
+
+export const ApiForbiddenResponse = (metadata: responseMetadata) =>
+  ApiResponse({
+    ...metadata,
+    status: HttpStatus.FORBIDDEN
+  });
+
+export const ApiGatewayTimeoutResponse = (metadata: responseMetadata) =>
+  ApiResponse({
+    ...metadata,
+    status: HttpStatus.GATEWAY_TIMEOUT
+  });
+
+export const ApiGoneResponse = (metadata: responseMetadata) =>
+  ApiResponse({
+    ...metadata,
+    status: HttpStatus.GONE
+  });
+
+export const ApiMethodNotAllowedResponse = (metadata: responseMetadata) =>
+  ApiResponse({
+    ...metadata,
+    status: HttpStatus.METHOD_NOT_ALLOWED
+  });
+
+export const ApiNotAcceptableResponse = (metadata: responseMetadata) =>
+  ApiResponse({
+    ...metadata,
+    status: HttpStatus.NOT_ACCEPTABLE
+  });
+
+export const ApiNotImplementedResponse = (metadata: responseMetadata) =>
+  ApiResponse({
+    ...metadata,
+    status: HttpStatus.NOT_IMPLEMENTED
+  });
+
+export const ApiPayloadTooLargeResponse = (metadata: responseMetadata) =>
+  ApiResponse({
+    ...metadata,
+    status: HttpStatus.PAYLOAD_TOO_LARGE
+  });
+
+export const ApiRequestTimeoutResponse = (metadata: responseMetadata) =>
+  ApiResponse({
+    ...metadata,
+    status: HttpStatus.REQUEST_TIMEOUT
+  });
+
+export const ApiServiceUnavailableResponse = (metadata: responseMetadata) =>
+  ApiResponse({
+    ...metadata,
+    status: HttpStatus.SERVICE_UNAVAILABLE
+  });
+
+export const ApiUnprocessableEntityResponse = (metadata: responseMetadata) =>
+  ApiResponse({
+    ...metadata,
+    status: HttpStatus.UNPROCESSABLE_ENTITY
+  });
+
+export const ApiUnsupportedMediaTypeResponse = (metadata: responseMetadata) =>
+  ApiResponse({
+    ...metadata,
+    status: HttpStatus.UNSUPPORTED_MEDIA_TYPE
+  });


### PR DESCRIPTION
- The number of "shortcut" ApiResponses matches with the number of "shortcut" HttpExceptions.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
Various "shortcut" to `@ApiResponse` have been added in according to `HttpStatus`. The number of the added decorators matches with the number of **shortcut** `HttpException`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information