### PR TITLE
feat: add format fields for ApiImplicitQuery and ApiImplicitParam.

### DIFF
--- a/lib/decorators/api-implicit-param.decorator.ts
+++ b/lib/decorators/api-implicit-param.decorator.ts
@@ -1,5 +1,7 @@
 import { isNil } from 'lodash';
 import { createParamDecorator } from './helpers';
+import { SwaggerTypeDataFormat } from '../types/swagger-type-data-format';
+import { SwaggerTypeDataType } from '../types/swagger-type-data-type';
 
 const initialMetadata = {
   name: '',
@@ -10,14 +12,16 @@ export const ApiImplicitParam = (metadata: {
   name: string;
   description?: string;
   required?: boolean;
-  type?: 'String' | 'Number' | 'Boolean' | any;
+  type?: SwaggerTypeDataType;
+  format?: SwaggerTypeDataFormat;
 }): MethodDecorator => {
   const param = {
     name: isNil(metadata.name) ? initialMetadata.name : metadata.name,
     in: 'path',
     description: metadata.description,
     required: metadata.required,
-    type: metadata.type
+    type: metadata.type,
+    format: metadata.format
   };
   return createParamDecorator(param, initialMetadata);
 };

--- a/lib/decorators/api-implicit-query.decorator.ts
+++ b/lib/decorators/api-implicit-query.decorator.ts
@@ -1,7 +1,8 @@
-import { DECORATORS } from '../constants';
+import { isNil } from 'lodash';
+import { createParamDecorator } from './helpers';
 import { SwaggerEnumType } from '../types/swagger-enum.type';
-import { createMethodDecorator, createParamDecorator } from './helpers';
-import { omit, pickBy, negate, isUndefined, isNil } from 'lodash';
+import { SwaggerTypeDataFormat } from '../types/swagger-type-data-format';
+import { SwaggerTypeDataType } from '../types/swagger-type-data-type';
 
 const initialMetadata = {
   name: '',
@@ -12,7 +13,8 @@ export const ApiImplicitQuery = (metadata: {
   name: string;
   description?: string;
   required?: boolean;
-  type?: 'String' | 'Number' | 'Boolean' | any;
+  type?: SwaggerTypeDataType;
+  format?: SwaggerTypeDataFormat;
   isArray?: boolean;
   enum?: SwaggerEnumType;
   collectionFormat?: 'csv' | 'ssv' | 'tsv' | 'pipes' | 'multi';
@@ -23,6 +25,7 @@ export const ApiImplicitQuery = (metadata: {
     description: metadata.description,
     required: metadata.required,
     type: metadata.type,
+    format: metadata.format,
     enum: undefined,
     items: undefined,
     collectionFormat: undefined

--- a/lib/types/swagger-type-data-format.ts
+++ b/lib/types/swagger-type-data-format.ts
@@ -1,0 +1,10 @@
+export type SwaggerTypeDataFormat =
+  | 'int32'
+  | 'int64'
+  | 'float'
+  | 'double'
+  | 'byte'
+  | 'binary'
+  | 'date'
+  | 'date-time'
+  | 'password';

--- a/lib/types/swagger-type-data-type.ts
+++ b/lib/types/swagger-type-data-type.ts
@@ -1,0 +1,6 @@
+export type SwaggerTypeDataType =
+  | 'string'
+  | 'boolean'
+  | 'number'
+  | 'integer'
+  | any;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
When I test the swagger json file generated by `nest/swagger` with (https://github.com/APIDevTools/swagger-parser)[https://github.com/APIDevTools/swagger-parser] it failed. I few issue to comply with mainly due to my code. But it is missing the ability to have the format for request params and query. 
To be more compliant with the swagger 2.0 standard I added enum with the available type and format for swagger (https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types)[https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#data-types].

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
The library is not able to export format for query params and request params.

Issue Number: N/A


## What is the new behavior?
The library is able to export format for query params and request params.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
<img width="432" alt="capture d ecran 2018-12-02 a 21 50 59" src="https://user-images.githubusercontent.com/6351671/49345493-ed78cb80-f685-11e8-82f0-e40d3e3f5e1f.png">
<img width="851" alt="capture d ecran 2018-12-02 a 21 50 28" src="https://user-images.githubusercontent.com/6351671/49345495-f1a4e900-f685-11e8-942b-002222298de2.png">
