### PR TITLE
Support multiple spec files

### DIFF
--- a/lib/swagger-scanner.ts
+++ b/lib/swagger-scanner.ts
@@ -1,4 +1,4 @@
-import { extend, flatten, reduce } from 'lodash';
+import { extend, flatten, reduce, filter, map } from 'lodash';
 import { SwaggerDocument } from './interfaces';
 import { SwaggerExplorer } from './swagger-explorer';
 import { SwaggerTransformer } from './swagger-transformer';
@@ -8,11 +8,19 @@ export class SwaggerScanner {
   private readonly explorer = new SwaggerExplorer();
   private readonly transfomer = new SwaggerTransformer();
 
-  public scanApplication(app): SwaggerDocument {
+  public scanApplication(app, includedModules): SwaggerDocument {
     const { container } = app;
     const modules = container.getModules();
-
-    const denormalizedPaths = [...modules.values()].map(
+    const denormalizedPaths = map(
+      filter(
+        [...modules.values()],
+        ({ metatype }) =>
+          !(
+            includedModules.length > 0 &&
+            metatype &&
+            !includedModules.includes(metatype)
+          )
+      ),
       ({ routes, metatype }) => {
         // get the module path (if any), to prefix it for all the module controllers.
         const path = metatype
@@ -28,9 +36,9 @@ export class SwaggerScanner {
   }
 
   public scanModuleRoutes(routes, modulePath): SwaggerDocument {
-    const denormalizedArray = [...routes.values()].map(ctrl =>
-      this.explorer.exploreController(ctrl, modulePath)
-    );
+    const denormalizedArray = [...routes.values()].map(ctrl => {
+      return this.explorer.exploreController(ctrl, modulePath);
+    });
     return flatten(denormalizedArray) as any;
   }
 }

--- a/lib/swagger-scanner.ts
+++ b/lib/swagger-scanner.ts
@@ -36,9 +36,9 @@ export class SwaggerScanner {
   }
 
   public scanModuleRoutes(routes, modulePath): SwaggerDocument {
-    const denormalizedArray = [...routes.values()].map(ctrl => {
-      return this.explorer.exploreController(ctrl, modulePath);
-    });
+    const denormalizedArray = [...routes.values()].map(ctrl =>
+      this.explorer.exploreController(ctrl, modulePath)
+    );
     return flatten(denormalizedArray) as any;
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
As #129 mentioned, there currently is no way to make this work.

Issue Number: #129 


## What is the new behavior?
`SwaggerModule` now supports multiple spec files to be served on different SwaggerUI Routes.

```javascript

  const swaggerDoc = SwaggerModule.createDocument(app, swaggerOptions, [SecondaryModule]);
  const swaggerDoc2 = SwaggerModule.createDocument(app, swaggerOptions, [ThirdModule]);

  SwaggerModule.setup('/api/docs', app, swaggerDoc);
  SwaggerModule.setup('/api/docs2', app, swaggerDoc2);
```

Result: 
**/api/docs**
![image](https://user-images.githubusercontent.com/25516557/44818514-d91cc280-abae-11e8-84a5-3e97464fa444.png)

**/api/docs2**
![image](https://user-images.githubusercontent.com/25516557/44818532-edf95600-abae-11e8-947d-5b5ca103fe8f.png)

This PR is based on this issue here on `swagger-ui-express` (which is the package used internally to serve SwaggerUI): https://github.com/scottie1984/swagger-ui-express/issues/65

**NOTE:** The PR is built towards Modularization Approach that NestJS embraces. If you build your application where you *shove* everything on `AppModule` then this PR won't be able to help. With that being said, if there's desire to support for such approach (everything-on-app-module), I'll modify/update the PR.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
This PR adds an **optional** `includedModules` parameter to `SwaggerModule.createDocument()`. It is not required to pass it in and leaving it empty maintains the current behavior of `SwaggerModule`

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information