### PR TITLE
feat(scanner): explore included modules for routes

### DIFF
--- a/lib/interfaces/swagger-document-options.interface.ts
+++ b/lib/interfaces/swagger-document-options.interface.ts
@@ -1,3 +1,5 @@
 export interface SwaggerDocumentOptions {
   include?: Function[];
+  /** if `true`, swagger will also load routes from the modules imported by `include` modules */
+  deepScanRoutes?: boolean;
 }

--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -18,7 +18,8 @@ export class SwaggerModule {
   ): SwaggerDocument {
     const document = this.swaggerScanner.scanApplication(
       app,
-      options.include || []
+      options.include || [],
+      options.deepScanRoutes
     );
     return {
       ...config,

--- a/lib/swagger-scanner.ts
+++ b/lib/swagger-scanner.ts
@@ -1,5 +1,7 @@
 import { MODULE_PATH } from '@nestjs/common/constants';
-import { extend, flatten, isEmpty, map, reduce } from 'lodash';
+import { Module } from '@nestjs/core/injector/module';
+import { NestContainer } from '@nestjs/core/injector/container';
+import { extend, flatten, isEmpty, reduce } from 'lodash';
 import { SwaggerDocument } from './interfaces';
 import { SwaggerExplorer } from './swagger-explorer';
 import { SwaggerTransformer } from './swagger-transformer';
@@ -8,17 +10,40 @@ export class SwaggerScanner {
   private readonly explorer = new SwaggerExplorer();
   private readonly transfomer = new SwaggerTransformer();
 
-  public scanApplication(app, includedModules?: Function[]): SwaggerDocument {
-    const { container } = app;
-    const modules = this.getModules(container.getModules(), includedModules);
-    const denormalizedPaths = map(modules, ({ routes, metatype }) => {
-      // Note: nest-router
-      // Get the module path (if any), to prefix it for all the module controllers.
-      const path = metatype
-        ? Reflect.getMetadata(MODULE_PATH, metatype)
-        : undefined;
-      return this.scanModuleRoutes(routes, path);
-    });
+  public scanApplication(
+    app,
+    includedModules: Function[],
+    deepScanRoutes?: boolean
+  ): SwaggerDocument {
+    const { container }: { container: NestContainer } = app;
+    const modules: Module[] = this.getModules(
+      container.getModules(),
+      includedModules
+    );
+    const denormalizedPaths = modules.map(
+      ({ routes, metatype, relatedModules }) => {
+        let allRoutes = new Map(routes);
+
+        if (deepScanRoutes) {
+          // only load submodules routes if asked
+          Array.from(relatedModules.values())
+            .filter(
+              relatedModule => !container.isGlobalModule(relatedModule as any)
+            )
+            .map(({ routes: relatedModuleRoutes }) => relatedModuleRoutes)
+            .forEach(relatedModuleRoutes => {
+              allRoutes = new Map([...allRoutes, ...relatedModuleRoutes]);
+            });
+        }
+
+        // Note: nest-router
+        // Get the module path (if any), to prefix it for all the module controllers.
+        const path = metatype
+          ? Reflect.getMetadata(MODULE_PATH, metatype)
+          : undefined;
+        return this.scanModuleRoutes(allRoutes, path);
+      }
+    );
     return {
       ...this.transfomer.normalizePaths(flatten(denormalizedPaths)),
       definitions: reduce(this.explorer.getModelsDefinitons(), extend)


### PR DESCRIPTION
Hi there!

_**This PR is a first proposal**. If it can be considered as an enhancement, I'd be glad to leave it "as is".

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

I noticed that the [Multiple Specifications](https://docs.nestjs.com/recipes/swagger#multiple-specifications) was not loading the controllers of the "sub modules" of any module passed in `include`.
Meaning that in the given example, if `CatsModule` imports `CatToysModule` which has its own controller `CatToysController`, its route won't be scanned and loaded in the OpenAPI configuration.

Issue Number: N/A


## What is the new behavior?

The `swagger-scanner` is exploring all the `relatedModules` of the `include`d modules to load their routes too, if the option `deepScanRoutes: true` is passed along `include`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No (as it is opt-in only)

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information