### PR TITLE
feat(): add use method name for operations option

### DIFF
--- a/lib/interfaces/swagger-document-options.interface.ts
+++ b/lib/interfaces/swagger-document-options.interface.ts
@@ -18,4 +18,9 @@ export interface SwaggerDocumentOptions {
    * If `true`, swagger will also load routes from the modules imported by `include` modules
    */
   deepScanRoutes?: boolean;
+
+  /**
+   * If `true`, only uses the method name in operations (getUser) instead of methods prefixed by the controller name (UserController_getUser).
+   */
+  useMethodNameForOperations?: boolean;
 }

--- a/lib/interfaces/swagger-document-options.interface.ts
+++ b/lib/interfaces/swagger-document-options.interface.ts
@@ -20,7 +20,9 @@ export interface SwaggerDocumentOptions {
   deepScanRoutes?: boolean;
 
   /**
-   * If `true`, only uses the method name in operations (getUser) instead of methods prefixed by the controller name (UserController_getUser).
+   * Custom operationIdFactory that will be used to generate the `operationId` based on the `controllerKey` and
+   * `methodKey`
+   * @default () => controllerKey_methodKey
    */
-  useMethodNameForOperations?: boolean;
+  operationIdFactory?: (controllerKey: string, methodKey: string) => string;
 }

--- a/lib/plugin/visitors/model-class.visitor.ts
+++ b/lib/plugin/visitors/model-class.visitor.ts
@@ -196,6 +196,7 @@ export class ModelClassVisitor extends AbstractFileVisitor {
     if (hasPropertyKey(key, existingProperties)) {
       return [];
     }
+<<<<<<< HEAD
     if (node) {
       if (ts.isTypeLiteralNode(node)) {
         const propertyAssignments = Array.from(node.members || []).map(
@@ -239,6 +240,17 @@ export class ModelClassVisitor extends AbstractFileVisitor {
         if (remainingTypes.length === 1) {
           const remainingTypesProperties = this.createTypePropertyAssignments(
             remainingTypes[0],
+=======
+    const type = typeChecker.getTypeAtLocation(node);
+    if (!type) {
+      return undefined;
+    }
+    if (node.type && ts.isTypeLiteralNode(node.type)) {
+      const propertyAssignments = Array.from(node.type.members || []).map(
+        (member) => {
+          const literalExpr = this.createDecoratorObjectLiteralExpr(
+            member as ts.PropertySignature,
+>>>>>>> feat(lib): add operation id factory
             typeChecker,
             existingProperties,
             hostFilename

--- a/lib/plugin/visitors/model-class.visitor.ts
+++ b/lib/plugin/visitors/model-class.visitor.ts
@@ -196,7 +196,6 @@ export class ModelClassVisitor extends AbstractFileVisitor {
     if (hasPropertyKey(key, existingProperties)) {
       return [];
     }
-<<<<<<< HEAD
     if (node) {
       if (ts.isTypeLiteralNode(node)) {
         const propertyAssignments = Array.from(node.members || []).map(
@@ -240,17 +239,6 @@ export class ModelClassVisitor extends AbstractFileVisitor {
         if (remainingTypes.length === 1) {
           const remainingTypesProperties = this.createTypePropertyAssignments(
             remainingTypes[0],
-=======
-    const type = typeChecker.getTypeAtLocation(node);
-    if (!type) {
-      return undefined;
-    }
-    if (node.type && ts.isTypeLiteralNode(node.type)) {
-      const propertyAssignments = Array.from(node.type.members || []).map(
-        (member) => {
-          const literalExpr = this.createDecoratorObjectLiteralExpr(
-            member as ts.PropertySignature,
->>>>>>> feat(lib): add operation id factory
             typeChecker,
             existingProperties,
             hostFilename

--- a/lib/swagger-explorer.ts
+++ b/lib/swagger-explorer.ts
@@ -56,8 +56,13 @@ export class SwaggerExplorer {
   private readonly metadataScanner = new MetadataScanner();
   private readonly schemas: SchemaObject[] = [];
   private readonly schemaRefsStack: string[] = [];
-  private operationIdFactory = (controllerKey: string, methodKey: string) =>
-    `${controllerKey}_${methodKey}`;
+  private operationIdFactory = (controllerKey: string, methodKey: string) => {
+    if (controllerKey) {
+      return `${controllerKey}_${methodKey}`;
+    } else {
+      return methodKey;
+    }
+  };
 
   constructor(private readonly schemaObjectFactory: SchemaObjectFactory) {}
 

--- a/lib/swagger-explorer.ts
+++ b/lib/swagger-explorer.ts
@@ -56,14 +56,17 @@ export class SwaggerExplorer {
   private readonly metadataScanner = new MetadataScanner();
   private readonly schemas: SchemaObject[] = [];
   private readonly schemaRefsStack: string[] = [];
+  private useMethodNameForOperations: boolean;
 
   constructor(private readonly schemaObjectFactory: SchemaObjectFactory) {}
 
   public exploreController(
     wrapper: InstanceWrapper<Controller>,
     modulePath?: string,
-    globalPrefix?: string
+    globalPrefix?: string,
+    useMethodNameForOperations?: boolean
   ) {
+    this.useMethodNameForOperations = useMethodNameForOperations;
     const { instance, metatype } = wrapper;
     const prototype = Object.getPrototypeOf(instance);
     const documentResolvers: DenormalizedDocResolvers = {
@@ -226,7 +229,7 @@ export class SwaggerExplorer {
   }
 
   private getOperationId(instance: object, method: Function): string {
-    if (instance.constructor) {
+    if (instance.constructor && !this.useMethodNameForOperations) {
       return `${instance.constructor.name}_${method.name}`;
     }
     return method.name;

--- a/lib/swagger-scanner.ts
+++ b/lib/swagger-scanner.ts
@@ -33,7 +33,7 @@ export class SwaggerScanner {
       include: includedModules = [],
       extraModels = [],
       ignoreGlobalPrefix = false,
-      useMethodNameForOperations = false
+      operationIdFactory
     } = options;
 
     const container: NestContainer = (app as any).container;
@@ -69,7 +69,7 @@ export class SwaggerScanner {
           allRoutes,
           path,
           globalPrefix,
-          useMethodNameForOperations
+          operationIdFactory
         );
       }
     );
@@ -92,14 +92,14 @@ export class SwaggerScanner {
     routes: Map<string, InstanceWrapper>,
     modulePath?: string,
     globalPrefix?: string,
-    useMethodNameForOperations?: boolean
+    operationIdFactory?: (controllerKey: string, methodKey: string) => string
   ): Array<Omit<OpenAPIObject, 'openapi' | 'info'> & Record<'root', any>> {
     const denormalizedArray = [...routes.values()].map((ctrl) =>
       this.explorer.exploreController(
         ctrl,
         modulePath,
         globalPrefix,
-        useMethodNameForOperations
+        operationIdFactory
       )
     );
     return flatten(denormalizedArray) as any;

--- a/lib/swagger-scanner.ts
+++ b/lib/swagger-scanner.ts
@@ -32,7 +32,8 @@ export class SwaggerScanner {
       deepScanRoutes,
       include: includedModules = [],
       extraModels = [],
-      ignoreGlobalPrefix = false
+      ignoreGlobalPrefix = false,
+      useMethodNameForOperations = false
     } = options;
 
     const container: NestContainer = (app as any).container;
@@ -64,7 +65,12 @@ export class SwaggerScanner {
           ? Reflect.getMetadata(MODULE_PATH, metatype)
           : undefined;
 
-        return this.scanModuleRoutes(allRoutes, path, globalPrefix);
+        return this.scanModuleRoutes(
+          allRoutes,
+          path,
+          globalPrefix,
+          useMethodNameForOperations
+        );
       }
     );
 
@@ -85,10 +91,16 @@ export class SwaggerScanner {
   public scanModuleRoutes(
     routes: Map<string, InstanceWrapper>,
     modulePath?: string,
-    globalPrefix?: string
+    globalPrefix?: string,
+    useMethodNameForOperations?: boolean
   ): Array<Omit<OpenAPIObject, 'openapi' | 'info'> & Record<'root', any>> {
     const denormalizedArray = [...routes.values()].map((ctrl) =>
-      this.explorer.exploreController(ctrl, modulePath, globalPrefix)
+      this.explorer.exploreController(
+        ctrl,
+        modulePath,
+        globalPrefix,
+        useMethodNameForOperations
+      )
     );
     return flatten(denormalizedArray) as any;
   }

--- a/test/explorer/swagger-explorer.spec.ts
+++ b/test/explorer/swagger-explorer.spec.ts
@@ -19,12 +19,14 @@ import { ModelPropertiesAccessor } from '../../lib/services/model-properties-acc
 import { SchemaObjectFactory } from '../../lib/services/schema-object-factory';
 import { SwaggerTypesMapper } from '../../lib/services/swagger-types-mapper';
 import { SwaggerExplorer } from '../../lib/swagger-explorer';
+import { DenormalizedDoc } from '../../lib/interfaces/denormalized-doc.interface';
 
 describe('SwaggerExplorer', () => {
   const schemaObjectFactory = new SchemaObjectFactory(
     new ModelPropertiesAccessor(),
     new SwaggerTypesMapper()
   );
+
   describe('when module only uses metadata', () => {
     class Foo {}
 
@@ -76,11 +78,35 @@ describe('SwaggerExplorer', () => {
         } as InstanceWrapper<FooController>,
         'path'
       );
+      const operationPrefix = 'FooController_';
 
+      validateRoutes(routes, operationPrefix);
+    });
+
+    it('sees two controller operations and their responses with useMethodNameForOperations = true', () => {
+      const explorer = new SwaggerExplorer(schemaObjectFactory);
+      const routes = explorer.exploreController(
+        {
+          instance: new FooController(),
+          metatype: FooController
+        } as InstanceWrapper<FooController>,
+        'path',
+        undefined,
+        true
+      );
+      const operationPrefix = '';
+
+      validateRoutes(routes, operationPrefix);
+    });
+
+    const validateRoutes = (
+      routes: DenormalizedDoc[],
+      operationPrefix: string
+    ) => {
       expect(routes.length).toEqual(2);
 
       // POST
-      expect(routes[0].root.operationId).toEqual('FooController_create');
+      expect(routes[0].root.operationId).toEqual(operationPrefix + 'create');
       expect(routes[0].root.method).toEqual('post');
       expect(routes[0].root.path).toEqual('/path/foos');
       expect(routes[0].root.summary).toEqual('Create foo');
@@ -141,7 +167,7 @@ describe('SwaggerExplorer', () => {
       });
 
       // GET
-      expect(routes[1].root.operationId).toEqual('FooController_find');
+      expect(routes[1].root.operationId).toEqual(operationPrefix + 'find');
       expect(routes[1].root.method).toEqual('get');
       expect(routes[1].root.path).toEqual('/path/foos/{objectId}');
       expect(routes[1].root.summary).toEqual('List all Foos');
@@ -179,8 +205,9 @@ describe('SwaggerExplorer', () => {
           }
         }
       });
-    });
+    };
   });
+
   describe('when explicit decorators and metadata are used', () => {
     class Foo {}
 
@@ -223,11 +250,35 @@ describe('SwaggerExplorer', () => {
         } as InstanceWrapper<FooController>,
         'path'
       );
+      const prefix = 'FooController_';
 
+      validateRoutes(routes, prefix);
+    });
+
+    it('sees two controller operations and their responses when useMethodNameForOperations = true', () => {
+      const explorer = new SwaggerExplorer(schemaObjectFactory);
+      const routes = explorer.exploreController(
+        {
+          instance: new FooController(),
+          metatype: FooController
+        } as InstanceWrapper<FooController>,
+        'path',
+        undefined,
+        true
+      );
+      const prefix = '';
+
+      validateRoutes(routes, prefix);
+    });
+
+    const validateRoutes = (
+      routes: DenormalizedDoc[],
+      operationPrefix: string
+    ) => {
       expect(routes.length).toEqual(2);
 
       // POST
-      expect(routes[0].root.operationId).toEqual('FooController_create');
+      expect(routes[0].root.operationId).toEqual(operationPrefix + 'create');
       expect(routes[0].root.method).toEqual('post');
       expect(routes[0].root.path).toEqual('/path/foos');
       expect(routes[0].root.summary).toEqual('Create foo');
@@ -260,7 +311,7 @@ describe('SwaggerExplorer', () => {
       });
 
       // GET
-      expect(routes[1].root.operationId).toEqual('FooController_find');
+      expect(routes[1].root.operationId).toEqual(operationPrefix + 'find');
       expect(routes[1].root.method).toEqual('get');
       expect(routes[1].root.path).toEqual('/path/foos/{objectId}');
       expect(routes[1].root.summary).toEqual('List all Foos');
@@ -310,7 +361,7 @@ describe('SwaggerExplorer', () => {
           }
         }
       });
-    });
+    };
   });
   describe('when only explicit decorators are used', () => {
     class Foo {}
@@ -351,11 +402,35 @@ describe('SwaggerExplorer', () => {
         } as InstanceWrapper<FooController>,
         'path'
       );
+      const operationPrefix = 'FooController_';
 
+      validateRoutes(routes, operationPrefix);
+    });
+
+    it('sees two controller operations and their responses when useMethodNameForOperations = true', () => {
+      const explorer = new SwaggerExplorer(schemaObjectFactory);
+      const routes = explorer.exploreController(
+        {
+          instance: new FooController(),
+          metatype: FooController
+        } as InstanceWrapper<FooController>,
+        'path',
+        undefined,
+        true
+      );
+      const operationPrefix = '';
+
+      validateRoutes(routes, operationPrefix);
+    });
+
+    const validateRoutes = (
+      routes: DenormalizedDoc[],
+      operationPrefix: string
+    ) => {
       expect(routes.length).toEqual(2);
 
       // POST
-      expect(routes[0].root.operationId).toEqual('FooController_create');
+      expect(routes[0].root.operationId).toEqual(operationPrefix + 'create');
       expect(routes[0].root.method).toEqual('post');
       expect(routes[0].root.path).toEqual('/path/foos');
       expect(routes[0].root.summary).toEqual('Create foo');
@@ -385,7 +460,7 @@ describe('SwaggerExplorer', () => {
       });
 
       // GET
-      expect(routes[1].root.operationId).toEqual('FooController_find');
+      expect(routes[1].root.operationId).toEqual(operationPrefix + 'find');
       expect(routes[1].root.method).toEqual('get');
       expect(routes[1].root.path).toEqual('/path/foos/{objectId}');
       expect(routes[1].root.summary).toEqual('List all Foos');
@@ -424,7 +499,7 @@ describe('SwaggerExplorer', () => {
           }
         }
       });
-    });
+    };
   });
   describe('when custom properties are passed', () => {
     class Foo {}
@@ -492,6 +567,25 @@ describe('SwaggerExplorer', () => {
         'path'
       );
 
+      validateRoutes(routes);
+    });
+
+    it('should merge implicit metadata with explicit options and useMethodNameForOperations = true', () => {
+      const explorer = new SwaggerExplorer(schemaObjectFactory);
+      const routes = explorer.exploreController(
+        {
+          instance: new FooController(),
+          metatype: FooController
+        } as InstanceWrapper<FooController>,
+        'path',
+        undefined,
+        true
+      );
+
+      validateRoutes(routes);
+    });
+
+    const validateRoutes = (routes: DenormalizedDoc[]) => {
       expect(routes.length).toEqual(2);
 
       // POST
@@ -581,7 +675,7 @@ describe('SwaggerExplorer', () => {
           }
         }
       });
-    });
+    };
   });
   describe('when enum is used', () => {
     enum ParamEnum {

--- a/test/explorer/swagger-explorer.spec.ts
+++ b/test/explorer/swagger-explorer.spec.ts
@@ -26,6 +26,11 @@ describe('SwaggerExplorer', () => {
     new ModelPropertiesAccessor(),
     new SwaggerTypesMapper()
   );
+  const methodKeyOperationIdFactory = (_, methodKey: string) => methodKey;
+  const controllerKeyMethodKeyOperationIdFactory = (
+    controllerKey: string,
+    methodKey: string
+  ) => `${controllerKey}.${methodKey}`;
 
   describe('when module only uses metadata', () => {
     class Foo {}
@@ -83,7 +88,7 @@ describe('SwaggerExplorer', () => {
       validateRoutes(routes, operationPrefix);
     });
 
-    it('sees two controller operations and their responses with useMethodNameForOperations = true', () => {
+    it('sees two controller operations and their responses with custom operationIdFactory to return methodKey', () => {
       const explorer = new SwaggerExplorer(schemaObjectFactory);
       const routes = explorer.exploreController(
         {
@@ -92,9 +97,25 @@ describe('SwaggerExplorer', () => {
         } as InstanceWrapper<FooController>,
         'path',
         undefined,
-        true
+        methodKeyOperationIdFactory
       );
       const operationPrefix = '';
+
+      validateRoutes(routes, operationPrefix);
+    });
+
+    it('sees two controller operations and their responses with custom operationIdFactory to return controllerKey.methodKey', () => {
+      const explorer = new SwaggerExplorer(schemaObjectFactory);
+      const routes = explorer.exploreController(
+        {
+          instance: new FooController(),
+          metatype: FooController
+        } as InstanceWrapper<FooController>,
+        'path',
+        undefined,
+        controllerKeyMethodKeyOperationIdFactory
+      );
+      const operationPrefix = 'FooController.';
 
       validateRoutes(routes, operationPrefix);
     });
@@ -255,7 +276,7 @@ describe('SwaggerExplorer', () => {
       validateRoutes(routes, prefix);
     });
 
-    it('sees two controller operations and their responses when useMethodNameForOperations = true', () => {
+    it('sees two controller operations and their responses with custom operationIdFactory to return methodKey', () => {
       const explorer = new SwaggerExplorer(schemaObjectFactory);
       const routes = explorer.exploreController(
         {
@@ -264,9 +285,25 @@ describe('SwaggerExplorer', () => {
         } as InstanceWrapper<FooController>,
         'path',
         undefined,
-        true
+        methodKeyOperationIdFactory
       );
       const prefix = '';
+
+      validateRoutes(routes, prefix);
+    });
+
+    it('sees two controller operations and their responses with custom operationIdFactory to return controllerKey.methodKey', () => {
+      const explorer = new SwaggerExplorer(schemaObjectFactory);
+      const routes = explorer.exploreController(
+        {
+          instance: new FooController(),
+          metatype: FooController
+        } as InstanceWrapper<FooController>,
+        'path',
+        undefined,
+        controllerKeyMethodKeyOperationIdFactory
+      );
+      const prefix = 'FooController.';
 
       validateRoutes(routes, prefix);
     });
@@ -407,7 +444,7 @@ describe('SwaggerExplorer', () => {
       validateRoutes(routes, operationPrefix);
     });
 
-    it('sees two controller operations and their responses when useMethodNameForOperations = true', () => {
+    it('sees two controller operations and their responses with custom operationIdFactory to return methodKey', () => {
       const explorer = new SwaggerExplorer(schemaObjectFactory);
       const routes = explorer.exploreController(
         {
@@ -416,9 +453,25 @@ describe('SwaggerExplorer', () => {
         } as InstanceWrapper<FooController>,
         'path',
         undefined,
-        true
+        methodKeyOperationIdFactory
       );
       const operationPrefix = '';
+
+      validateRoutes(routes, operationPrefix);
+    });
+
+    it('sees two controller operations and their responses with custom operationIdFactory to return controllerKey.methodKey', () => {
+      const explorer = new SwaggerExplorer(schemaObjectFactory);
+      const routes = explorer.exploreController(
+        {
+          instance: new FooController(),
+          metatype: FooController
+        } as InstanceWrapper<FooController>,
+        'path',
+        undefined,
+        controllerKeyMethodKeyOperationIdFactory
+      );
+      const operationPrefix = 'FooController.';
 
       validateRoutes(routes, operationPrefix);
     });
@@ -570,7 +623,7 @@ describe('SwaggerExplorer', () => {
       validateRoutes(routes);
     });
 
-    it('should merge implicit metadata with explicit options and useMethodNameForOperations = true', () => {
+    it('should merge implicit metadata with explicit options and use default operationIdFactory', () => {
       const explorer = new SwaggerExplorer(schemaObjectFactory);
       const routes = explorer.exploreController(
         {
@@ -578,8 +631,7 @@ describe('SwaggerExplorer', () => {
           metatype: FooController
         } as InstanceWrapper<FooController>,
         'path',
-        undefined,
-        true
+        undefined
       );
 
       validateRoutes(routes);


### PR DESCRIPTION
Make the behavior change for operation names that was introduced in https://github.com/nestjs/swagger/pull/487 configurable, and allow users whose client libraries have broken because of this (see https://github.com/nestjs/swagger/issues/482) to configure this behavior.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features) yes, see https://github.com/nestjs/docs.nestjs.com/pull/1247


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Since #487 was merged, operation IDs generated by NestJS changed from e.g.
```
addUser
```
to
```
UserController_addUser
```
... this is causing users of generated client libraries (e.g. Angular) to have to update all their service calls to unnecessarily long names, e.g. from `designService.updateImages` to `designService.frontendDesignsControllerUpdateImages` (see https://github.com/nestjs/swagger/issues/482#issuecomment-577777620).

Issue Number: N/A


## What is the new behavior?
This PR allows users to configure this behavior. By default, nothing changes, unless the user configures @nestjs/swagger with a custom `operationIdFactory`:

```TypeScript
const app = await NestFactory.create(AppModule);
const operationIdFactory = (
  controllerKey: string,
  methodKey: string
) => `${methodKey}`;

const options = new DocumentBuilder()
  .setTitle('Cats example')
  .setDescription('The cats API description')
  .setVersion('1.0')
  .addTag('cats')
  .build();
const document = SwaggerModule.createDocument(app, options, {
  operationIdFactory
});
SwaggerModule.setup('api', app, document);
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information