### PR TITLE
fix: create a Scanner when calling createDocument

### DIFF
--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -9,14 +9,13 @@ import {
 import { SwaggerScanner } from './swagger-scanner';
 
 export class SwaggerModule {
-  private static readonly swaggerScanner = new SwaggerScanner();
-
   public static createDocument(
     app: INestApplication,
     config: SwaggerBaseConfig,
     options: SwaggerDocumentOptions = {}
   ): SwaggerDocument {
-    const document = this.swaggerScanner.scanApplication(
+    const swaggerScanner = new SwaggerScanner();
+    const document = swaggerScanner.scanApplication(
       app,
       options.include || []
     );
@@ -51,12 +50,14 @@ export class SwaggerModule {
     document: SwaggerDocument,
     options?: SwaggerCustomOptions
   ) {
-    const validatePath = (path): string =>
-      path.charAt(0) !== '/' ? '/' + path : path;
+    const validatePath = (inputPath: string): string =>
+      inputPath.charAt(0) !== '/' ? '/' + inputPath : inputPath;
 
     const finalPath = validatePath(path);
 
-    const swaggerUi = loadPackage('swagger-ui-express', 'SwaggerModule', () => require('swagger-ui-express'));
+    const swaggerUi = loadPackage('swagger-ui-express', 'SwaggerModule', () =>
+      require('swagger-ui-express')
+    );
     const swaggerHtml = swaggerUi.generateHTML(document, options);
     app.use(finalPath, swaggerUi.serveFiles(document, options));
     app.use(finalPath, (req, res) => res.send(swaggerHtml));
@@ -68,14 +69,19 @@ export class SwaggerModule {
     httpServer: any,
     document: SwaggerDocument
   ) {
-    httpServer.register(loadPackage('fastify-swagger', 'SwaggerModule', () => require('fastify-swagger')), {
-      swagger: document,
-      exposeRoute: true,
-      routePrefix: path,
-      mode: 'static',
-      specification: {
-        document
+    httpServer.register(
+      loadPackage('fastify-swagger', 'SwaggerModule', () =>
+        require('fastify-swagger')
+      ),
+      {
+        swagger: document,
+        exposeRoute: true,
+        routePrefix: path,
+        mode: 'static',
+        specification: {
+          document
+        }
       }
-    });
+    );
   }
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`SwaggerScanner` is instantiated once, and thus, always uses the same instance of `SwaggerExplorer`, which leads to compounding `modelsDefinitions` at each call of `createDocument`. Thus, only the first swagger document created has a valid list of "Models". The other ones have their models and all the ones previously scanned.

Issue Number: N/A


## What is the new behavior?

Instantiate a new Scanner for each Document created, so we never re-use data from the previous documents. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
