### PR TITLE
fix(lib): fix query param enum schema

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       - checkout
       - run:
           name: Update NPM version
-          command: npm install -g npm@latest
+          command: npm install -g npm@8
       - restore_cache:
           key: dependency-cache-{{ checksum "package.json" }}
       - run:

--- a/e2e/api-spec.json
+++ b/e2e/api-spec.json
@@ -249,6 +249,17 @@
             }
           },
           {
+            "name": "letters",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Letter"
+              }
+            }
+          },
+          {
             "name": "beforeDate",
             "required": true,
             "in": "query",
@@ -409,6 +420,17 @@
               "type": "array",
               "items": {
                 "$ref": "#/components/schemas/LettersEnum"
+              }
+            }
+          },
+          {
+            "name": "letters",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Letter"
               }
             }
           },
@@ -964,6 +986,14 @@
           "_options",
           "enum",
           "enumArr"
+        ]
+      },
+      "Letter": {
+        "type": "string",
+        "enum": [
+          "A",
+          "B",
+          "C"
         ]
       }
     }

--- a/e2e/src/cats/dto/pagination-query.dto.ts
+++ b/e2e/src/cats/dto/pagination-query.dto.ts
@@ -38,7 +38,14 @@ export class PaginationQuery {
     enumName: 'LettersEnum',
     isArray: true
   })
-  enumArr: LettersEnum;
+  enumArr: LettersEnum[];
+
+  @ApiProperty({
+    enum: LettersEnum,
+    enumName: 'Letter',
+    isArray: true,
+  })
+  letters: LettersEnum[];
 
   @ApiProperty()
   beforeDate: Date;

--- a/lib/services/parameter-metadata-accessor.ts
+++ b/lib/services/parameter-metadata-accessor.ts
@@ -5,7 +5,7 @@ import {
 } from '@nestjs/common/constants';
 import { RouteParamtypes } from '@nestjs/common/enums/route-paramtypes.enum';
 import { isEmpty, mapValues, omitBy } from 'lodash';
-import { ParameterLocation } from '../interfaces/open-api-spec.interface';
+import { ParameterLocation, SchemaObject } from '../interfaces/open-api-spec.interface';
 import { reverseObjectKeys } from '../utils/reverse-object-keys.util';
 
 interface ParamMetadata {
@@ -19,6 +19,7 @@ export interface ParamWithTypeMetadata {
   type?: Type<unknown>;
   in?: ParameterLocation | 'body' | typeof PARAM_TOKEN_PLACEHOLDER;
   isArray?: boolean;
+  items?: SchemaObject;
   required: true;
   enum?: unknown[];
   enumName?: string;

--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -247,11 +247,9 @@ export class SchemaObjectFactory {
     const $ref = getSchemaPath(enumName);
 
     if (!(enumName in schemas)) {
-      const _enum = param.enum
-        ? param.enum
-        : param.schema['items']
-        ? param.schema['items']['enum']
-        : param.schema['enum'];
+      const _enum = param.isArray || param.items
+        ? param.items?.enum
+        : param.enum
 
       schemas[enumName] = {
         type: 'string',


### PR DESCRIPTION
fix #1096 fix retrieve enum values from query param metadata while creating new enum schema if enumName is used with isArray

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1096

### Reproduction
a full reproduction repo is available by the issue creator https://github.com/murbanowicz/nest-swagger-1096
```ts
//enum
export enum FooEnum {
  BAR = 'BAR',
  FOO = 'FOO',
}
//DTO class
class BuggyQueryDTO {
  @ApiProperty({
    isArray: true,
    enum: FooEnum,
    enumName: 'buggy',
  })
  public readonly foos!: FooEnum[];
}
// controller
  @Get()
  getHello(@Query() query: BuggyQueryDTO): string {
    return this.appService.getHello();
  }
```
The above code will throw error on `SwaggerModule.createDocument(app, options);`:
```bash
TypeError: Cannot read property 'items'
 of undefined
    at SchemaObjectFactory.createEnumParam (/home/marek/dev/oss/bugs/enum-array-query/
node_modules/@nestjs/swagger/dist/services/schema-object-factory.js:168:31)
    at SchemaObjectFactory.createQueryOrParamSchema (/home/marek/dev/oss/bugs/enum-arr
ay-query/node_modules/@nestjs/swagger/dist/services/schema-object-factory.js:51:25)
    at /home/marek/dev/oss/bugs/enum-array-query/node_modules/@nestjs/swagger/dist/ser
vices/schema-object-factory.js:31:29
    at Array.map (<anonymous>)
    at SchemaObjectFactory.createFromModel (/home/marek/dev/oss/bugs/enum-array-query/
node_modules/@nestjs/swagger/dist/services/schema-object-factory.js:20:45)
    at exports.exploreApiParametersMetadata (/home/marek/dev/oss/bugs/enum-array-query
/node_modules/@nestjs/swagger/dist/explorers/api-parameters.explorer.js:33:55)
    at /home/marek/dev/oss/bugs/enum-array-query/node_modules/@nestjs/swagger/dist/swa
gger-explorer.js:73:45
    at Array.reduce (<anonymous>)
    at /home/marek/dev/oss/bugs/enum-array-query/node_modules/@nestjs/swagger/dist/swa
gger-explorer.js:72:99
    at /home/marek/dev/oss/bugs/enum-array-query/node_modules/lodash/lodash.js:13427:3
8
```
## What is the new behavior?
After some study on the src code, this PR might fix the issue, or hopefully give some insights for maintainers to fix the bug.

From my understanding, while @ApiProperty`enumName` is used in query DTO, we try to create a enum schema for usage of parameter `$ref`. Through the createApiPropertyDecorator,
https://github.com/nestjs/swagger/blob/35b09075230b65b3c0e582e6caa37737a60797f4/lib/decorators/api-property.decorator.ts#L33
the enum type and values should be available in either `param.type`, `param.enum` or `param.items.type` and `param.items.enum` (if param value type isArray).

### Produced output:
```json
  "components": {
    "schemas": {
      "buggy": {
        "type": "string",
        "enum": [
          "BAR",
          "FOO"
        ]
      }
    }
  },
  "paths": {
    "/": {
      "get": {
        "operationId": "AppController_getHello",
        "parameters": [
          {
            "name": "foos",
            "required": true,
            "in": "query",
            "schema": {
              "type": "array",
              "items": {
                "$ref": "#/components/schemas/buggy"
              }
            }
          }
        ],
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Also notice the related test case
https://github.com/nestjs/swagger/commit/e417a7af739a732a8a4d6719d25bcc0f02555be0
does not cover this issue.
