### PR TITLE
feat(api-response): support $ref

### DIFF
--- a/lib/decorators/api-response.decorator.ts
+++ b/lib/decorators/api-response.decorator.ts
@@ -4,7 +4,8 @@ import { omit } from 'lodash';
 import { DECORATORS } from '../constants';
 import {
   ResponseObject,
-  SchemaObject
+  SchemaObject,
+  ReferenceObject
 } from '../interfaces/open-api-spec.interface';
 import { getTypeIsArrayTuple } from './helpers';
 
@@ -18,7 +19,7 @@ export interface ApiResponseMetadata
 
 export interface ApiResponseSchemaHost
   extends Omit<ResponseObject, 'description'> {
-  schema: SchemaObject;
+  schema: SchemaObject & Partial<ReferenceObject>;
   status?: number;
   description?: string;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
OpenAPI's schema have optional parameter `$ref`, but `ApiResponse` decorator does not accept `schema.$ref`.


## What is the new behavior?
`ApiResponse` accepts `schema.$ref`. This change is valuable when we want to use a shema that is defined in external spec file. For Example, now we can write `@ApiResponse({schema: {$ref: '../path/to/yaml#components/schemas/SomeSchema}})`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information