### PR TITLE
feat: status code multiple responses

### DIFF
--- a/lib/decorators/helpers.ts
+++ b/lib/decorators/helpers.ts
@@ -102,3 +102,20 @@ export const getTypeIsArrayTuple = (
   const type = isInputArray ? input[0] : input;
   return [type, isInputArray];
 };
+
+/*
+  This functions adds spaces to response status code to ensure that
+  responses with the same status code are not overlaying each other.
+
+  Note: swagger takes a string for a response code and not a number
+*/
+export const getValidResponseName = (
+  name: string | number,
+  responses: { [key: string]: any }
+): string => {
+  let validName = name.toString();
+  while (responses[validName]) {
+    validName += ' ';
+  }
+  return validName;
+};


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

Swagger does not allow multiple responses with the same status code, so I edit the decorator code to add an empty ` ` space after each repeated response status code as a workaround.

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Swagger takes the first response with the same status code.

Issue Number: https://github.com/nestjs/swagger/issues/225


## What is the new behavior?

All responses are added to the documentation with a ` ` space added after duplicated status codes.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
