### PR TITLE
feat: set operationId to method name by default

### DIFF
--- a/lib/swagger-explorer.ts
+++ b/lib/swagger-explorer.ts
@@ -158,7 +158,8 @@ export class SwaggerExplorer {
     const fullPath = globalPath + this.validateRoutePath(routePath);
     return {
       method: RequestMethod[requestMethod].toLowerCase(),
-      path: fullPath === '' ? '/' : fullPath
+      path: fullPath === '' ? '/' : fullPath,
+      operationId: method.name
     };
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
No operationId is set, if you want to use it, you have to manually define one by using the `ApiOperation` decorator. 

## What is the new behavior?
By default, the operationId is the method name. You can still use the `ApiOperation` decorator which will overwrite the default value.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information