### PR TITLE
Add body name 

### DIFF
--- a/lib/decorators/api-body.decorator.ts
+++ b/lib/decorators/api-body.decorator.ts
@@ -19,6 +19,7 @@ interface ApiBodyMetadata extends RequestBodyOptions {
   type?: Type<unknown> | Function | [Function] | string;
   isArray?: boolean;
   enum?: SwaggerEnumType;
+  name?: string;
 }
 
 interface ApiBodySchemaHost extends RequestBodyOptions {

--- a/lib/swagger-explorer.ts
+++ b/lib/swagger-explorer.ts
@@ -353,6 +353,8 @@ export class SwaggerExplorer {
       ...omit(requestBody, keysToRemove),
       ...this.mimetypeContentWrapper.wrap(consumes, pick(requestBody, 'schema'))
     };
+    if (requestBody.name)
+      document.root["x-codegen-request-body-name"] = requestBody.name;
     return document;
   }
 

--- a/test/explorer/swagger-explorer.spec.ts
+++ b/test/explorer/swagger-explorer.spec.ts
@@ -901,6 +901,63 @@ describe('SwaggerExplorer', () => {
       ]);
     });
   });
+  describe('when body name is used', () => {
+
+    it('should properly define x-codegen-request-body-name extension', () => {
+
+      class Foo {}
+
+      @Controller('')
+      class FooController {
+        @Post('foos')
+        @ApiBody({
+          name: 'myBodyName',
+          type: Foo
+        })
+        create(): Promise<Foo> {
+          return Promise.resolve({});
+        }
+      }
+
+      const explorer = new SwaggerExplorer(schemaObjectFactory);
+      const routes = explorer.exploreController(
+        {
+          instance: new FooController(),
+          metatype: FooController
+        } as InstanceWrapper<FooController>,
+        'path'
+      );
+
+      expect(routes[0].root["x-codegen-request-body-name"]).toEqual("myBodyName");
+    });
+
+    it('should use default when body name is empty', () => {
+
+      class Foo {}
+
+      @Controller('')
+      class FooController {
+        @Post('foos')
+        @ApiBody({
+          type: Foo
+        })
+        create(): Promise<Foo> {
+          return Promise.resolve({});
+        }
+      }
+
+      const explorer = new SwaggerExplorer(schemaObjectFactory);
+      const routes = explorer.exploreController(
+        {
+          instance: new FooController(),
+          metatype: FooController
+        } as InstanceWrapper<FooController>,
+        'path'
+      );
+
+      expect(routes[0].root["x-codegen-request-body-name"]).toEqual("Foo");
+    });
+  });
 
   describe('when headers are defined', () => {
     class Foo {}


### PR DESCRIPTION
... which will produce the x-codegen-request-body-name extension in the root of the document

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/nestjs/swagger/issues/1212


## What is the new behavior?
`@ApiBody({name: "Foo"}) is working (again) as expected

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
- For us, coming from @nestjs/swagger@3.x it is not a new feature, it used to work like this. Nevertheless, for 4.x it could be a feature? 
- I checked "Docs have been added" since the current documentation is valid: It does not state that, during the migration, you would have lost this feature