### PR TITLE
fix(plugin): update metadata correctly when using plugin in watch mode

### DIFF
--- a/test/plugin/fixtures/changed-class.dto.ts
+++ b/test/plugin/fixtures/changed-class.dto.ts
@@ -1,0 +1,27 @@
+export const originalCatDtoText = `
+export class ChangedCatDto {
+  name: string;
+  status: string;
+}
+`;
+
+export const changedCatDtoText = `
+export class ChangedCatDto {
+  name: string;
+}
+`;
+
+export const changedCatDtoTextTranspiled = `\"use strict\";
+Object.defineProperty(exports, \"__esModule\", { value: true });
+exports.ChangedCatDto = void 0;
+var openapi = require(\"@nestjs/swagger\");
+var ChangedCatDto = /** @class */ (function () {
+    function ChangedCatDto() {
+    }
+    ChangedCatDto._OPENAPI_METADATA_FACTORY = function () {
+        return { name: { required: true, type: function () { return String; } } };
+    };
+    return ChangedCatDto;
+}());
+exports.ChangedCatDto = ChangedCatDto;
+`;

--- a/test/plugin/model-class-visitor.spec.ts
+++ b/test/plugin/model-class-visitor.spec.ts
@@ -16,6 +16,11 @@ import {
   es5CreateCatDtoText,
   es5CreateCatDtoTextTranspiled
 } from './fixtures/es5-class.dto';
+import {
+  changedCatDtoText,
+  changedCatDtoTextTranspiled,
+  originalCatDtoText
+} from "./fixtures/changed-class.dto";
 
 describe('API model properties', () => {
   it('should add the metadata factory when no decorators exist', () => {
@@ -100,5 +105,35 @@ describe('API model properties', () => {
       }
     });
     expect(result.outputText).toEqual(es5CreateCatDtoTextTranspiled);
+  });
+
+  it('should remove properties from metadata when properties removed from dto', () => {
+    const options: ts.CompilerOptions = {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES5,
+      newLine: ts.NewLineKind.LineFeed,
+      noEmitHelpers: true,
+      strict: true
+    };
+    const filename = 'changed-class.dto.ts';
+    const fakeProgram = ts.createProgram([filename], options);
+
+    ts.transpileModule(originalCatDtoText, {
+      compilerOptions: options,
+      fileName: filename,
+      transformers: {
+        before: [before({ classValidatorShim: true }, fakeProgram)]
+      }
+    });
+
+    const changedResult = ts.transpileModule(changedCatDtoText, {
+      compilerOptions: options,
+      fileName: filename,
+      transformers: {
+        before: [before({ classValidatorShim: true }, fakeProgram)]
+      }
+    });
+
+    expect(changedResult.outputText).toEqual(changedCatDtoTextTranspiled);
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
When using swagger plugin with tsc/ttsc in watch mode, removing property from DTO does not lead to its removal from metadata until tsc/ttsc is restarted.
This behavior can be reproduced in https://github.com/artemsmirnov/nestjs-swagger-bug-demo by starting it with
`node index.js` and then removing `foo` or `test` property from `src/example.dto.ts`.

Issue Number: N/A


## What is the new behavior?
Metadata is updated according to changes in source file.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information