### PR TITLE
fix(): prevent adding the same property name more than once

### DIFF
--- a/lib/decorators/helpers.ts
+++ b/lib/decorators/helpers.ts
@@ -35,7 +35,7 @@ export function createPropertyDecorator<T extends Record<string, any> = any>(
       Reflect.getMetadata(DECORATORS.API_MODEL_PROPERTIES_ARRAY, target) || [];
     Reflect.defineMetadata(
       DECORATORS.API_MODEL_PROPERTIES_ARRAY,
-      [...properties, `:${propertyKey}`],
+      [...new Set([...properties, `:${propertyKey}`])],
       target
     );
     Reflect.defineMetadata(

--- a/test/services/model-properties-accessor.spec.ts
+++ b/test/services/model-properties-accessor.spec.ts
@@ -11,6 +11,11 @@ describe('ModelPropertiesAccessor', () => {
     password: string;
   }
 
+  class UpdateUserDto extends CreateUserDto {
+    @ApiProperty()
+    password: string;
+  }
+
   let modelPropertiesAccessor: ModelPropertiesAccessor;
 
   beforeEach(() => {
@@ -22,6 +27,14 @@ describe('ModelPropertiesAccessor', () => {
       expect(
         modelPropertiesAccessor.getModelProperties(
           (CreateUserDto.prototype as any) as Type<any>
+        )
+      ).toEqual(['login', 'password']);
+    });
+
+    it('should not duplicate properties when the ApiProperty decorator is applied on base class and sub class', () => {
+      expect(
+        modelPropertiesAccessor.getModelProperties(
+          (UpdateUserDto.prototype as any) as Type<any>
         )
       ).toEqual(['login', 'password']);
     });


### PR DESCRIPTION
A property that is decorated for a base class and also for a subclass
gets added twice to the `API_MODEL_PROPERTIES_ARRAY` metadata

This behaviour leads to an openapi definition error when the property is
marked as required becasue it also gets added twice to the list of
required properties

![OpenAPI error](https://i.imgur.com/bqug6pY.png)

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

The property only is added once to the list of model properties. The openapi definition no longer emits an error


## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information