### PR TITLE
fix(decorator) Return type of ApiResponse

### DIFF
--- a/lib/decorators/api-response.decorator.ts
+++ b/lib/decorators/api-response.decorator.ts
@@ -25,7 +25,7 @@ export interface ApiResponseSchemaHost
 
 export type ApiResponseOptions = ApiResponseMetadata | ApiResponseSchemaHost;
 
-export function ApiResponse(options: ApiResponseOptions): any {
+export function ApiResponse(options: ApiResponseOptions): MethodDecorator {
   const [type, isArray] = getTypeIsArrayTuple(
     (options as ApiResponseMetadata).type,
     (options as ApiResponseMetadata).isArray


### PR DESCRIPTION
Narrowed the return type of ApiResponse() from "any" to "MethodDecorator".

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
TSLint complains about "Unsafe use of expression of type 'any'" whenever a response decorator is used.

Issue Number: N/A


## What is the new behavior?

No complaints.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information