### PR TITLE
fix(core): allow the apibody decorator to add examples and add $ref f…

### DIFF
--- a/lib/decorators/api-body.decorator.ts
+++ b/lib/decorators/api-body.decorator.ts
@@ -1,6 +1,8 @@
 import { Type } from '@nestjs/common';
 import { omit } from 'lodash';
 import {
+  ExamplesObject,
+  ReferenceObject,
   RequestBodyObject,
   SchemaObject
 } from '../interfaces/open-api-spec.interface';
@@ -22,7 +24,8 @@ interface ApiBodyMetadata extends RequestBodyOptions {
 }
 
 interface ApiBodySchemaHost extends RequestBodyOptions {
-  schema: SchemaObject;
+  schema: SchemaObject | ReferenceObject;
+  examples?: ExamplesObject;
 }
 
 export type ApiBodyOptions = ApiBodyMetadata | ApiBodySchemaHost;

--- a/lib/swagger-explorer.ts
+++ b/lib/swagger-explorer.ts
@@ -348,10 +348,13 @@ export class SwaggerExplorer {
     let consumes = mergeAndUniq(classConsumes, methodConsumes);
     consumes = isEmpty(consumes) ? ['application/json'] : consumes;
 
-    const keysToRemove = ['schema', 'in', 'name'];
+    const keysToRemove = ['schema', 'in', 'name', 'examples'];
     document.root.requestBody = {
       ...omit(requestBody, keysToRemove),
-      ...this.mimetypeContentWrapper.wrap(consumes, pick(requestBody, 'schema'))
+      ...this.mimetypeContentWrapper.wrap(
+        consumes,
+        pick(requestBody, ['schema', 'examples'])
+      )
     };
     return document;
   }


### PR DESCRIPTION
…or schema

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: #1073 

The ApiBody decorator does not allow to add an examples section
and the schema option does not allow to use a $ref

The issue that @Body overrides all this information from the @ApiOperations
decorator is still an issue, but defining this information in the ApiBody is a 
good workaround

## What is the new behavior?

The ApiBody uses the examples section and allow a $ref type.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```