### PR TITLE
Fix #118 - Add missing metadata on `$ref` types using `allOf`

### DIFF
--- a/lib/explorers/api-parameters.explorer.ts
+++ b/lib/explorers/api-parameters.explorer.ts
@@ -175,7 +175,20 @@ export const exploreModelDefinition = (type, definitions) => {
       if (metadata.isArray) {
         return transformToArrayModelProperty(metadata, key, { $ref });
       }
-      return { name: key, $ref, required: metadata.required };
+      const strippedMetadata = { ...metadata };
+      delete strippedMetadata.type;
+      delete strippedMetadata.isArray;
+      delete strippedMetadata.collectionFormat;
+      delete strippedMetadata.required;
+      if (Object.keys(strippedMetadata).length === 0) {
+        return { name: key, required: metadata.required, $ref };
+      }
+      return {
+        name: key,
+        required: metadata.required,
+        title: nestedModelName,
+        allOf: [{ $ref }, strippedMetadata]
+      };
     }
     const metatype: string =
       metadata.type && isFunction(metadata.type)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

There are no tests in this repo, one is provided in the associated ticket.
There is no need to update any doc.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #118 


## What is the new behavior?
Use `allOf` to mix the model `$ref` and any other metadata set by the `ApiModelProperty` decorator, except `type`, `isArray` (along with `collectionFormat`) and `required` which seem to have special treatment throughout this repo:
```
{
    description?: string;
    required?: boolean; // REMOVED FROM allOf
    type?: any; // REMOVED FROM allOf
    isArray?: boolean; // REMOVED FROM allOf
    collectionFormat?: string; // REMOVED FROM allOf
    default?: any;
    enum?: SwaggerEnumType;
    format?: string;
    multipleOf?: number;
    maximum?: number;
    exclusiveMaximum?: number;
    minimum?: number;
    exclusiveMinimum?: number;
    maxLength?: number;
    minLength?: number;
    pattern?: string;
    maxItems?: number;
    minItems?: number;
    uniqueItems?: boolean;
    maxProperties?: number;
    minProperties?: number;
    readOnly?: boolean;
    xml?: any;
    example?: any;
}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information