### PR TITLE
auto generate description from comments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.idea
 /.awcache
 /.vscode
+.history
 
 # misc
 npm-debug.log

--- a/lib/plugin/compiler-plugin.ts
+++ b/lib/plugin/compiler-plugin.ts
@@ -17,7 +17,7 @@ export const before = (options?: Record<string, any>, program?: ts.Program) => {
         return modelClassVisitor.visit(sf, ctx, program, options);
       }
       if (isFilenameMatched(options.controllerFileNameSuffix, sf.fileName)) {
-        return controllerClassVisitor.visit(sf, ctx, program);
+        return controllerClassVisitor.visit(sf, ctx, program, options);
       }
       return sf;
     };

--- a/lib/plugin/merge-options.ts
+++ b/lib/plugin/merge-options.ts
@@ -4,12 +4,16 @@ export interface PluginOptions {
   dtoFileNameSuffix?: string | string[];
   controllerFileNameSuffix?: string | string[];
   classValidatorShim?: boolean;
+  dtoKeyOfComment?: string;
+  controllerKeyOfComment?: string;
 }
 
 const defaultOptions: PluginOptions = {
   dtoFileNameSuffix: ['.dto.ts', '.entity.ts'],
   controllerFileNameSuffix: ['.controller.ts'],
-  classValidatorShim: true
+  classValidatorShim: true,
+  dtoKeyOfComment: 'description',
+  controllerKeyOfComment: 'description'
 };
 
 export const mergePluginOptions = (

--- a/lib/plugin/utils/ast-utils.ts
+++ b/lib/plugin/utils/ast-utils.ts
@@ -11,7 +11,11 @@ import {
   Type,
   TypeChecker,
   TypeFlags,
-  TypeFormatFlags
+  TypeFormatFlags,
+  SourceFile,
+  getTrailingCommentRanges,
+  getLeadingCommentRanges,
+  CommentRange
 } from 'typescript';
 import { isDynamicallyAdded } from './plugin-utils';
 
@@ -74,6 +78,8 @@ export function hasObjectFlag(type: Type, flag: ObjectFlags) {
   return ((type as ObjectType).objectFlags & flag) === flag;
 }
 
+// exprot function getDescription()
+
 export function getText(
   type: Type,
   typeChecker: TypeChecker,
@@ -96,6 +102,46 @@ export function getDefaultTypeFormatFlags(enclosingNode: Node) {
   if (enclosingNode && enclosingNode.kind === SyntaxKind.TypeAliasDeclaration)
     formatFlags |= TypeFormatFlags.InTypeAlias;
   return formatFlags;
+}
+
+export function getMainCommentAnExamplesOfNode(
+  node: Node,
+  sourceFile: SourceFile,
+  needExamples?: boolean
+): [string, string[]] {
+  const sourceText = sourceFile.getText();
+  const replaceRegex = /^ *\** *@.*$|^ *\/\*+ *|^ *\/+ *|^ *\*+ *| +$| *\**\/ *$/gim;
+
+  const commentResult = [];
+  const examplesResult = [];
+  const extractCommentsAndExamples = (comments?: CommentRange[]) =>
+    comments?.forEach(comment => {
+      const commentSource = sourceText.substring(comment.pos, comment.end);
+      const oneComment = commentSource.replace(replaceRegex, '').trim();
+      if (oneComment) {
+        commentResult.push(oneComment);
+      }
+      if (needExamples) {
+        const regexOfExample = /@example *['"]?([^ ]+?)['"]? *$/gim;
+        let execResult: RegExpExecArray;
+        while (
+          (execResult = regexOfExample.exec(commentSource)) &&
+          execResult.length > 1
+        ) {
+          examplesResult.push(execResult[1]);
+        }
+      }
+    });
+  extractCommentsAndExamples(
+    getLeadingCommentRanges(sourceText, node.getFullStart())
+  );
+  if (!commentResult.length) {
+    extractCommentsAndExamples(
+      getTrailingCommentRanges(sourceText, node.getFullStart())
+    );
+  }
+
+  return [commentResult.join('\n'), examplesResult];
 }
 
 export function getDecoratorArguments(decorator: Decorator) {

--- a/lib/plugin/utils/ast-utils.ts
+++ b/lib/plugin/utils/ast-utils.ts
@@ -109,8 +109,9 @@ export function getMainCommentAnExamplesOfNode(
   sourceFile: SourceFile,
   needExamples?: boolean
 ): [string, string[]] {
-  const sourceText = sourceFile.getText();
-  const replaceRegex = /^ *\** *@.*$|^ *\/\*+ *|^ *\/+ *|^ *\*+ *| +$| *\**\/ *$/gim;
+  const sourceText = sourceFile.getFullText();
+
+  const replaceRegex = /^ *\** *@.*$|^ *\/\*+ *|^ *\/\/+.*|^ *\/+ *|^ *\*+ *| +$| *\**\/ *$/gim;
 
   const commentResult = [];
   const examplesResult = [];

--- a/lib/plugin/utils/ast-utils.ts
+++ b/lib/plugin/utils/ast-utils.ts
@@ -78,8 +78,6 @@ export function hasObjectFlag(type: Type, flag: ObjectFlags) {
   return ((type as ObjectType).objectFlags & flag) === flag;
 }
 
-// exprot function getDescription()
-
 export function getText(
   type: Type,
   typeChecker: TypeChecker,
@@ -104,7 +102,7 @@ export function getDefaultTypeFormatFlags(enclosingNode: Node) {
   return formatFlags;
 }
 
-export function getMainCommentAnExamplesOfNode(
+export function getMainCommentAndExamplesOfNode(
   node: Node,
   sourceFile: SourceFile,
   needExamples?: boolean

--- a/lib/plugin/visitors/controller-class.visitor.ts
+++ b/lib/plugin/visitors/controller-class.visitor.ts
@@ -4,7 +4,7 @@ import { ApiResponse, ApiOperation } from '../../decorators';
 import { OPENAPI_NAMESPACE } from '../plugin-constants';
 import {
   getDecoratorArguments,
-  getMainCommentAnExamplesOfNode
+  getMainCommentAndExamplesOfNode
 } from '../utils/ast-utils';
 import {
   getDecoratorOrUndefinedByNames,
@@ -105,7 +105,7 @@ export class ControllerClassVisitor extends AbstractFileVisitor {
         >) ||
         !hasPropertyKey(keyToGenerate, apiOperationOptionsProperties)) &&
       // Has comments
-      ([comments] = getMainCommentAnExamplesOfNode(node, sourceFile))[0]
+      ([comments] = getMainCommentAndExamplesOfNode(node, sourceFile))[0]
     ) {
       const properties = [
         ts.createPropertyAssignment(keyToGenerate, ts.createLiteral(comments)),

--- a/lib/plugin/visitors/model-class.visitor.ts
+++ b/lib/plugin/visitors/model-class.visitor.ts
@@ -162,9 +162,10 @@ export class ModelClassVisitor extends AbstractFileVisitor {
         sourceFile,
         true
       );
-      if (!hasPropertyKey('description', existingProperties) && comments) {
+      const keyOfComment = options?.dtoKeyOfComment ??'description';
+      if (!hasPropertyKey(keyOfComment, existingProperties) && comments) {
         descriptionPropertyWapper.push(
-          ts.createPropertyAssignment('description', ts.createLiteral(comments))
+          ts.createPropertyAssignment(keyOfComment, ts.createLiteral(comments))
         );
       }
       if (

--- a/lib/plugin/visitors/model-class.visitor.ts
+++ b/lib/plugin/visitors/model-class.visitor.ts
@@ -174,12 +174,6 @@ export class ModelClassVisitor extends AbstractFileVisitor {
         ) &&
         examples.length
       ) {
-        console.log(
-          examples,
-          hasPropertyKey('example', existingProperties),
-          hasPropertyKey('examples', existingProperties),
-          '==============================================='
-        );
         if (examples.length == 1) {
           examplesPropertyWapper.push(
             ts.createPropertyAssignment(

--- a/lib/plugin/visitors/model-class.visitor.ts
+++ b/lib/plugin/visitors/model-class.visitor.ts
@@ -11,7 +11,7 @@ import {
   getDecoratorArguments,
   getText,
   isEnum,
-  getMainCommentAnExamplesOfNode
+  getMainCommentAndExamplesOfNode
 } from '../utils/ast-utils';
 import {
   extractTypeArgumentIfArray,
@@ -157,7 +157,7 @@ export class ModelClassVisitor extends AbstractFileVisitor {
     const descriptionPropertyWapper = [];
     const examplesPropertyWapper = [];
     if (sourceFile) {
-      const [comments, examples] = getMainCommentAnExamplesOfNode(
+      const [comments, examples] = getMainCommentAndExamplesOfNode(
         node,
         sourceFile,
         true

--- a/test/plugin/controller-class-visitor.spec.ts
+++ b/test/plugin/controller-class-visitor.spec.ts
@@ -19,7 +19,9 @@ describe('Controller methods', () => {
     const result = ts.transpileModule(appControllerText, {
       compilerOptions: options,
       fileName: filename,
-      transformers: { before: [before({}, fakeProgram)] }
+      transformers: {
+        before: [before({ controllerKeyOfComment: 'summary' }, fakeProgram)]
+      }
     });
     expect(result.outputText).toEqual(appControllerTextTranspiled);
   });

--- a/test/plugin/fixtures/app.controller.ts
+++ b/test/plugin/fixtures/app.controller.ts
@@ -1,12 +1,35 @@
 export const appControllerText = `import { Controller, Post, HttpStatus } from '@nestjs/common';
+import { ApiOperation } from '@nestjs/swagger';
 
 class Cat {}
 
 @Controller('cats')
 export class AppController {
+  /**
+   * create a Cat
+   *
+   * @returns {Promise<Cat>}
+   * @memberof AppController
+   */
   @Post()
   async create(): Promise<Cat> {}
 
+  /**
+   * find a Cat
+   */
+  @ApiOperation({})
+  @Get()
+  async findOne(): Promise<Cat> {}
+
+  /**
+   * find all Cats im comment
+   *
+   * @returns {Promise<Cat>}
+   * @memberof AppController
+   */
+  @ApiOperation({
+    description: 'find all Cats',
+  })
   @Get()
   @HttpCode(HttpStatus.NO_CONTENT)
   async findAll(): Promise<Cat[]> {}
@@ -20,14 +43,39 @@ const common_1 = require(\"@nestjs/common\");
 class Cat {
 }
 let AppController = class AppController {
+    /**
+     * create a Cat
+     *
+     * @returns {Promise<Cat>}
+     * @memberof AppController
+     */
     async create() { }
+    /**
+     * find a Cat
+     */
+    async findOne() { }
+    /**
+     * find all Cats im comment
+     *
+     * @returns {Promise<Cat>}
+     * @memberof AppController
+     */
     async findAll() { }
 };
 __decorate([
+    openapi.ApiOperation({ description: "create a Cat" }),
     common_1.Post(),
     openapi.ApiResponse({ status: 201, type: Cat })
 ], AppController.prototype, \"create\", null);
 __decorate([
+    swagger_1.ApiOperation({ description: "find a Cat" }),
+    Get(),
+    openapi.ApiResponse({ status: 200, type: Cat })
+], AppController.prototype, \"findOne\", null);
+__decorate([
+    swagger_1.ApiOperation({
+        description: 'find all Cats',
+    }),
     Get(),
     HttpCode(common_1.HttpStatus.NO_CONTENT),
     openapi.ApiResponse({ status: common_1.HttpStatus.NO_CONTENT, type: [Cat] })

--- a/test/plugin/fixtures/app.controller.ts
+++ b/test/plugin/fixtures/app.controller.ts
@@ -63,19 +63,17 @@ let AppController = class AppController {
     async findAll() { }
 };
 __decorate([
-    openapi.ApiOperation({ description: "create a Cat" }),
+    openapi.ApiOperation({ summary: "create a Cat" }),
     common_1.Post(),
     openapi.ApiResponse({ status: 201, type: Cat })
 ], AppController.prototype, \"create\", null);
 __decorate([
-    swagger_1.ApiOperation({ description: "find a Cat" }),
+    swagger_1.ApiOperation({ summary: "find a Cat" }),
     Get(),
     openapi.ApiResponse({ status: 200, type: Cat })
 ], AppController.prototype, \"findOne\", null);
 __decorate([
-    swagger_1.ApiOperation({
-        description: 'find all Cats',
-    }),
+    swagger_1.ApiOperation({ summary: "find all Cats im comment", description: 'find all Cats' }),
     Get(),
     HttpCode(common_1.HttpStatus.NO_CONTENT),
     openapi.ApiResponse({ status: common_1.HttpStatus.NO_CONTENT, type: [Cat] })

--- a/test/plugin/fixtures/app.controller.ts
+++ b/test/plugin/fixtures/app.controller.ts
@@ -40,6 +40,7 @@ Object.defineProperty(exports, \"__esModule\", { value: true });
 exports.AppController = void 0;
 const openapi = require(\"@nestjs/swagger\");
 const common_1 = require(\"@nestjs/common\");
+const swagger_1 = require("@nestjs/swagger");
 class Cat {
 }
 let AppController = class AppController {

--- a/test/plugin/fixtures/create-cat-alt.dto.ts
+++ b/test/plugin/fixtures/create-cat-alt.dto.ts
@@ -25,6 +25,7 @@ export class CreateCatDto2 {
   readonly breed?: string | undefined;
   nodes: Node[];
   alias: AliasedType;
+  /** NumberAlias */
   numberAlias: NumberAlias;
   union: 1 | 2;
   intersection: Function & string;
@@ -55,7 +56,7 @@ export class CreateCatDto2 {
         this.status = Status.ENABLED;
     }
     static _OPENAPI_METADATA_FACTORY() {
-        return { name: { required: true, type: () => String }, age: { required: true, type: () => Number, default: 3 }, tags: { required: true, type: () => [String] }, status: { required: true, default: Status.ENABLED, enum: Status }, breed: { required: false, type: () => String }, nodes: { required: true, type: () => [Object] }, alias: { required: true, type: () => Object }, numberAlias: { required: true, type: () => Number }, union: { required: true, type: () => Object }, intersection: { required: true, type: () => Object }, nested: { required: true, type: () => ({ first: { required: true, type: () => String }, second: { required: true, type: () => Number }, status: { required: true, enum: Status }, tags: { required: true, type: () => [String] }, nodes: { required: true, type: () => [Object] }, alias: { required: true, type: () => Object }, numberAlias: { required: true, type: () => Number } }) } };
+        return { name: { required: true, type: () => String }, age: { required: true, type: () => Number, default: 3 }, tags: { required: true, type: () => [String] }, status: { required: true, default: Status.ENABLED, enum: Status }, breed: { required: false, type: () => String }, nodes: { required: true, type: () => [Object] }, alias: { required: true, type: () => Object }, numberAlias: { description: "NumberAlias", required: true, type: () => Number }, union: { required: true, type: () => Object }, intersection: { required: true, type: () => Object }, nested: { required: true, type: () => ({ first: { required: true, type: () => String }, second: { required: true, type: () => Number }, status: { required: true, enum: Status }, tags: { required: true, type: () => [String] }, nodes: { required: true, type: () => [Object] }, alias: { required: true, type: () => Object }, numberAlias: { required: true, type: () => Number } }) } };
     }
 }
 __decorate([

--- a/test/plugin/fixtures/create-cat-alt2.dto.ts
+++ b/test/plugin/fixtures/create-cat-alt2.dto.ts
@@ -2,21 +2,39 @@ export const createCatDtoAlt2Text = `
 import { CreateDateColumn, UpdateDateColumn, VersionColumn } from 'typeorm';
 
 export abstract class Audit {
+  /** test on createdAt */
   @CreateDateColumn()
   createdAt;
 
+  // test on updatedAt1
+  // test on updatedAt2
   @UpdateDateColumn()
   updatedAt;
 
+  /**
+   * test
+   * version 
+   * @example '0.0.1'
+   * @memberof Audit
+   */
   @VersionColumn()
   version;
+
+  /**
+   * testVersion
+   *  
+   * @example '0.0.1'
+   * @example '0.0.2'
+   * @memberof Audit
+   */
+  testVersion;
 }
 `;
 
 export const createCatDtoTextAlt2Transpiled = `import { CreateDateColumn, UpdateDateColumn, VersionColumn } from 'typeorm';
 export class Audit {
     static _OPENAPI_METADATA_FACTORY() {
-        return { createdAt: { required: true, type: () => Object }, updatedAt: { required: true, type: () => Object }, version: { required: true, type: () => Object } };
+        return { createdAt: { description: "test on createdAt", required: true, type: () => Object }, updatedAt: { description: "test on updatedAt1\\ntest on updatedAt2", required: true, type: () => Object }, version: { description: "test\\nversion", required: true, type: () => Object, example: "0.0.1" }, testVersion: { description: "testVersion", required: true, type: () => Object, examples: ["0.0.1", "0.0.2"] } };
     }
 }
 __decorate([

--- a/test/plugin/fixtures/create-cat-alt2.dto.ts
+++ b/test/plugin/fixtures/create-cat-alt2.dto.ts
@@ -34,7 +34,7 @@ export abstract class Audit {
 export const createCatDtoTextAlt2Transpiled = `import { CreateDateColumn, UpdateDateColumn, VersionColumn } from 'typeorm';
 export class Audit {
     static _OPENAPI_METADATA_FACTORY() {
-        return { createdAt: { description: "test on createdAt", required: true, type: () => Object }, updatedAt: { description: "test on updatedAt1\\ntest on updatedAt2", required: true, type: () => Object }, version: { description: "test\\nversion", required: true, type: () => Object, example: "0.0.1" }, testVersion: { description: "testVersion", required: true, type: () => Object, examples: ["0.0.1", "0.0.2"] } };
+        return { createdAt: { description: "test on createdAt", required: true, type: () => Object }, updatedAt: { required: true, type: () => Object }, version: { description: "test\\nversion", required: true, type: () => Object, example: "0.0.1" }, testVersion: { description: "testVersion", required: true, type: () => Object, examples: ["0.0.1", "0.0.2"] } };
     }
 }
 __decorate([

--- a/test/plugin/fixtures/create-cat.dto.ts
+++ b/test/plugin/fixtures/create-cat.dto.ts
@@ -26,7 +26,8 @@ export class CreateCatDto {
   oneValueEnum?: OneValueEnum;
   oneValueEnumArr?: OneValueEnum[];
 
-  @ApiProperty({ type: String })
+  // this is breed im comment
+  @ApiProperty({ description: "this is breed", type: String })
   @IsString()
   readonly breed?: string;
 
@@ -57,7 +58,7 @@ export class CreateCatDto {
         this.status = Status.ENABLED;
     }
     static _OPENAPI_METADATA_FACTORY() {
-        return { name: { required: true, type: () => String }, age: { required: true, type: () => Number, default: 3, minimum: 0, maximum: 10 }, tags: { required: true, type: () => [String] }, status: { required: true, default: Status.ENABLED, enum: Status }, status2: { required: false, enum: Status }, statusArr: { required: false, enum: Status, isArray: true }, oneValueEnum: { required: false, enum: OneValueEnum }, oneValueEnumArr: { required: false, enum: OneValueEnum }, breed: { required: false, type: () => String }, nodes: { required: true, type: () => [Object] }, optionalBoolean: { required: false, type: () => Boolean }, date: { required: true, type: () => Date } };
+        return { name: { required: true, type: () => String }, age: { required: true, type: () => Number, default: 3, minimum: 0, maximum: 10 }, tags: { required: true, type: () => [String] }, status: { required: true, default: Status.ENABLED, enum: Status }, status2: { required: false, enum: Status }, statusArr: { required: false, enum: Status, isArray: true }, oneValueEnum: { required: false, enum: OneValueEnum }, oneValueEnumArr: { required: false, enum: OneValueEnum }, breed: { description: "this is breed", required: false, type: () => String }, nodes: { required: true, type: () => [Object] }, optionalBoolean: { required: false, type: () => Boolean }, date: { required: true, type: () => Date } };
     }
 }
 __decorate([
@@ -65,7 +66,6 @@ __decorate([
     Max(10)
 ], CreateCatDto.prototype, \"age\", void 0);
 __decorate([
-    ApiProperty({ type: String }),
     IsString()
 ], CreateCatDto.prototype, \"breed\", void 0);
 __decorate([

--- a/test/plugin/fixtures/create-cat.dto.ts
+++ b/test/plugin/fixtures/create-cat.dto.ts
@@ -26,7 +26,7 @@ export class CreateCatDto {
   oneValueEnum?: OneValueEnum;
   oneValueEnumArr?: OneValueEnum[];
 
-  // this is breed im comment
+  /** this is breed im comment */
   @ApiProperty({ description: "this is breed", type: String })
   @IsString()
   readonly breed?: string;
@@ -58,7 +58,7 @@ export class CreateCatDto {
         this.status = Status.ENABLED;
     }
     static _OPENAPI_METADATA_FACTORY() {
-        return { name: { required: true, type: () => String }, age: { required: true, type: () => Number, default: 3, minimum: 0, maximum: 10 }, tags: { required: true, type: () => [String] }, status: { required: true, default: Status.ENABLED, enum: Status }, status2: { required: false, enum: Status }, statusArr: { required: false, enum: Status, isArray: true }, oneValueEnum: { required: false, enum: OneValueEnum }, oneValueEnumArr: { required: false, enum: OneValueEnum }, breed: { description: "this is breed", required: false, type: () => String }, nodes: { required: true, type: () => [Object] }, optionalBoolean: { required: false, type: () => Boolean }, date: { required: true, type: () => Date } };
+        return { name: { required: true, type: () => String }, age: { required: true, type: () => Number, default: 3, minimum: 0, maximum: 10 }, tags: { required: true, type: () => [String] }, status: { required: true, default: Status.ENABLED, enum: Status }, status2: { required: false, enum: Status }, statusArr: { required: false, enum: Status, isArray: true }, oneValueEnum: { required: false, enum: OneValueEnum }, oneValueEnumArr: { required: false, enum: OneValueEnum }, breed: { description: "this is breed", type: () => String, title: "this is breed im comment", required: false }, nodes: { required: true, type: () => [Object] }, optionalBoolean: { required: false, type: () => Boolean }, date: { required: true, type: () => Date } };
     }
 }
 __decorate([

--- a/test/plugin/fixtures/create-cat.dto.ts
+++ b/test/plugin/fixtures/create-cat.dto.ts
@@ -58,7 +58,7 @@ export class CreateCatDto {
         this.status = Status.ENABLED;
     }
     static _OPENAPI_METADATA_FACTORY() {
-        return { name: { required: true, type: () => String }, age: { required: true, type: () => Number, default: 3, minimum: 0, maximum: 10 }, tags: { required: true, type: () => [String] }, status: { required: true, default: Status.ENABLED, enum: Status }, status2: { required: false, enum: Status }, statusArr: { required: false, enum: Status, isArray: true }, oneValueEnum: { required: false, enum: OneValueEnum }, oneValueEnumArr: { required: false, enum: OneValueEnum }, breed: { description: "this is breed", type: () => String, title: "this is breed im comment", required: false }, nodes: { required: true, type: () => [Object] }, optionalBoolean: { required: false, type: () => Boolean }, date: { required: true, type: () => Date } };
+        return { name: { required: true, type: () => String }, age: { required: true, type: () => Number, default: 3, minimum: 0, maximum: 10 }, tags: { required: true, type: () => [String] }, status: { required: true, default: Status.ENABLED, enum: Status }, status2: { required: false, enum: Status }, statusArr: { required: false, enum: Status, isArray: true }, oneValueEnum: { required: false, enum: OneValueEnum }, oneValueEnumArr: { required: false, enum: OneValueEnum }, breed: { description: "this is breed", type: String, title: "this is breed im comment", required: false }, nodes: { required: true, type: () => [Object] }, optionalBoolean: { required: false, type: () => Boolean }, date: { required: true, type: () => Date } };
     }
 }
 __decorate([

--- a/test/plugin/fixtures/es5-class.dto.ts
+++ b/test/plugin/fixtures/es5-class.dto.ts
@@ -6,6 +6,7 @@ import { CONSTANT_STRING, CONSTANT_OBJECT, MIN_VAL } from './constants';
 export class CreateCatDtoEs5 {
   // field name
   name: string = CONSTANT_STRING;
+  /** status */
   status: Status = Status.ENABLED;
   obj = CONSTANT_OBJECT;
 
@@ -25,12 +26,13 @@ var CreateCatDtoEs5 = /** @class */ (function () {
     function CreateCatDtoEs5() {
         // field name
         this.name = constants_1.CONSTANT_STRING;
+        /** status */
         this.status = status_1.Status.ENABLED;
         this.obj = constants_1.CONSTANT_OBJECT;
         this.age = 3;
     }
     CreateCatDtoEs5._OPENAPI_METADATA_FACTORY = function () {
-        return { name: { description: "field name", required: true, type: function () { return String; }, default: constants_1.CONSTANT_STRING }, status: { required: true, type: function () { return Object; }, default: status_1.Status.ENABLED }, obj: { required: true, type: function () { return Object; }, default: constants_1.CONSTANT_OBJECT }, age: { required: true, type: function () { return Number; }, default: 3, minimum: constants_1.MIN_VAL, maximum: 10 } };
+        return { name: { required: true, type: function () { return String; }, default: constants_1.CONSTANT_STRING }, status: { description: "status", required: true, type: function () { return Object; }, default: status_1.Status.ENABLED }, obj: { required: true, type: function () { return Object; }, default: constants_1.CONSTANT_OBJECT }, age: { required: true, type: function () { return Number; }, default: 3, minimum: constants_1.MIN_VAL, maximum: 10 } };
     };
     __decorate([
         Min(constants_1.MIN_VAL),

--- a/test/plugin/fixtures/es5-class.dto.ts
+++ b/test/plugin/fixtures/es5-class.dto.ts
@@ -4,6 +4,7 @@ import { Status } from './status';
 import { CONSTANT_STRING, CONSTANT_OBJECT, MIN_VAL } from './constants';
 
 export class CreateCatDtoEs5 {
+  // field name
   name: string = CONSTANT_STRING;
   status: Status = Status.ENABLED;
   obj = CONSTANT_OBJECT;
@@ -22,13 +23,14 @@ var status_1 = require(\"./status\");
 var constants_1 = require(\"./constants\");
 var CreateCatDtoEs5 = /** @class */ (function () {
     function CreateCatDtoEs5() {
+        // field name
         this.name = constants_1.CONSTANT_STRING;
         this.status = status_1.Status.ENABLED;
         this.obj = constants_1.CONSTANT_OBJECT;
         this.age = 3;
     }
     CreateCatDtoEs5._OPENAPI_METADATA_FACTORY = function () {
-        return { name: { required: true, type: function () { return String; }, default: constants_1.CONSTANT_STRING }, status: { required: true, type: function () { return Object; }, default: status_1.Status.ENABLED }, obj: { required: true, type: function () { return Object; }, default: constants_1.CONSTANT_OBJECT }, age: { required: true, type: function () { return Number; }, default: 3, minimum: constants_1.MIN_VAL, maximum: 10 } };
+        return { name: { description: "field name", required: true, type: function () { return String; }, default: constants_1.CONSTANT_STRING }, status: { required: true, type: function () { return Object; }, default: status_1.Status.ENABLED }, obj: { required: true, type: function () { return Object; }, default: constants_1.CONSTANT_OBJECT }, age: { required: true, type: function () { return Number; }, default: 3, minimum: constants_1.MIN_VAL, maximum: 10 } };
     };
     __decorate([
         Min(constants_1.MIN_VAL),

--- a/test/plugin/model-class-visitor.spec.ts
+++ b/test/plugin/model-class-visitor.spec.ts
@@ -18,7 +18,7 @@ import {
 } from './fixtures/es5-class.dto';
 
 describe('API model properties', () => {
-  it('should add the metadata factory when no decorators exist', () => {
+  it('should add the metadata factory when no decorators exist, and generated propertyKey is title', () => {
     const options: ts.CompilerOptions = {
       module: ts.ModuleKind.ESNext,
       target: ts.ScriptTarget.ESNext,
@@ -33,7 +33,12 @@ describe('API model properties', () => {
       compilerOptions: options,
       fileName: filename,
       transformers: {
-        before: [before({ classValidatorShim: true }, fakeProgram)]
+        before: [
+          before(
+            { classValidatorShim: true, dtoKeyOfComment: 'title' },
+            fakeProgram
+          )
+        ]
       }
     });
     expect(result.outputText).toEqual(createCatDtoTextTranspiled);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)  
test added.
- [x] Docs have been added / updated (for bug fixes / features)  
no docs in this project yet.


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When enable the plugin by modified nest-cli.json , there is no default `description` and `example` in `ApiProperty` and `ApiOperation`

## What is the new behavior?

Auto generate `description` and (`example` or `examples`) from comment, just like this:
```
export abstract class Audit {
  /** test on createdAt */
  @CreateDateColumn()
  createdAt;

  // test on updatedAt1
  // test on updatedAt2
  @UpdateDateColumn()
  updatedAt;

  /**
   * test
   * version 
   * @example '0.0.1'
   * @memberof Audit
   */
  @VersionColumn()
  version;

  /**
   * testVersion
   *  
   * @example '0.0.1'
   * @example '0.0.2'
   * @memberof Audit
   */
  testVersion;
}
``` 
=>
```
export class Audit {
    static _OPENAPI_METADATA_FACTORY() {
        return { createdAt: { description: "test on createdAt", required: true, type: () => Object }, updatedAt: { description: "test on updatedAt1\\ntest on updatedAt2", required: true, type: () => Object }, version: { description: "test\\nversion", required: true, type: () => Object, example: "0.0.1" }, testVersion: { description: "testVersion", required: true, type: () => Object, examples: ["0.0.1", "0.0.2"] } };
    }
}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information