### PR TITLE
perf: store schemas in an object instead of an array of key/value

### DIFF
--- a/lib/explorers/api-parameters.explorer.ts
+++ b/lib/explorers/api-parameters.explorer.ts
@@ -23,8 +23,7 @@ const schemaObjectFactory = new SchemaObjectFactory(
 );
 
 export const exploreApiParametersMetadata = (
-  schemas: SchemaObject[],
-  schemaRefsStack: [],
+  schemas: Record<string, SchemaObject>,
   instance: object,
   prototype: Type<unknown>,
   method: Function
@@ -63,8 +62,7 @@ export const exploreApiParametersMetadata = (
 
   const paramsWithDefinitions = schemaObjectFactory.createFromModel(
     properties,
-    schemas,
-    schemaRefsStack
+    schemas
   );
   const parameters = swaggerTypesMapper.mapParamTypes(paramsWithDefinitions);
   return parameters ? { parameters } : undefined;

--- a/lib/explorers/api-response.explorer.ts
+++ b/lib/explorers/api-response.explorer.ts
@@ -11,7 +11,7 @@ import { mergeAndUniq } from '../utils/merge-and-uniq.util';
 const responseObjectFactory = new ResponseObjectFactory();
 
 export const exploreGlobalApiResponseMetadata = (
-  schemas: SchemaObject[],
+  schemas: Record<string, SchemaObject>,
   metatype: Type<unknown>
 ) => {
   const responses: ApiResponseMetadata[] = Reflect.getMetadata(
@@ -27,7 +27,7 @@ export const exploreGlobalApiResponseMetadata = (
 };
 
 export const exploreApiResponseMetadata = (
-  schemas: SchemaObject[],
+  schemas: Record<string, SchemaObject>,
   instance: object,
   prototype: Type<unknown>,
   method: Function
@@ -72,7 +72,7 @@ const getStatusCode = (method: Function) => {
 const omitParamType = (param: Record<string, any>) => omit(param, 'type');
 const mapResponsesToSwaggerResponses = (
   responses: ApiResponseMetadata[],
-  schemas: SchemaObject[],
+  schemas: Record<string, SchemaObject>,
   produces: string[] = ['application/json']
 ) => {
   produces = isEmpty(produces) ? ['application/json'] : produces;

--- a/lib/services/response-object-factory.ts
+++ b/lib/services/response-object-factory.ts
@@ -21,7 +21,7 @@ export class ResponseObjectFactory {
   create(
     response: ApiResponseMetadata,
     produces: string[],
-    schemas: SchemaObject[]
+    schemas: Record<string, SchemaObject>
   ) {
     const { type, isArray } = response as ApiResponseMetadata;
     response = omit(response, ['isArray']);

--- a/lib/swagger-explorer.ts
+++ b/lib/swagger-explorer.ts
@@ -54,8 +54,7 @@ import { mergeAndUniq } from './utils/merge-and-uniq.util';
 export class SwaggerExplorer {
   private readonly mimetypeContentWrapper = new MimetypeContentWrapper();
   private readonly metadataScanner = new MetadataScanner();
-  private readonly schemas: SchemaObject[] = [];
-  private readonly schemaRefsStack: string[] = [];
+  private readonly schemas: Record<string, SchemaObject> = {};
   private operationIdFactory = (controllerKey: string, methodKey: string) =>
     controllerKey ? `${controllerKey}_${methodKey}` : methodKey;
 
@@ -76,11 +75,7 @@ export class SwaggerExplorer {
       root: [
         this.exploreRoutePathAndMethod,
         exploreApiOperationMetadata,
-        exploreApiParametersMetadata.bind(
-          null,
-          this.schemas,
-          this.schemaRefsStack
-        )
+        exploreApiParametersMetadata.bind(null, this.schemas)
       ],
       security: [exploreApiSecurityMetadata],
       tags: [exploreApiTagsMetadata],
@@ -96,7 +91,7 @@ export class SwaggerExplorer {
     );
   }
 
-  public getSchemas(): SchemaObject[] {
+  public getSchemas(): Record<string, SchemaObject> {
     return this.schemas;
   }
 

--- a/lib/swagger-scanner.ts
+++ b/lib/swagger-scanner.ts
@@ -3,7 +3,7 @@ import { MODULE_PATH } from '@nestjs/common/constants';
 import { NestContainer } from '@nestjs/core/injector/container';
 import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 import { Module } from '@nestjs/core/injector/module';
-import { extend, flatten, isEmpty, reduce } from 'lodash';
+import { flatten, isEmpty } from 'lodash';
 import { OpenAPIObject, SwaggerDocumentOptions } from './interfaces';
 import {
   ReferenceObject,
@@ -80,10 +80,7 @@ export class SwaggerScanner {
     return {
       ...this.transfomer.normalizePaths(flatten(denormalizedPaths)),
       components: {
-        schemas: reduce(this.explorer.getSchemas(), extend) as Record<
-          string,
-          SchemaObject | ReferenceObject
-        >
+        schemas: schemas as Record<string, SchemaObject | ReferenceObject>
       }
     };
   }
@@ -117,7 +114,10 @@ export class SwaggerScanner {
     );
   }
 
-  public addExtraModels(schemas: SchemaObject[], extraModels: Function[]) {
+  public addExtraModels(
+    schemas: Record<string, SchemaObject>,
+    extraModels: Function[]
+  ) {
     extraModels.forEach((item) => {
       this.schemaObjectFactory.exploreModelSchema(item, schemas);
     });

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '../../lib/decorators';
+import { SchemasObject } from '../../lib/interfaces/open-api-spec.interface';
 import { ModelPropertiesAccessor } from '../../lib/services/model-properties-accessor';
 import { SchemaObjectFactory } from '../../lib/services/schema-object-factory';
 import { SwaggerTypesMapper } from '../../lib/services/swagger-types-mapper';
@@ -39,18 +40,18 @@ describe('SchemaObjectFactory', () => {
     }
 
     it('should explore enum', () => {
-      const schemas = [];
+      const schemas: Record<string, SchemasObject> = {};
       schemaObjectFactory.exploreModelSchema(Person, schemas);
 
-      expect(schemas).toHaveLength(2);
+      expect(Object.keys(schemas)).toHaveLength(2);
 
-      expect(schemas[0]['Role']).toBeDefined();
-      expect(schemas[0]['Role']).toEqual({
+      expect(schemas).toHaveProperty('Role');
+      expect(schemas.Role).toEqual({
         type: 'string',
         enum: ['admin', 'user']
       });
-      expect(schemas[1]['Person']).toBeDefined();
-      expect(schemas[1]['Person']).toEqual({
+      expect(schemas).toHaveProperty('Person');
+      expect(schemas.Person).toEqual({
         type: 'object',
         properties: {
           role: {
@@ -66,14 +67,11 @@ describe('SchemaObjectFactory', () => {
         required: ['role', 'roles']
       });
 
-      schemaObjectFactory.exploreModelSchema(CreatePersonDto, schemas, [
-        'Person',
-        'Role'
-      ]);
+      schemaObjectFactory.exploreModelSchema(CreatePersonDto, schemas);
 
-      expect(schemas).toHaveLength(3);
-      expect(schemas[2]['CreatePersonDto']).toBeDefined();
-      expect(schemas[2]['CreatePersonDto']).toEqual({
+      expect(Object.keys(schemas)).toHaveLength(3);
+      expect(schemas).toHaveProperty('CreatePersonDto');
+      expect(schemas.CreatePersonDto).toEqual({
         type: 'object',
         properties: {
           name: {
@@ -88,13 +86,13 @@ describe('SchemaObjectFactory', () => {
     });
 
     it('should create openapi schema', () => {
-      const schemas = [];
+      const schemas: Record<string, SchemasObject> = {};
       const schemaKey = schemaObjectFactory.exploreModelSchema(
         CreateUserDto,
         schemas
       );
 
-      expect(schemas[1][schemaKey]).toEqual({
+      expect(schemas[schemaKey]).toEqual({
         type: 'object',
         properties: {
           login: {
@@ -190,7 +188,7 @@ describe('SchemaObjectFactory', () => {
           'createdAt'
         ]
       });
-      expect(schemas[2]['CreateProfileDto']).toEqual({
+      expect(schemas['CreateProfileDto']).toEqual({
         type: 'object',
         properties: {
           firstname: {
@@ -218,18 +216,18 @@ describe('SchemaObjectFactory', () => {
         name: string;
       }
 
-      const schemas = [];
+      const schemas: Record<string, SchemasObject> = {};
 
       schemaObjectFactory.exploreModelSchema(CreatUserDto, schemas);
       schemaObjectFactory.exploreModelSchema(UpdateUserDto, schemas);
 
-      expect(schemas[0][CreatUserDto.name]).toEqual({
+      expect(schemas[CreatUserDto.name]).toEqual({
         type: 'object',
         properties: { name: { type: 'string', minLength: 0 } },
         required: ['name']
       });
 
-      expect(schemas[1][UpdateUserDto.name]).toEqual({
+      expect(schemas[UpdateUserDto.name]).toEqual({
         type: 'object',
         properties: { name: { type: 'string', minLength: 1 } }
       });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[x] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[x] Other... Please describe: perf improvement
```

## What is the current behavior?

Currently the schemas are passed around with two variables:
- `schemas` of type `Array<{[key: string]: SchemaObject>`
- `schemasRefPaths` which lists the keys

There are a few issues:
- `schemas` is wrongly typed as `SchemaObject[]` in the code
- Two related arguments need to be passed to many function accepting schemas
- To check if an item is already in `schemas`, `schemasRefPaths.includes(key)` is used which is O(schemas.length)

## What is the new behavior?

This PR merges `schemaRefsPaths` and `schemas` into only one variable, `schemas`, and allows for fast lookup in O(1). 

A variable `pendingSchemaRefs` is added only where needed -- where the use of `schemasRefPaths` was preventing infinite recursion. It's passed by copy when modified, to stay as small as possible, and only contains the refs to schemas _in the process of_ being added to `schemas`.

The typing of `schemas` is also now accurate.
## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
