### PR TITLE
refactor(setup): change swaggerOptions type

### DIFF
--- a/lib/interfaces/swagger-custom-options.interface.ts
+++ b/lib/interfaces/swagger-custom-options.interface.ts
@@ -1,6 +1,6 @@
 export interface SwaggerCustomOptions {
   explorer?: boolean;
-  swaggerOptions?: any;
+  swaggerOptions?: Record<string, any>;
   customCss?: string;
   customCssUrl?: string;
   customJs?: string;


### PR DESCRIPTION
We had a discussion here about this change: https://github.com/nestjs/docs.nestjs.com/pull/1645#discussion_r565926754

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
`swaggerOptions` accepts any type of parameters like boolean or string.

Issue Number: N/A


## What is the new behavior?
`swaggerOptions` should accept only object type.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
We had a discussion [here ]( https://github.com/nestjs/docs.nestjs.com/pull/1645#discussion_r565926754)about this change.