### PR TITLE
feat(config): merge passed schemas, links, ... in createDocument

### DIFF
--- a/e2e/validate-schema.e2e-spec.ts
+++ b/e2e/validate-schema.e2e-spec.ts
@@ -1,20 +1,30 @@
+import { INestApplication } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { writeFileSync } from 'fs';
 import { join } from 'path';
 import * as SwaggerParser from 'swagger-parser';
-import { DocumentBuilder, OpenAPIObject, SwaggerModule } from '../lib';
+import {
+  DocumentBuilder,
+  getSchemaPath,
+  OpenAPIObject,
+  SwaggerModule
+} from '../lib';
 import { ApplicationModule } from './src/app.module';
+import { Cat } from './src/cats/classes/cat.class';
+import { TagDto } from './src/cats/dto/tag.dto';
+import type { OpenAPIV3 } from 'openapi-types';
 
 describe('Validate OpenAPI schema', () => {
-  let document: OpenAPIObject;
+  let app: INestApplication;
+  let options: Omit<OpenAPIObject, 'paths'>;
 
   beforeEach(async () => {
-    const app = await NestFactory.create(ApplicationModule, {
+    app = await NestFactory.create(ApplicationModule, {
       logger: false
     });
     app.setGlobalPrefix('api/');
 
-    const options = new DocumentBuilder()
+    options = new DocumentBuilder()
       .setTitle('Cats example')
       .setDescription('The cats API description')
       .setVersion('1.0')
@@ -27,11 +37,11 @@ describe('Validate OpenAPI schema', () => {
       .addCookieAuth()
       .addSecurityRequirements('bearer')
       .build();
-
-    document = SwaggerModule.createDocument(app, options);
   });
 
   it('should produce a valid OpenAPI 3.0 schema', async () => {
+    const document = SwaggerModule.createDocument(app, options);
+
     const doc = JSON.stringify(document, null, 2);
     writeFileSync(join(__dirname, 'api-spec.json'), doc);
 
@@ -47,5 +57,44 @@ describe('Validate OpenAPI schema', () => {
       console.log(doc);
       expect(err).toBeUndefined();
     }
+  });
+
+  it('should merge custom components passed via config', async () => {
+    const components = {
+      schemas: {
+        Person: {
+          oneOf: [
+            {
+              $ref: getSchemaPath(Cat)
+            },
+            {
+              $ref: getSchemaPath(TagDto)
+            }
+          ],
+          discriminator: {
+            propertyName: '_resolveType',
+            mapping: {
+              cat: getSchemaPath(Cat),
+              tag: getSchemaPath(TagDto)
+            }
+          }
+        }
+      }
+    };
+
+    const document = SwaggerModule.createDocument(app, {
+      ...options,
+      components: {
+        ...options.components,
+        ...components
+      }
+    });
+
+    let api = (await SwaggerParser.validate(
+      document as any
+    )) as OpenAPIV3.Document;
+    console.log('API name: %s, Version: %s', api.info.title, api.info.version);
+    expect(api.components.schemas).toHaveProperty('Person');
+    expect(api.components.schemas).toHaveProperty('Cat');
   });
 });

--- a/lib/document-builder.ts
+++ b/lib/document-builder.ts
@@ -173,7 +173,7 @@ export class DocumentBuilder {
     return this;
   }
 
-  public build(): Omit<OpenAPIObject, 'components' | 'paths'> {
+  public build(): Omit<OpenAPIObject, 'paths'> {
     return this.document;
   }
 }

--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -6,6 +6,7 @@ import {
   SwaggerDocumentOptions
 } from './interfaces';
 import { SwaggerScanner } from './swagger-scanner';
+import { assignTwoLevelsDeep } from './utils/assign-two-levels-deep';
 import { validatePath } from './utils/validate-path.util';
 
 export class SwaggerModule {
@@ -16,10 +17,13 @@ export class SwaggerModule {
   ): OpenAPIObject {
     const swaggerScanner = new SwaggerScanner();
     const document = swaggerScanner.scanApplication(app, options);
-    document.components = {
-      ...(config.components || {}),
-      ...document.components
-    };
+
+    document.components = assignTwoLevelsDeep(
+      {},
+      config.components,
+      document.components
+    );
+
     return {
       openapi: '3.0.0',
       ...config,

--- a/lib/utils/assign-two-levels-deep.ts
+++ b/lib/utils/assign-two-levels-deep.ts
@@ -1,0 +1,27 @@
+/**
+ * Merge one level deeper than a regular Object.assign().
+ *
+ * @example
+ *
+ * ```
+ * const a = {foo: {bar: 1, baz: 2, bag: {x : 1}}};
+ * const b = {foo: {baz: 3, bag: {y: 2}}};
+ *
+ * assignTwoLevelsDeep(a, b);
+ *
+ * // a is {foo: {bar: 1, baz: 3, bag: {y: 2}}}
+ * ```
+ */
+export function assignTwoLevelsDeep<TObject, T>(_dest: TObject, ...args: T[]) {
+  const dest = _dest as TObject & T;
+
+  for (const arg of args) {
+    for (const [key, value] of Object.entries(arg ?? {}) as Array<
+      [keyof T, T[keyof T]]
+    >) {
+      dest[key] = { ...dest[key], ...value };
+    }
+  }
+
+  return dest;
+}


### PR DESCRIPTION
Merge the passed config's components one level deeper, so as to be able to
specify individual schemas that will not be overwritten by the generated document.

Fix #1244

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1244 


## What is the new behavior?

`config.components` is merged one level deeper.

There is an alternative solution to #1244 which is to create a new decorator.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

Schemas, links, examples, responses, ... passed to `SwaggerModule.createDocument` via `config.components` are no longer overwritten if definitions of the same kind are present in the generated document.

They will be overwritten only if a definition of the same kind AND with the same name is present.

The amount of existing applications that would need to migrate should be relatively low, as the config will typically be handcrafted with nothing extra unwanted.
