### PR TITLE
feat(introspectComments): Enhanced introduction comments using tsdocs

### DIFF
--- a/lib/plugin/utils/ast-utils.ts
+++ b/lib/plugin/utils/ast-utils.ts
@@ -18,6 +18,7 @@ import {
   TypeFormatFlags
 } from 'typescript';
 import { isDynamicallyAdded } from './plugin-utils';
+import { DocComment, DocExcerpt, DocNode, ParserContext, TSDocParser } from '@microsoft/tsdoc';
 
 export function isArray(type: Type) {
   const symbol = type.getSymbol();
@@ -100,6 +101,30 @@ export function getDefaultTypeFormatFlags(enclosingNode: Node) {
   if (enclosingNode && enclosingNode.kind === SyntaxKind.TypeAliasDeclaration)
     formatFlags |= TypeFormatFlags.InTypeAlias;
   return formatFlags;
+}
+
+export function getNodeDocs(
+  node: Node
+): DocComment {
+  const tsdocParser: TSDocParser = new TSDocParser();
+  const parserContext: ParserContext = tsdocParser.parseString(node.getFullText());
+  return parserContext.docComment;
+}
+
+export function docNodeToString(docNode: DocNode): string {
+  let result = '';
+
+  if (docNode) {
+    if (docNode instanceof DocExcerpt) {
+      result += docNode.content.toString();
+    }
+
+    for(const childNode of docNode.getChildNodes()) {
+      result += docNodeToString(childNode);
+    }
+  }
+
+  return result.trim();
 }
 
 export function getMainCommentAndExamplesOfNode(

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "4.7.12",
       "license": "MIT",
       "dependencies": {
+        "@microsoft/tsdoc": "^0.13.0",
         "@nestjs/mapped-types": "0.3.0",
         "lodash": "4.17.20",
         "path-to-regexp": "3.2.0"
@@ -1825,6 +1826,7 @@
         "jest-resolve": "^26.6.2",
         "jest-util": "^26.6.2",
         "jest-worker": "^26.6.2",
+        "node-notifier": "^8.0.0",
         "slash": "^3.0.0",
         "source-map": "^0.6.0",
         "string-length": "^4.0.1",
@@ -2316,6 +2318,11 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "dev": true
+    },
+    "node_modules/@microsoft/tsdoc": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.13.0.tgz",
+      "integrity": "sha512-/8J+4DdvexBH1Qh1yR8VZ6bPay2DL/TDdmSIypAa3dAghJzsdaiZG8COvzpYIML6HV2UVN0g4qbuqzjG4YKgWg=="
     },
     "node_modules/@nestjs/common": {
       "version": "7.6.12",
@@ -5400,7 +5407,8 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1"
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -9332,6 +9340,7 @@
         "@types/node": "*",
         "anymatch": "^3.0.3",
         "fb-watchman": "^2.0.0",
+        "fsevents": "^2.1.2",
         "graceful-fs": "^4.2.4",
         "jest-regex-util": "^26.0.0",
         "jest-serializer": "^26.6.2",
@@ -11552,6 +11561,7 @@
       "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
       "dev": true,
       "dependencies": {
+        "graceful-fs": "^4.1.6",
         "universalify": "^1.0.0"
       },
       "optionalDependencies": {
@@ -17325,6 +17335,7 @@
       "integrity": "sha512-zkvK/9TC6p38IwcrbnT3ul9in1UX4cm1y/VZSs4GHKIiDCrlafc+YQBgQBUdDXLAoZHf2qvQ7gJJOo6yT1LH6A==",
       "dev": true,
       "dependencies": {
+        "commander": "^2.7.1",
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
         "validator": "^12.0.0"
@@ -19135,6 +19146,11 @@
       "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
       "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
       "dev": true
+    },
+    "@microsoft/tsdoc": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/tsdoc/-/tsdoc-0.13.0.tgz",
+      "integrity": "sha512-/8J+4DdvexBH1Qh1yR8VZ6bPay2DL/TDdmSIypAa3dAghJzsdaiZG8COvzpYIML6HV2UVN0g4qbuqzjG4YKgWg=="
     },
     "@nestjs/common": {
       "version": "7.6.12",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "release": "release-it"
   },
   "dependencies": {
+    "@microsoft/tsdoc": "^0.13.0",
     "@nestjs/mapped-types": "0.3.0",
     "lodash": "4.17.20",
     "path-to-regexp": "3.2.0"

--- a/test/plugin/controller-class-visitor.spec.ts
+++ b/test/plugin/controller-class-visitor.spec.ts
@@ -4,6 +4,10 @@ import {
   appControllerText,
   appControllerTextTranspiled
 } from './fixtures/app.controller';
+import {
+  enhancedCommentsControllerText,
+  enhancedCommentsControllerTextTranspiled
+} from './fixtures/enhanced-comments.controller';
 
 const compilerOptions: ts.CompilerOptions = {
   module: ts.ModuleKind.CommonJS,
@@ -40,4 +44,14 @@ describe('Controller methods', () => {
 
     expect(result.outputText).toEqual(appControllerTextTranspiled);
   });
+
+  it('Should generate summary and description if no controllerKeyOfComments', () => {
+    const result = transpileModule(
+      'enhanced-comments.controller.ts',
+      enhancedCommentsControllerText,
+      compilerOptions,
+      { controllerKeyOfComment: null }
+    );
+    expect(result.outputText).toEqual(enhancedCommentsControllerTextTranspiled);
+  })
 });

--- a/test/plugin/controller-class-visitor.spec.ts
+++ b/test/plugin/controller-class-visitor.spec.ts
@@ -5,29 +5,39 @@ import {
   appControllerTextTranspiled
 } from './fixtures/app.controller';
 
-describe('Controller methods', () => {
-  it('should add response based on the return value', () => {
-    const options: ts.CompilerOptions = {
-      module: ts.ModuleKind.CommonJS,
-      target: ts.ScriptTarget.ESNext,
-      newLine: ts.NewLineKind.LineFeed,
-      noEmitHelpers: true
-    };
-    const filename = 'app.controller.ts';
-    const fakeProgram = ts.createProgram([filename], options);
+const compilerOptions: ts.CompilerOptions = {
+  module: ts.ModuleKind.CommonJS,
+  target: ts.ScriptTarget.ESNext,
+  newLine: ts.NewLineKind.LineFeed,
+  noEmitHelpers: true
+}
 
-    const result = ts.transpileModule(appControllerText, {
-      compilerOptions: options,
-      fileName: filename,
-      transformers: {
-        before: [
-          before(
-            { controllerKeyOfComment: 'summary', introspectComments: true },
-            fakeProgram
-          )
-        ]
-      }
-    });
+const transpileModule = (filename, controllerText, compilerOptions, swaggerDocumentOptions = {}) => {
+  const fakeProgram = ts.createProgram([filename], compilerOptions);
+
+  return ts.transpileModule(controllerText, {
+    compilerOptions,
+    fileName: filename,
+    transformers: {
+      before: [
+        before(
+          {...swaggerDocumentOptions, introspectComments: true },
+          fakeProgram
+        )
+      ]
+    }
+  })
+}
+
+describe('Controller methods', () => {
+  it('Should generate summary property', () => {
+    const result = transpileModule(
+      'app.controller.ts',
+      appControllerText,
+      compilerOptions,
+      {controllerKeyOfComment: 'summary'}
+    );
+
     expect(result.outputText).toEqual(appControllerTextTranspiled);
   });
 });

--- a/test/plugin/fixtures/enhanced-comments.controller.ts
+++ b/test/plugin/fixtures/enhanced-comments.controller.ts
@@ -1,0 +1,109 @@
+export const enhancedCommentsControllerText = `import { Controller, Post, HttpStatus } from '@nestjs/common';
+import { ApiOperation } from '@nestjs/swagger';
+
+class Cat {}
+
+@Controller('cats')
+export class EnhancedCommentsController {
+  onApplicationBootstrap() {}
+
+  /**
+   * create a Cat
+   *
+   * @remarks
+   * Create a super nice cat
+   *
+   * @returns {Promise<Cat>}
+   * @memberof AppController
+   */
+  @Post()
+  async create(): Promise<Cat> {}
+
+  /**
+   * find a Cat
+   *
+   * @remarks
+   * Find the best cat in the world
+   */
+  @ApiOperation({})
+  @Get()
+  async findOne(): Promise<Cat> {}
+
+  /**
+   * find all Cats im comment
+   *
+   * @remarks
+   * Find all cats while you write comments
+   *
+   * @returns {Promise<Cat>}
+   * @memberof AppController
+   */
+  @ApiOperation({
+    summary: 'find all Cats',
+    description: 'Find all cats while you write decorators'
+  })
+  @Get()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async findAll(): Promise<Cat[]> {}
+}`;
+
+export const enhancedCommentsControllerTextTranspiled = `"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.EnhancedCommentsController = void 0;
+const openapi = require("@nestjs/swagger");
+const common_1 = require("@nestjs/common");
+const swagger_1 = require("@nestjs/swagger");
+class Cat {
+}
+let EnhancedCommentsController = class EnhancedCommentsController {
+    onApplicationBootstrap() { }
+    /**
+     * create a Cat
+     *
+     * @remarks
+     * Create a super nice cat
+     *
+     * @returns {Promise<Cat>}
+     * @memberof AppController
+     */
+    async create() { }
+    /**
+     * find a Cat
+     *
+     * @remarks
+     * Find the best cat in the world
+     */
+    async findOne() { }
+    /**
+     * find all Cats im comment
+     *
+     * @remarks
+     * Find all cats while you write comments
+     *
+     * @returns {Promise<Cat>}
+     * @memberof AppController
+     */
+    async findAll() { }
+};
+__decorate([
+    openapi.ApiOperation({ summary: "create a Cat", description: "Create a super nice cat" }),
+    common_1.Post(),
+    openapi.ApiResponse({ status: 201, type: Cat })
+], EnhancedCommentsController.prototype, "create", null);
+__decorate([
+    swagger_1.ApiOperation({ summary: "find a Cat", description: "Find the best cat in the world" }),
+    Get(),
+    openapi.ApiResponse({ status: 200, type: Cat })
+], EnhancedCommentsController.prototype, "findOne", null);
+__decorate([
+    swagger_1.ApiOperation({ summary: 'find all Cats',
+        description: 'Find all cats while you write decorators' }),
+    Get(),
+    HttpCode(common_1.HttpStatus.NO_CONTENT),
+    openapi.ApiResponse({ status: common_1.HttpStatus.NO_CONTENT, type: [Cat] })
+], EnhancedCommentsController.prototype, "findAll", null);
+EnhancedCommentsController = __decorate([
+    common_1.Controller('cats')
+], EnhancedCommentsController);
+exports.EnhancedCommentsController = EnhancedCommentsController;
+`;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1097 


## What is the new behavior?
With this PR comments can be analysed with `@microsoft/tsdoc` parser to generate enhanced OpenApi spec based on comments rather than using Decorators.

In this PR only adds support for summary and description blocks, but we can keep improving it to add @examples, @params or whatever we need.

This PR keeps BC (while adding a package is not a bc). The new behaviour only works when setting `controllerKeyOfComment` to `null`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information