### PR TITLE
Allow a raw swagger type config to be passed

### DIFF
--- a/lib/explorers/api-parameters.explorer.ts
+++ b/lib/explorers/api-parameters.explorer.ts
@@ -334,7 +334,6 @@ const mapParametersTypes = parameters =>
       return omitParamType(param);
     }
     const { type } = param;
-    console.log(type);
     const paramWithStringType: any = pickBy(
       {
         ...param,

--- a/lib/explorers/api-parameters.explorer.ts
+++ b/lib/explorers/api-parameters.explorer.ts
@@ -210,6 +210,13 @@ export const exploreModelDefinition = (
         allOf: [{ $ref }, strippedMetadata]
       };
     }
+
+    const isRawSwagger = metadata.type.type && metadata.type.items;
+    if (isRawSwagger) {
+      const { type, items } = metadata.type;
+      return Object.assign({}, metadata, { name: key, type, items });
+    }
+
     const metatype: string =
       metadata.type && isFunction(metadata.type)
         ? metadata.type.name
@@ -327,6 +334,7 @@ const mapParametersTypes = parameters =>
       return omitParamType(param);
     }
     const { type } = param;
+    console.log(type);
     const paramWithStringType: any = pickBy(
       {
         ...param,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/nestjs/swagger/issues/275


## What is the new behavior?

This now allows you to pass in an object which defined a `type` and `items` config in the `@ApiModelProperty` decorator. It works like so:

```
@ApiModelProperty({
  type: {
    type: 'array',
    items: {
      type: 'array',
      items: {
        type: 'array',
        items: {
          type: 'number',
        },
        minItems: 2,
        maxItems: 2,
      },
    },
  },
})
```

Which allows a type to be defined for a data structure which looks like:

```
[
  [
    [-122.38005638122557, 37.60376025592665],
    [-122.37773895263672, 37.60593620261328],
    [-122.36555099487303, 37.600632221054056],
    [-122.34992980957031, 37.61858263247881],
    [-122.38417625427246, 37.6399950678721],
    [-122.39996910095215, 37.63809199009653],
    [-122.39705085754393, 37.63251841048015],
    [-122.39996910095215, 37.6315667819348],
    [-122.40159988403319, 37.62918765725775],
    [-122.3964500427246, 37.61416342563735],
    [-122.38005638122557, 37.60376025592665]
  ]
]
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

I am open to alternative approaches to doing this, such as adding a new property to the `ApiModelProperty` param interface. I did a good amount of digging, and could not find anywhere where my current solution would cause conflict, but very open to feedback.