### PR TITLE
fix: non-primitive parameter types are converted to query parameters

### DIFF
--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -110,6 +110,15 @@ export class SchemaObjectFactory {
         type: 'string'
       };
     }
+
+    // Path parameters are always of type string.
+    if (param.in === 'path') {
+      return {
+        ...param,
+        type: 'string'
+      };
+    }
+
     if (isFunction(param.type)) {
       const propertiesWithType = this.extractPropertiesFromType(
         param.type,

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -1,5 +1,6 @@
 import { ApiProperty } from '../../lib/decorators';
 import { ModelPropertiesAccessor } from '../../lib/services/model-properties-accessor';
+import { ParamWithTypeMetadata } from '../../lib/services/parameter-metadata-accessor';
 import { SchemaObjectFactory } from '../../lib/services/schema-object-factory';
 import { SwaggerTypesMapper } from '../../lib/services/swagger-types-mapper';
 import { CreateUserDto } from './fixtures/create-user.dto';
@@ -234,5 +235,27 @@ describe('SchemaObjectFactory', () => {
         properties: { name: { type: 'string', minLength: 1 } }
       });
     });
+  });
+
+  describe("createFromModel", () => {
+    it("should return path parameters with a non-primitive type as parameter with string type", () => {
+      class Test {}
+
+      const testParameter: ParamWithTypeMetadata = {
+        name: "test",
+        type: Test,
+        in: "path",
+        required: true
+      }
+
+      const result = schemaObjectFactory.createFromModel([testParameter], [], []);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toStrictEqual({
+        name: "test",
+        type: "string",
+        in: "path",
+        required: true
+      });
+    })
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1197 


## What is the new behavior?

non-primitive path parameters are exported as type string.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information