### PR TITLE
bugfix(@nestjs/swagger) set consumes field only on methods with body

### DIFF
--- a/test/explorer/explore-controllers.spec.ts
+++ b/test/explorer/explore-controllers.spec.ts
@@ -1,4 +1,4 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, Post } from '@nestjs/common';
 import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 import { ApiOkResponse, ApiOperation } from '../../lib/decorators';
 import { SwaggerExplorer } from '../../lib/swagger-explorer';
@@ -12,6 +12,18 @@ describe('Explore controllers', () => {
     @ApiOperation({ title: 'List all Foos' })
     @ApiOkResponse({ type: Foo })
     find(): Promise<Foo> {
+      return Promise.resolve({});
+    }
+  }
+
+  class Bar {}
+
+  @Controller('')
+  class BarController {
+    @Post('bars/:objectId')
+    @ApiOperation({ title: 'Creates a Bar' })
+    @ApiOkResponse({ type: Bar })
+    create(): Promise<Bar> {
       return Promise.resolve({});
     }
   }
@@ -30,5 +42,33 @@ describe('Explore controllers', () => {
     expect(routes[0].root.method).toEqual('get');
     expect(routes[0].root.path).toEqual('/path/foos/{objectId}');
     expect(routes[0].root.summary).toEqual('List all Foos');
+  });
+
+  it('sees a get controller operation without consumes keyword', () => {
+    const explorer = new SwaggerExplorer();
+    const routes = explorer.exploreController(
+      {
+        instance: new FooController(),
+        metatype: FooController
+      } as InstanceWrapper<FooController>,
+      'path'
+    );
+    expect(routes.length).toEqual(1);
+    expect(routes[0].root.method).toEqual('get');
+    expect(routes[0].consumes).toBeUndefined();
+  });
+
+  it('sees a post controller operation with consumes keyword', () => {
+    const explorer = new SwaggerExplorer();
+    const routes = explorer.exploreController(
+      {
+        instance: new BarController(),
+        metatype: BarController
+      } as InstanceWrapper<BarController>,
+      'path'
+    );
+    expect(routes.length).toEqual(1);
+    expect(routes[0].root.method).toEqual('post');
+    expect(routes[0].consumes).toEqual(['application/json']);
   });
 });


### PR DESCRIPTION
## PR Checklist
- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:

## What is the current behavior?
The consume field is added to all method if not already present.

Issue Number: #341 

## What is the new behavior?
as defined in the swagger spec 2.0 t consumes only affects operations with a request body (GET, HEAD, OPTIONS). I check is added for this before the field is set.

## Does this PR introduce a breaking change?
[ ] Yes
[X] No