### PR TITLE
fix(api-extension): support for additional api extension values

### DIFF
--- a/lib/decorators/api-extension.decorator.ts
+++ b/lib/decorators/api-extension.decorator.ts
@@ -9,10 +9,7 @@ export function ApiExtension(extensionKey: string, extensionProperties: any) {
   }
 
   const extensionObject = {
-    [extensionKey]:
-      typeof extensionProperties !== 'string'
-        ? { ...extensionProperties }
-        : extensionProperties
+    [extensionKey]: extensionProperties
   };
 
   return createMixedDecorator(DECORATORS.API_EXTENSION, extensionObject);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: #1130 

## What is the new behavior?

The `ApiExtension` decorator now accepts any value to be assigned.  As referenced [here](https://swagger.io/docs/specification/openapi-extensions/), "The extension value can be a primitive, an array, an object or null.".

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information

I did a quick poke around and didn't see anywhere that a test case for this may be added and checked.  However, if there is somewhere that I should be testing this behaviour, please let me know 🙂