### PR TITLE
Drop @Body reflected parameter when @ApiImplicitBody is described

### DIFF
--- a/test/explorer/issue-185.spec.ts
+++ b/test/explorer/issue-185.spec.ts
@@ -1,0 +1,99 @@
+import { Controller, Get, Body, Post, Req, Query } from '@nestjs/common';
+import {
+  ApiOkResponse,
+  ApiOperation,
+  ApiImplicitBody,
+  ApiImplicitQuery
+} from '../../lib/decorators';
+import { SwaggerExplorer } from '../../lib/swagger-explorer';
+
+import { ApiModelProperty } from '../../lib/decorators/api-model-property.decorator';
+import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
+
+export class UserPayload {
+  @ApiModelProperty()
+  public name: string;
+}
+
+describe('@Body without @ApiImplicitBody', () => {
+  @Controller('')
+  class FooController {
+    @Post('/')
+    public create(@Body() payload: UserPayload) {}
+  }
+
+  it('output @Body refelected paramter', () => {
+    const explorer = new SwaggerExplorer();
+    const routes = explorer.exploreController(
+      {
+        instance: new FooController(),
+        metatype: FooController
+      } as InstanceWrapper<FooController>,
+      'path'
+    );
+
+    expect(routes.length).toEqual(1);
+    expect(routes[0].root.method).toEqual('post');
+    expect(routes[0].root.parameters.length).toEqual(1);
+    expect(routes[0].root.parameters[0].name).toEqual('UserPayload');
+    expect(routes[0].root.parameters[0].required).toEqual(true);
+    expect(routes[0].root.parameters[0].in).toEqual('body');
+    expect(routes[0].root.parameters[0].schema).toEqual({
+      $ref: '#/definitions/UserPayload'
+    });
+  });
+});
+
+describe('@Body with name', () => {
+  @Controller('')
+  class FooController {
+    @Post('/')
+    public create(@Body('body') payload: UserPayload) {}
+  }
+
+  it('ignores @Body', () => {
+    const explorer = new SwaggerExplorer();
+    const routes = explorer.exploreController(
+      {
+        instance: new FooController(),
+        metatype: FooController
+      } as InstanceWrapper<FooController>,
+      'path'
+    );
+
+    expect(routes.length).toEqual(1);
+    expect(routes[0].root.method).toEqual('post');
+    expect(routes[0].root.parameters).toEqual(undefined);
+  });
+});
+
+describe('@Body with @ApiImplicitBody', () => {
+  @Controller('')
+  class FooController {
+    @ApiImplicitBody({ name: 'body', type: UserPayload })
+    @Post('/')
+    public create(@Body() payload: UserPayload) {}
+  }
+
+  it('drops @Body reflected parameter when @ApiImplicitBody is described', () => {
+    const explorer = new SwaggerExplorer();
+    const routes = explorer.exploreController(
+      {
+        instance: new FooController(),
+        metatype: FooController
+      } as InstanceWrapper<FooController>,
+      'path'
+    );
+
+    expect(routes.length).toEqual(1);
+    expect(routes[0].root.method).toEqual('post');
+    expect(routes[0].root.parameters.length).toEqual(1);
+    expect(routes[0].root.parameters[0].name).toEqual('body');
+    expect(routes[0].root.parameters[0].required).toEqual(true);
+    expect(routes[0].root.parameters[0].in).toEqual('body');
+    expect(routes[0].root.parameters[0].isArray).toEqual(false);
+    expect(routes[0].root.parameters[0].schema).toEqual({
+      $ref: '#/definitions/UserPayload'
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #185 


## What is the new behavior?

This PR drops @Body reflected parameter when @ApiImplicitBody is described and leaves @Body reflected parameter when @ApiImplicitBody is not described.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information