### PR TITLE
test(platform): Explicitly added a new line type to tests

### DIFF
--- a/test/plugin/controller-class-visitor.spec.ts
+++ b/test/plugin/controller-class-visitor.spec.ts
@@ -10,6 +10,7 @@ describe('Controller methods', () => {
     const options: ts.CompilerOptions = {
       module: ts.ModuleKind.CommonJS,
       target: ts.ScriptTarget.ESNext,
+      newLine: ts.NewLineKind.LineFeed,
       noEmitHelpers: true
     };
     const filename = 'app.controller.ts';

--- a/test/plugin/model-class-visitor.spec.ts
+++ b/test/plugin/model-class-visitor.spec.ts
@@ -22,6 +22,7 @@ describe('API model properties', () => {
     const options: ts.CompilerOptions = {
       module: ts.ModuleKind.ESNext,
       target: ts.ScriptTarget.ESNext,
+      newLine: ts.NewLineKind.LineFeed,
       noEmitHelpers: true
     };
     const filename = 'create-cat.dto.ts';
@@ -41,6 +42,7 @@ describe('API model properties', () => {
     const options: ts.CompilerOptions = {
       module: ts.ModuleKind.ESNext,
       target: ts.ScriptTarget.ESNext,
+      newLine: ts.NewLineKind.LineFeed,
       noEmitHelpers: true
     };
     const filename = 'create-cat.dto.ts';
@@ -60,6 +62,7 @@ describe('API model properties', () => {
     const options: ts.CompilerOptions = {
       module: ts.ModuleKind.ESNext,
       target: ts.ScriptTarget.ESNext,
+      newLine: ts.NewLineKind.LineFeed,
       noEmitHelpers: true
     };
     const filename = 'create-cat-alt2.dto.ts';
@@ -79,6 +82,7 @@ describe('API model properties', () => {
     const options: ts.CompilerOptions = {
       module: ts.ModuleKind.CommonJS,
       target: ts.ScriptTarget.ES5,
+      newLine: ts.NewLineKind.LineFeed,
       noEmitHelpers: true
     };
     const filename = 'es5-class.dto.ts';


### PR DESCRIPTION
This allows tests to run normally on Windows.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[x] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The new line of tests was left as the default. However, on Windows, TypeScript generates files with Windows line endings, making the test expectations not match.

Issue Number: N/A


## What is the new behavior?

New line is explicitly set to linux line endings, so that regardless of what platform the tests are executed on, the tests will pass.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information