### PR TITLE
feature(api-response): Headers to ResponseMetadata

### DIFF
--- a/lib/decorators/api-response.decorator.ts
+++ b/lib/decorators/api-response.decorator.ts
@@ -7,12 +7,12 @@ export interface ResponseMetadata {
   description?: string;
   type?: any;
   isArray?: boolean;
+  headers?: any;
 }
 
 export const ApiResponse = (
   metadata: {
     status: number;
-    headers?: any;
   } & ResponseMetadata
 ) => {
   const [type, isArray] = getTypeIsArrayTuple(metadata.type, metadata.isArray);


### PR DESCRIPTION
Move headers to ResponseMetadata interface to allow it being used from the helper decorators as well.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
ResponseMetadata interface does not contain headers property.

Issue Number: N/A


## What is the new behavior?
ResponseMetadata interface includes headers property.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```