### PR TITLE
Dynamic swagger-ui-express loading

### DIFF
--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -1,6 +1,5 @@
 import { INestApplication } from '@nestjs/common';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
-import * as swaggerUi from 'swagger-ui-express';
 import {
   SwaggerBaseConfig,
   SwaggerCustomOptions,
@@ -34,9 +33,6 @@ export class SwaggerModule {
     document: SwaggerDocument,
     options?: SwaggerCustomOptions
   ) {
-    const validatePath = (path): string =>
-      path.charAt(0) !== '/' ? '/' + path : path;
-
     const httpAdapter = app.getHttpAdapter();
     if (
       httpAdapter &&
@@ -45,8 +41,22 @@ export class SwaggerModule {
     ) {
       return this.setupFastify(path, httpAdapter, document);
     }
+
+    return this.setupExpress(path, app, document, options);
+  }
+
+  private static setupExpress(
+    path: string,
+    app: INestApplication,
+    document: SwaggerDocument,
+    options?: SwaggerCustomOptions
+  ) {
+    const validatePath = (path): string =>
+      path.charAt(0) !== '/' ? '/' + path : path;
+
     const finalPath = validatePath(path);
 
+    const swaggerUi = loadPackage('swagger-ui-express', 'SwaggerModule');
     const swaggerHtml = swaggerUi.generateHTML(document, options);
     app.use(finalPath, swaggerUi.serveFiles(document, options));
     app.use(finalPath, (req, res) => res.send(swaggerHtml));

--- a/package.json
+++ b/package.json
@@ -15,14 +15,12 @@
   },
   "dependencies": {
     "lodash": "4.17.11",
-    "path-to-regexp": "3.0.0",
-    "swagger-ui-express": "4.0.2"
+    "path-to-regexp": "3.0.0"
   },
   "devDependencies": {
     "@nestjs/common": "6.0.1",
     "@nestjs/core": "6.0.1",
     "@types/node": "11.11.3",
-    "fastify-swagger": "2.3.2",
     "husky": "0.14.3",
     "lint-staged": "8.1.5",
     "prettier": "1.16.4",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
swagger-ui-express loads using JS import, so it's impossible to use this package without express installation. 
Issue Number: #215 


## What is the new behavior?
swagger-ui-express for now loads dynamically, so there is no need in express package when FastifyAdapter is used. Also I remove swagger-ui-express & fastify-swagger from dependencies & devDependencies.

## Does this PR introduce a breaking change?
```
[x] Yes
[] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

For express usage it's needed to install swagger-ui-express package manually. Old behavior can be achieved by reverting d1cc738 commit.