### PR TITLE
feat(): enable defining global responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The following methods have been added:
 - `addBasicAuth`
 - `addSecurity`
 - `addSecurityRequirements`
+- `addResponse`
 
 ## Support
 

--- a/e2e/api-spec.json
+++ b/e2e/api-spec.json
@@ -39,6 +39,11 @@
         "name": "connect.sid"
       }
     },
+    "responses": {
+      "502": {
+        "description": "Bad gateway"
+      }
+    },
     "schemas": {
       "ExtraModel": {
         "type": "object",
@@ -274,6 +279,12 @@
           },
           "403": {
             "description": "Forbidden."
+          },
+          "500": {
+            "description": "Internal server error"
+          },
+          "502": {
+            "$ref": "#/components/responses/502"
           }
         },
         "tags": [
@@ -368,6 +379,12 @@
         "responses": {
           "200": {
             "description": ""
+          },
+          "500": {
+            "description": "Internal server error"
+          },
+          "502": {
+            "$ref": "#/components/responses/502"
           }
         },
         "tags": [
@@ -417,6 +434,12 @@
                 }
               }
             }
+          },
+          "500": {
+            "description": "Internal server error"
+          },
+          "502": {
+            "$ref": "#/components/responses/502"
           }
         },
         "tags": [
@@ -545,6 +568,12 @@
         "responses": {
           "200": {
             "description": ""
+          },
+          "500": {
+            "description": "Internal server error"
+          },
+          "502": {
+            "$ref": "#/components/responses/502"
           }
         },
         "tags": [
@@ -589,6 +618,12 @@
         "responses": {
           "201": {
             "description": ""
+          },
+          "500": {
+            "description": "Internal server error"
+          },
+          "502": {
+            "$ref": "#/components/responses/502"
           }
         },
         "tags": [
@@ -643,6 +678,12 @@
           },
           "403": {
             "description": "Forbidden."
+          },
+          "500": {
+            "description": "Internal server error"
+          },
+          "502": {
+            "$ref": "#/components/responses/502"
           }
         },
         "tags": [
@@ -676,6 +717,12 @@
         "responses": {
           "200": {
             "description": ""
+          },
+          "500": {
+            "description": "Internal server error"
+          },
+          "502": {
+            "$ref": "#/components/responses/502"
           }
         },
         "tags": [

--- a/e2e/src/cats/cats.controller.ts
+++ b/e2e/src/cats/cats.controller.ts
@@ -24,6 +24,7 @@ import { PaginationQuery } from './dto/pagination-query.dto';
   description: 'Test',
   schema: { default: 'test' }
 })
+@ApiResponse({ status: 500, description: 'Internal server error' })
 @Controller('cats')
 export class CatsController {
   constructor(private readonly catsService: CatsService) {}

--- a/e2e/validate-schema.e2e-spec.ts
+++ b/e2e/validate-schema.e2e-spec.ts
@@ -26,6 +26,10 @@ describe('Validate OpenAPI schema', () => {
       .addApiKey()
       .addCookieAuth()
       .addSecurityRequirements('bearer')
+      .addResponse({
+        status: 502,
+        description: 'Bad gateway'
+      })
       .build();
 
     document = SwaggerModule.createDocument(app, options);

--- a/lib/document-builder.ts
+++ b/lib/document-builder.ts
@@ -1,9 +1,11 @@
 import { Logger } from '@nestjs/common';
-import { isUndefined, negate, pickBy } from 'lodash';
+import { isUndefined, negate, omit, pickBy } from 'lodash';
 import { buildDocumentBase } from './fixtures/document.base';
 import { OpenAPIObject } from './interfaces';
+import { ApiResponseOptions } from './decorators/';
 import {
   ExternalDocumentationObject,
+  ResponseObject,
   SecuritySchemeObject,
   ServerVariableObject,
   TagObject
@@ -170,6 +172,15 @@ export class DocumentBuilder {
       name: cookieName,
       ...options
     });
+    return this;
+  }
+
+  public addResponse(options: ApiResponseOptions): this {
+    this.document.components.responses = {
+      ...(this.document.components.responses || {}),
+      [options.status]: omit(options, 'status') as ResponseObject
+    };
+
     return this;
   }
 

--- a/lib/explorers/api-response.explorer.ts
+++ b/lib/explorers/api-response.explorer.ts
@@ -1,20 +1,17 @@
 import { HttpStatus, RequestMethod, Type } from '@nestjs/common';
 import { HTTP_CODE_METADATA, METHOD_METADATA } from '@nestjs/common/constants';
-import { isEmpty } from '@nestjs/common/utils/shared.utils';
-import { get, mapValues, omit } from 'lodash';
+import { get } from 'lodash';
 import { DECORATORS } from '../constants';
 import { ApiResponseMetadata } from '../decorators';
 import { SchemaObject } from '../interfaces/open-api-spec.interface';
-import { ResponseObjectFactory } from '../services/response-object-factory';
+import { mapResponsesToSwaggerResponses } from '../utils/map-responses-to-swagger-responses.util';
 import { mergeAndUniq } from '../utils/merge-and-uniq.util';
-
-const responseObjectFactory = new ResponseObjectFactory();
 
 export const exploreGlobalApiResponseMetadata = (
   schemas: SchemaObject[],
   metatype: Type<unknown>
 ) => {
-  const responses: ApiResponseMetadata[] = Reflect.getMetadata(
+  const responses: Record<string, ApiResponseMetadata> = Reflect.getMetadata(
     DECORATORS.API_RESPONSE,
     metatype
   );
@@ -67,20 +64,4 @@ const getStatusCode = (method: Function) => {
     default:
       return HttpStatus.OK;
   }
-};
-
-const omitParamType = (param: Record<string, any>) => omit(param, 'type');
-const mapResponsesToSwaggerResponses = (
-  responses: ApiResponseMetadata[],
-  schemas: SchemaObject[],
-  produces: string[] = ['application/json']
-) => {
-  produces = isEmpty(produces) ? ['application/json'] : produces;
-
-  const openApiResponses = mapValues(
-    responses,
-    (response: ApiResponseMetadata) =>
-      responseObjectFactory.create(response, produces, schemas)
-  );
-  return mapValues(openApiResponses, omitParamType);
 };

--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -15,7 +15,7 @@ export class SwaggerModule {
     options: SwaggerDocumentOptions = {}
   ): OpenAPIObject {
     const swaggerScanner = new SwaggerScanner();
-    const document = swaggerScanner.scanApplication(app, options);
+    const document = swaggerScanner.scanApplication(app, options, config);
     document.components = {
       ...(config.components || {}),
       ...document.components

--- a/lib/swagger-scanner.ts
+++ b/lib/swagger-scanner.ts
@@ -3,10 +3,12 @@ import { MODULE_PATH } from '@nestjs/common/constants';
 import { NestContainer } from '@nestjs/core/injector/container';
 import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 import { Module } from '@nestjs/core/injector/module';
-import { extend, flatten, isEmpty, reduce } from 'lodash';
+import { extend, flatten, isEmpty, mapValues, reduce } from 'lodash';
+import { ApiResponseOptions } from './decorators/';
 import { OpenAPIObject, SwaggerDocumentOptions } from './interfaces';
 import {
   ReferenceObject,
+  ResponsesObject,
   SchemaObject
 } from './interfaces/open-api-spec.interface';
 import { ModelPropertiesAccessor } from './services/model-properties-accessor';
@@ -14,7 +16,9 @@ import { SchemaObjectFactory } from './services/schema-object-factory';
 import { SwaggerTypesMapper } from './services/swagger-types-mapper';
 import { SwaggerExplorer } from './swagger-explorer';
 import { SwaggerTransformer } from './swagger-transformer';
+import { mapResponsesToSwaggerResponses } from './utils/map-responses-to-swagger-responses.util';
 import { stripLastSlash } from './utils/strip-last-slash.util';
+import { transformResponsesToRefs } from './utils/transform-responses-to-refs.util';
 
 export class SwaggerScanner {
   private readonly transfomer = new SwaggerTransformer();
@@ -26,7 +30,8 @@ export class SwaggerScanner {
 
   public scanApplication(
     app: INestApplication,
-    options: SwaggerDocumentOptions
+    options: SwaggerDocumentOptions,
+    config: Omit<OpenAPIObject, 'paths'>
   ): Omit<OpenAPIObject, 'openapi' | 'info'> {
     const {
       deepScanRoutes,
@@ -35,6 +40,7 @@ export class SwaggerScanner {
       ignoreGlobalPrefix = false,
       operationIdFactory
     } = options;
+    const schemas = this.explorer.getSchemas();
 
     const container: NestContainer = (app as any).container;
     const modules: Module[] = this.getModules(
@@ -44,6 +50,10 @@ export class SwaggerScanner {
     const globalPrefix = !ignoreGlobalPrefix
       ? stripLastSlash(this.getGlobalPrefix(app))
       : '';
+    const globalResponses = mapResponsesToSwaggerResponses(
+      config.components.responses as Record<string, ApiResponseOptions>,
+      schemas
+    );
 
     const denormalizedPaths = modules.map(
       ({ routes, metatype, relatedModules }) => {
@@ -69,17 +79,18 @@ export class SwaggerScanner {
           allRoutes,
           path,
           globalPrefix,
+          transformResponsesToRefs(globalResponses),
           operationIdFactory
         );
       }
     );
 
-    const schemas = this.explorer.getSchemas();
     this.addExtraModels(schemas, extraModels);
 
     return {
       ...this.transfomer.normalizePaths(flatten(denormalizedPaths)),
       components: {
+        responses: globalResponses as ResponsesObject,
         schemas: reduce(this.explorer.getSchemas(), extend) as Record<
           string,
           SchemaObject | ReferenceObject
@@ -92,6 +103,7 @@ export class SwaggerScanner {
     routes: Map<string, InstanceWrapper>,
     modulePath?: string,
     globalPrefix?: string,
+    globalResponses?: ResponsesObject,
     operationIdFactory?: (controllerKey: string, methodKey: string) => string
   ): Array<Omit<OpenAPIObject, 'openapi' | 'info'> & Record<'root', any>> {
     const denormalizedArray = [...routes.values()].map((ctrl) =>
@@ -99,6 +111,7 @@ export class SwaggerScanner {
         ctrl,
         modulePath,
         globalPrefix,
+        globalResponses,
         operationIdFactory
       )
     );

--- a/lib/utils/map-responses-to-swagger-responses.util.ts
+++ b/lib/utils/map-responses-to-swagger-responses.util.ts
@@ -1,0 +1,23 @@
+import { mapValues, omit } from 'lodash';
+import { isEmpty } from '@nestjs/common/utils/shared.utils';
+import { ApiResponseMetadata } from '../decorators';
+import { SchemaObject } from '../interfaces/open-api-spec.interface';
+import { ResponseObjectFactory } from '../services/response-object-factory';
+
+const responseObjectFactory = new ResponseObjectFactory();
+const omitParamType = (param: Record<string, any>) => omit(param, 'type');
+
+export function mapResponsesToSwaggerResponses(
+  responses: Record<string, ApiResponseMetadata>,
+  schemas: SchemaObject[],
+  produces: string[] = ['application/json']
+) {
+  produces = isEmpty(produces) ? ['application/json'] : produces;
+
+  const openApiResponses = mapValues(
+    responses,
+    (response: ApiResponseMetadata) =>
+      responseObjectFactory.create(response, produces, schemas)
+  );
+  return mapValues(openApiResponses, omitParamType);
+}

--- a/lib/utils/transform-responses-to-refs.util.ts
+++ b/lib/utils/transform-responses-to-refs.util.ts
@@ -1,0 +1,11 @@
+import { mapValues } from 'lodash';
+import { ApiResponseOptions } from '../decorators';
+import { ReferenceObject } from '../interfaces/open-api-spec.interface';
+
+export function transformResponsesToRefs(
+  globalResponses: Record<string, ApiResponseOptions>
+): Record<string, ReferenceObject> {
+  return mapValues(globalResponses, (value, key) => ({
+    $ref: `#/components/responses/${key}`
+  }));
+}


### PR DESCRIPTION
Enables defining global responses which are inherited by all server routes.

fixes #884

## PR Checklist
Please check if your PR fulfils the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behaviour?

Issue Number: #884

## What is the new behaviour?

`DocumentBuilder.addResponse` has been added as a way to specify API responses globally. All server routes are then by default extending global responses.

```typescript
SwaggerModule.createDocument(
  app,
  new DocumentBuilder()
    .addResponse({
      status: 500,
      description: 'Internal server error'
    }) // Same type as @ApiResponse decorator: ApiResponseOptions
   ...
)
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information