### PR TITLE
fix(): replace import path for windows fix

### DIFF
--- a/lib/plugin/utils/plugin-utils.ts
+++ b/lib/plugin/utils/plugin-utils.ts
@@ -1,5 +1,5 @@
 import { head } from 'lodash';
-import { dirname, posix } from 'path';
+import { dirname, relative } from 'path';
 import * as ts from 'typescript';
 import {
   getDecoratorName,
@@ -17,7 +17,7 @@ export function getDecoratorOrUndefinedByNames(
   names: string[],
   decorators: ts.NodeArray<ts.Decorator>
 ): ts.Decorator | undefined {
-  return (decorators || ts.createNodeArray()).find(item =>
+  return (decorators || ts.createNodeArray()).find((item) =>
     names.includes(getDecoratorName(item))
   );
 }
@@ -99,8 +99,8 @@ export function hasPropertyKey(
   properties: ts.NodeArray<ts.PropertyAssignment>
 ): boolean {
   return properties
-    .filter(item => !isDynamicallyAdded(item))
-    .some(item => item.name.getText() === key);
+    .filter((item) => !isDynamicallyAdded(item))
+    .some((item) => item.name.getText() === key);
 }
 
 export function replaceImportPath(typeReference: string, fileName: string) {
@@ -113,7 +113,7 @@ export function replaceImportPath(typeReference: string, fileName: string) {
   }
   importPath = importPath.slice(2, importPath.length - 1);
 
-  let relativePath = posix.relative(dirname(fileName), importPath);
+  let relativePath = relative(dirname(fileName), importPath);
   relativePath = relativePath[0] !== '.' ? './' + relativePath : relativePath;
 
   const nodeModulesText = 'node_modules';

--- a/test/plugin/plugin-utils.spec.ts
+++ b/test/plugin/plugin-utils.spec.ts
@@ -1,0 +1,43 @@
+import { replaceImportPath } from '../../lib/plugin/utils/plugin-utils';
+
+describe('Plugin utils', () => {
+  const params = [
+    {
+      description:
+        'should replace import path correctly when absolute pathes passed on windows',
+      typeReference:
+        '[import("d:\\Projects\\PG\\src\\services\\users\\users.dto").UserDto]',
+      fileName: 'd:\\Projects\\PG\\src\\services\\users\\users.controller.ts',
+      expected: '[require("./users.dto").UserDto]'
+    },
+    {
+      description:
+        'should replace import path correctly when relative pathes passed on windows',
+      typeReference: '[import(".\\src\\services\\users\\users.dto").UserDto]',
+      fileName: '.\\src\\services\\users\\users.controller.ts',
+      expected: '[require("./users.dto").UserDto]'
+    },
+    {
+      description:
+        'should replace import path correctly when absolute pathes passed on posix systems',
+      typeReference:
+        '[import("/home/Projects/PG/src/services/users/users.dto").UserDto]',
+      fileName: '/home/Projects/PG/src/services/users/users.controller.ts',
+      expected: '[require("./users.dto").UserDto]'
+    },
+    {
+      description:
+        'should replace import path correctly when relative pathes passed on posix systems',
+      typeReference: '[import("./services/users/users.dto").UserDto]',
+      fileName: './services/users/users.controller.ts',
+      expected: '[require("./users.dto").UserDto]'
+    }
+  ];
+
+  params.forEach((x) => {
+    it(x.description, () => {
+      const res = replaceImportPath(x.typeReference, x.fileName);
+      expect(res).toEqual(x.expected);
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
replaceImportPath not working for windows system when absolute path received, which leads to webpack sourcemaps generation errors, as well as incorrect plugin generated code in decorators injection section.

Issue Number: 769


## What is the new behavior?
replaceImportPath should now behave correctly for windows and posix systems both.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information