### PR TITLE
fix(document-builder): always use a new base

### DIFF
--- a/lib/document-builder.ts
+++ b/lib/document-builder.ts
@@ -3,10 +3,10 @@ import {
   SwaggerScheme
 } from './interfaces/swagger-base-config.interface';
 
-import { documentBase } from './fixtures/document.base';
+import { buildDocumentBase } from './fixtures/document.base';
 
 export class DocumentBuilder {
-  private readonly document: SwaggerBaseConfig = documentBase;
+  private readonly document: SwaggerBaseConfig = buildDocumentBase();
 
   public setTitle(title: string): this {
     this.document.info.title = title;

--- a/lib/fixtures/document.base.ts
+++ b/lib/fixtures/document.base.ts
@@ -1,6 +1,6 @@
 import { SwaggerScheme } from '../interfaces/swagger-base-config.interface';
 
-export const documentBase = {
+export const buildDocumentBase = () => ({
   swagger: '2.0',
   info: {
     description: '',
@@ -10,4 +10,4 @@ export const documentBase = {
   basePath: '/',
   tags: [],
   schemes: ['http'] as SwaggerScheme[]
-};
+});


### PR DESCRIPTION
Addresses #190 

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Tags are "inherited" from a specification to an other, as "documentBase" (`this.document` in `DocumentBuilder`) is never renewed (and tags are always appended in the existing array).

Issue Number: #190 


## What is the new behavior?

The "documentBase" is now recreated anytime `DocumentBuilder` is instantiated.
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information