### PR TITLE
feature: add OpenAPI's nullable flag to APIModelProperty

### DIFF
--- a/lib/decorators/api-model-property.decorator.ts
+++ b/lib/decorators/api-model-property.decorator.ts
@@ -27,6 +27,7 @@ export const ApiModelProperty = (
     maxProperties?: number;
     minProperties?: number;
     readOnly?: boolean;
+    nullable?: boolean;
     xml?: any;
     example?: any;
   } = {}
@@ -63,6 +64,7 @@ export const ApiModelPropertyOptional = (
     maxProperties?: number;
     minProperties?: number;
     readOnly?: boolean;
+    nullable?: boolean;
     xml?: any;
     example?: any;
   } = {}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

(Explanation: Checking through the rest of the repo I am not seeing any tests for `maximum` or `exclusiveMaximum`, say, nor any documentation other than that they exist in the first place?)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently the system type-errors when you try to specify that a field could be `null` because the `nullable` flag does not exist as an allowed piece of `ApiModelProperty` data.

## What is the new behavior?
This adds it. If I am understanding the repository's function right, it then gets copied into swagger docs right alongside the `type`, which is where it is supposed to go.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

See e.g. https://swagger.io/docs/specification/data-models/data-types/ for more documentation on this, JSON Schema has an explicit null type and you would say `type: ['null', 'string']` for a nullable string; OpenAPI differs from this in that it cannot specify `type: ['null']` in swagger: if you are using `null` to communicate an intentional absence of a value you must also define what that value would otherwise have been.