### PR TITLE
fix: IntersectionType doesn't inherit default values #875

### DIFF
--- a/lib/type-helpers/intersection-type.helper.ts
+++ b/lib/type-helpers/intersection-type.helper.ts
@@ -1,13 +1,13 @@
 import { Type } from '@nestjs/common';
 import {
   inheritTransformationMetadata,
-  inheritValidationMetadata
+  inheritValidationMetadata,
+  inheritPropertyInitializers
 } from '@nestjs/mapped-types';
 import { DECORATORS } from '../constants';
 import { ApiProperty } from '../decorators';
 import { ModelPropertiesAccessor } from '../services/model-properties-accessor';
 import { clonePluginMetadataFactory } from './mapped-types.utils';
-import { inheritPropertyInitializers } from '@nestjs/mapped-types/dist/type-helpers.utils';
 
 const modelPropertiesAccessor = new ModelPropertiesAccessor();
 

--- a/lib/type-helpers/intersection-type.helper.ts
+++ b/lib/type-helpers/intersection-type.helper.ts
@@ -7,6 +7,7 @@ import { DECORATORS } from '../constants';
 import { ApiProperty } from '../decorators';
 import { ModelPropertiesAccessor } from '../services/model-properties-accessor';
 import { clonePluginMetadataFactory } from './mapped-types.utils';
+import { inheritPropertyInitializers } from '@nestjs/mapped-types/dist/type-helpers.utils';
 
 const modelPropertiesAccessor = new ModelPropertiesAccessor();
 
@@ -21,7 +22,12 @@ export function IntersectionType<A, B>(
     classBRef.prototype
   );
 
-  abstract class IntersectionTypeClass {}
+  abstract class IntersectionTypeClass {
+    constructor() {
+      inheritPropertyInitializers(this, classARef);
+      inheritPropertyInitializers(this, classBRef);
+    }
+  }
   inheritValidationMetadata(classARef, IntersectionTypeClass);
   inheritTransformationMetadata(classARef, IntersectionTypeClass);
   inheritValidationMetadata(classBRef, IntersectionTypeClass);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1841,8 +1841,8 @@
       }
     },
     "@nestjs/mapped-types": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-0.1.0.tgz",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-0.1.1.tgz",
       "integrity": "sha512-FfQsZK5K1OvvGqjPHCJtrNTLlKLg7bLuphtCRTFb5K2P98JTfslauMbT7bS8huOoK/86HMNmNoHR/EVLAd4FzA=="
     },
     "@nestjs/platform-express": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "release": "release-it"
   },
   "dependencies": {
-    "@nestjs/mapped-types": "0.1.0",
+    "@nestjs/mapped-types": "0.1.1",
     "lodash": "4.17.20",
     "path-to-regexp": "3.2.0"
   },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
Default property value are not inherit. 
[https://github.com/nestjs/mapped-types/issues/199](https://github.com/nestjs/mapped-types/issues/199)
[https://github.com/nestjs/swagger/issues/875](https://github.com/nestjs/swagger/issues/875)



Issue Number: #875


## What is the new behavior?
Default property value are passed. To work with Swagger OpenAPI is neccessary to put it in @ApiProperty() decoratora as default value. 
```ts
  @ApiProperty({ default: "queryPhrase 2" })
  queryPhrase: string = "queryPhrase 2";

```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information