### PR TITLE
feat(): add yaml export for Express apps

### DIFF
--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -51,11 +51,16 @@ export class SwaggerModule {
     const swaggerUi = loadPackage('swagger-ui-express', 'SwaggerModule', () =>
       require('swagger-ui-express')
     );
+    const YAML = loadPackage('yaml', 'SwaggerModule', () => require('yaml'));
     const swaggerHtml = swaggerUi.generateHTML(document, options);
     app.use(finalPath, swaggerUi.serveFiles(document, options));
 
     httpAdapter.get(finalPath, (req, res) => res.send(swaggerHtml));
     httpAdapter.get(finalPath + '-json', (req, res) => res.json(document));
+    httpAdapter.get(finalPath + '-yaml', (req, res) => {
+      res.header('Content-Type', 'application/x-yaml');
+      res.send(YAML.stringify(document));
+    });
   }
 
   private static setupFastify(

--- a/package-lock.json
+++ b/package-lock.json
@@ -361,15 +361,6 @@
         "@babel/helper-plugin-utils": "^7.8.0"
       }
     },
-    "@babel/runtime": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.8.3.tgz",
-      "integrity": "sha512-fVHx1rzEmwB130VTkLnxR+HmxcTjGzH12LYQcFFoBwakMd3aOMD4OsRN7tGG/UOYE2ektgFrS8uACAoRk1CY0w==",
-      "dev": true,
-      "requires": {
-        "regenerator-runtime": "^0.13.2"
-      }
-    },
     "@babel/template": {
       "version": "7.8.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
@@ -10864,12 +10855,6 @@
       "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg==",
       "dev": true
     },
-    "regenerator-runtime": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw==",
-      "dev": true
-    },
     "regex-not": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
@@ -13314,13 +13299,10 @@
       "dev": true
     },
     "yaml": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz",
-      "integrity": "sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==",
-      "dev": true,
-      "requires": {
-        "@babel/runtime": "^7.6.3"
-      }
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==",
+      "dev": true
     },
     "yargs": {
       "version": "15.3.1",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
     "swagger-parser": "9.0.1",
     "swagger-ui-express": "4.1.4",
     "ts-jest": "26.0.0",
-    "typescript": "3.8.3"
+    "typescript": "3.8.3",
+    "yaml": "1.10.0"
   },
   "peerDependencies": {
     "@nestjs/common": "^6.8.0 || ^7.0.0",


### PR DESCRIPTION
Add /api-yaml endpoint to return the openapi document formatted as yaml

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
It adds an endpoint with the `-yaml` suffix for express apps, just like the `-json` suffix we currently have.
<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[X] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
We currently have `-json` endpoint to export the openapi spec as JSON. This does the same, but with YAML.
Issue Number: N/A


## What is the new behavior?
We currently have `-json` endpoint to export the openapi spec as JSON. This does the same, but with YAML.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Couldn't find any test for the current `-json` endpoint, so I haven't added any for the `-yaml` one.
As for documentation, I also couldn't find in here anything related to the JSON export. I know the main nestjs repo has this mentioned and this will have to be added there next to the JSON one.