### PR TITLE
fix(api-extension): add support for string extensions

### DIFF
--- a/e2e/api-spec.json
+++ b/e2e/api-spec.json
@@ -345,6 +345,7 @@
     "/api/cats/{id}": {
       "get": {
         "operationId": "CatsController_findOne",
+        "x-auth-type": "NONE",
         "parameters": [
           {
             "name": "id",

--- a/e2e/src/cats/cats.controller.ts
+++ b/e2e/src/cats/cats.controller.ts
@@ -40,6 +40,7 @@ export class CatsController {
     description: 'The found record',
     type: Cat
   })
+  @ApiExtension('x-auth-type', 'NONE')
   findOne(@Param('id') id: string): Cat {
     return this.catsService.findOne(+id);
   }

--- a/lib/decorators/api-extension.decorator.ts
+++ b/lib/decorators/api-extension.decorator.ts
@@ -9,9 +9,10 @@ export function ApiExtension(extensionKey: string, extensionProperties: any) {
   }
 
   const extensionObject = {
-    [extensionKey]: {
-      ...extensionProperties
-    }
+    [extensionKey]:
+      typeof extensionProperties !== 'string'
+        ? { ...extensionProperties }
+        : extensionProperties
   };
 
   return createMixedDecorator(DECORATORS.API_EXTENSION, extensionObject);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
The current `@ApiExtension` produces a wrong json output when the extension is a string.
The following extension `@ApiExtension('x-key', 'VALUE');` produces:

```json
{
  "x-key": { "0": "V", "1": "A", "2": "L", "3": "U", "4": "E" }
}
```

## What is the new behavior?

```json
{
  "x-key": "VALUE"
}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```