### PR TITLE
fix: set default status for api-response decorator

### DIFF
--- a/lib/decorators/api-response.decorator.ts
+++ b/lib/decorators/api-response.decorator.ts
@@ -38,7 +38,9 @@ export function ApiResponse(
   (options as ApiResponseMetadata).isArray = isArray;
   options.description = options.description ? options.description : '';
 
-  const groupedMetadata = { [options.status]: omit(options, 'status') };
+  const groupedMetadata = {
+    [options.status || 'default']: omit(options, 'status')
+  };
   return (
     target: object,
     key?: string | symbol,


### PR DESCRIPTION
set default value for the status code in ApiResponse
decorator if status code  not pass.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1017


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information