### PR TITLE
refactor(main) Added main and types entries to package.json…

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,0 @@
-export * from './dist';

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "author": "Kamil Mysliwiec",
   "license": "MIT",
   "repository": "https://github.com/nestjs/swagger",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "format": "prettier \"lib/**/*.ts\" --write",

--- a/plugin.js
+++ b/plugin.js
@@ -1,6 +1,0 @@
-'use strict';
-function __export(m) {
-  for (var p in m) if (!exports.hasOwnProperty(p)) exports[p] = m[p];
-}
-exports.__esModule = true;
-__export(require('./dist/plugin'));

--- a/plugin.ts
+++ b/plugin.ts
@@ -1,1 +1,0 @@
-export * from './lib/plugin';


### PR DESCRIPTION
Added main and types entries to package.json, and removed index.ts and plugin.ts files from repo root (as they were merely pointers to those files).

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features) (no new tests required; existing tests pass)
- [N/A] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

There are index.ts and plugin.ts files in the repo root, but they are out of the scope of tsconfig.json, meaning they don't get compiled into .js files.

Issue Number: N/A


## What is the new behavior?

/dist/index.js is set as main in package.json. This removes the need for the index.ts at the repo root. Since plugin is a folder inside /dist and has its own index, there's also no need for plugin.ts anymore.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Not unless someone has explicitly added a ".ts" extension in their plugin reference. If not using an extension, the change from a ".ts" file to a folder containing an index should be invisible.

## Other information