### PR TITLE
fix(): nested schema additional properties take place next to allof

### DIFF
--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -360,7 +360,8 @@ export class SchemaObjectFactory {
       return {
         name: metadata.name || key,
         required: metadata.required,
-        allOf: [{ $ref }, { ...validMetadataObject }]
+        ...validMetadataObject,
+        allOf: [{ $ref }]
       } as SchemaObjectMetadata;
     }
     return {

--- a/test/services/fixtures/create-user.dto.ts
+++ b/test/services/fixtures/create-user.dto.ts
@@ -36,6 +36,7 @@ export class CreateUserDto {
 
   @ApiProperty({
     description: 'Profile',
+    nullable: true,
     type: () => CreateProfileDto
   })
   profile: CreateProfileDto;

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -132,12 +132,11 @@ describe('SchemaObjectFactory', () => {
             }
           },
           profile: {
+            description: 'Profile',
+            nullable: true,
             allOf: [
               {
                 $ref: '#/components/schemas/CreateProfileDto'
-              },
-              {
-                description: 'Profile'
               }
             ]
           },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

When using the `description` and `nullable` properties on a nested object, they are not properly added to the schema. So they are not visible in the Swagger UI and `nullable` is not interpreted by the typescript-axios lang of openapi-generator.

Extract of the generated Schema:

```
{
    "NestedObjectDto": {
        "type": "object",
        "properties": {
            "foo": {
                "allOf": [{
                    "$ref": "#/components/schemas/NestedPropertyDto"
                }, {
                    "description": "Foo",
                    "nullable": true
                }]
            }
        },
        "required": ["foo"]
    }
}
```

## What is the new behavior?

Regarding 

https://github.com/OAI/OpenAPI-Specification/issues/556#issuecomment-192007034
https://github.com/OAI/OpenAPI-Specification/issues/1368#issuecomment-688454562

The generated schema should look like this:

```
{
    "NestedObjectDto": {
        "type": "object",
        "properties": {
            "foo": {
                "description": "Foo",
                "nullable": true,
                "allOf": [{
                    "$ref": "#/components/schemas/NestedPropertyDto"
                }]
            }
        },
        "required": ["foo"]
    }
}
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information

The swagger-ui-dist dependency of swagger-ui-express is not up to date and displays the value of description but not that of nullable. Using the latest release on https://editor.swagger.io/ the corrected schema correctly displays the values of description and nullable.