### PR TITLE
fix: add isArray prop for enums on api query decorator when applicable

### DIFF
--- a/lib/decorators/api-query.decorator.ts
+++ b/lib/decorators/api-query.decorator.ts
@@ -46,14 +46,17 @@ export function ApiQuery(options: ApiQueryOptions): MethodDecorator {
     name: isNil(options.name) ? defaultQueryOptions.name : options.name,
     in: 'query',
     ...omit(options, 'enum'),
-    type,
-    isArray
+    type
   };
 
   if (isEnumArray(options)) {
     addEnumArraySchema(param, options);
   } else if (isEnumDefined(options)) {
     addEnumSchema(param, options);
+  }
+
+  if (isArray) {
+    param.isArray = isArray;
   }
 
   return createParamDecorator(param, defaultQueryOptions);

--- a/test/explorer/swagger-explorer.spec.ts
+++ b/test/explorer/swagger-explorer.spec.ts
@@ -843,7 +843,6 @@ describe('SwaggerExplorer', () => {
       expect(routes[0].root.parameters).toEqual([
         {
           in: 'query',
-          isArray: true,
           name: 'page',
           required: true,
           schema: {

--- a/test/explorer/swagger-explorer.spec.ts
+++ b/test/explorer/swagger-explorer.spec.ts
@@ -790,7 +790,7 @@ describe('SwaggerExplorer', () => {
         enum: ParamEnum
       })
       @ApiQuery({ name: 'order', enum: QueryEnum })
-      @ApiQuery({ name: 'page', enum: ['d', 'e', 'f'], isArray: true })
+      @ApiQuery({ name: 'page', enum: ['d', 'e', 'f'] })
       find(): Promise<Foo[]> {
         return Promise.resolve([]);
       }
@@ -832,11 +832,8 @@ describe('SwaggerExplorer', () => {
           name: 'page',
           required: true,
           schema: {
-            type: 'array',
-            items: {
-              type: 'string',
-              enum: ['d', 'e', 'f']
-            }
+            enum: ['d', 'e', 'f'],
+            type: 'string'
           }
         },
         {

--- a/test/explorer/swagger-explorer.spec.ts
+++ b/test/explorer/swagger-explorer.spec.ts
@@ -843,6 +843,7 @@ describe('SwaggerExplorer', () => {
       expect(routes[0].root.parameters).toEqual([
         {
           in: 'query',
+          isArray: true,
           name: 'page',
           required: true,
           schema: {


### PR DESCRIPTION
Only add isArray prop to params list when it is an array.
This change is needed to create valid OpenAPI documents.

Closes #1221

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1221 


## What is the new behavior?

Add isArray prop for enums on the Api Query decorator when applicable.

This is needed to create valid Open API documentation

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information