### PR TITLE
Add ApiResponse wrappers for missing status codes

### DIFF
--- a/lib/decorators/api-response.decorator.ts
+++ b/lib/decorators/api-response.decorator.ts
@@ -62,10 +62,40 @@ export const ApiCreatedResponse = (metadata: ResponseMetadata) =>
     status: HttpStatus.CREATED
   });
 
+export const ApiAcceptedResponse = (metadata: ResponseMetadata) =>
+  ApiResponse({
+    ...metadata,
+    status: HttpStatus.ACCEPTED
+  });
+
+export const ApiNoContentResponse = (metadata: ResponseMetadata) =>
+  ApiResponse({
+    ...metadata,
+    status: HttpStatus.NO_CONTENT
+  });
+
+export const ApiMovedPermanentlyResponse = (metadata: ResponseMetadata) =>
+  ApiResponse({
+    ...metadata,
+    status: HttpStatus.MOVED_PERMANENTLY
+  });
+
 export const ApiBadRequestResponse = (metadata: ResponseMetadata) =>
   ApiResponse({
     ...metadata,
     status: HttpStatus.BAD_REQUEST
+  });
+
+export const ApiUnauthorizedResponse = (metadata: ResponseMetadata) =>
+  ApiResponse({
+    ...metadata,
+    status: HttpStatus.UNAUTHORIZED
+  });
+
+export const ApiTooManyRequestsResponse = (metadata: ResponseMetadata) =>
+  ApiResponse({
+    ...metadata,
+    status: HttpStatus.TOO_MANY_REQUESTS
   });
 
 export const ApiNotFoundResponse = (metadata: ResponseMetadata) =>


### PR DESCRIPTION
Added missing `ApiResponse` wrappers for commonly used http statuses: 

- `202 ACCEPTED` - `@ApiAcceptedResponse()`
- `204 NO CONTENT` - `@ApiNoContentResponse()`
- `302 MOVED PERMANENTLY` - `@ApiMovedPermanentlyResponse()`
- `401 UNAUTHORIZED` - `@ApiUnauthorizedResponse()`
- `429 TOO MANY REQUESTS` - `@ApiTooManyRequestsResponse()`

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information