### PR TITLE
feat: Add ApiResponse wrapper for 302 FOUND

### DIFF
--- a/lib/decorators/api-response.decorator.ts
+++ b/lib/decorators/api-response.decorator.ts
@@ -101,6 +101,12 @@ export const ApiMovedPermanentlyResponse = (options: ApiResponseOptions = {}) =>
     status: HttpStatus.MOVED_PERMANENTLY
   });
 
+export const ApiFoundResponse = (options: ApiResponseOptions = {}) =>
+  ApiResponse({
+    ...options,
+    status: HttpStatus.FOUND
+  });
+
 export const ApiBadRequestResponse = (options: ApiResponseOptions = {}) =>
   ApiResponse({
     ...options,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Commit 759241607 states that it adds a wrapper for 302 MOVED PERMANENTLY. It does add [MOVED PERMANENTLY](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/301), but that is a [301 response](https://github.com/nestjs/nest/blob/v7.4.4/packages/common/enums/http-status.enum.ts#L13).

To produce API documentation that reports that an endpoint could return a 302 FOUND, one must use `ApiResponse()`:

```js
@ApiResponse({
  status: HttpStatus.FOUND,
  description: 'Success will redirect to a resource.'
})
```

## What is the new behavior?

This adds to the `ApiResponse` wrappers a decorator for the [302 FOUND](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/302) response, commonly used for resource redirects.

```js
@ApiFoundResponse({ description: 'Success will redirect to a resource.' })
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information