### PR TITLE
Feat/define global responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The following methods have been added:
 - `addBasicAuth`
 - `addSecurity`
 - `addSecurityRequirements`
+- `addResponse`
 
 ## Support
 

--- a/e2e/api-spec.json
+++ b/e2e/api-spec.json
@@ -49,6 +49,11 @@
         "name": "connect.sid"
       }
     },
+    "responses": {
+      "502": {
+        "description": "Bad gateway"
+      }
+    },
     "schemas": {
       "ExtraModel": {
         "type": "object",
@@ -289,6 +294,12 @@
           },
           "403": {
             "description": "Forbidden."
+          },
+          "500": {
+            "description": "Internal server error"
+          },
+          "502": {
+            "$ref": "#/components/responses/502"
           }
         },
         "tags": [
@@ -402,6 +413,12 @@
         "responses": {
           "200": {
             "description": ""
+          },
+          "500": {
+            "description": "Internal server error"
+          },
+          "502": {
+            "$ref": "#/components/responses/502"
           }
         },
         "tags": [
@@ -455,6 +472,12 @@
                 }
               }
             }
+          },
+          "500": {
+            "description": "Internal server error"
+          },
+          "502": {
+            "$ref": "#/components/responses/502"
           }
         },
         "tags": [
@@ -600,6 +623,12 @@
         "responses": {
           "200": {
             "description": ""
+          },
+          "500": {
+            "description": "Internal server error"
+          },
+          "502": {
+            "$ref": "#/components/responses/502"
           }
         },
         "tags": [
@@ -648,6 +677,12 @@
         "responses": {
           "201": {
             "description": ""
+          },
+          "500": {
+            "description": "Internal server error"
+          },
+          "502": {
+            "$ref": "#/components/responses/502"
           }
         },
         "tags": [
@@ -706,6 +741,12 @@
           },
           "403": {
             "description": "Forbidden."
+          },
+          "500": {
+            "description": "Internal server error"
+          },
+          "502": {
+            "$ref": "#/components/responses/502"
           }
         },
         "tags": [
@@ -743,6 +784,12 @@
         "responses": {
           "200": {
             "description": ""
+          },
+          "500": {
+            "description": "Internal server error"
+          },
+          "502": {
+            "$ref": "#/components/responses/502"
           }
         },
         "tags": [

--- a/e2e/src/cats/cats.controller.ts
+++ b/e2e/src/cats/cats.controller.ts
@@ -25,6 +25,7 @@ import { PaginationQuery } from './dto/pagination-query.dto';
   description: 'Test',
   schema: { default: 'test' }
 })
+@ApiResponse({ status: 500, description: 'Internal server error' })
 @Controller('cats')
 export class CatsController {
   constructor(private readonly catsService: CatsService) {}

--- a/e2e/validate-schema.e2e-spec.ts
+++ b/e2e/validate-schema.e2e-spec.ts
@@ -29,6 +29,10 @@ describe('Validate OpenAPI schema', () => {
       .addCookieAuth()
       .addSecurityRequirements('bearer')
       .addSecurityRequirements({ basic: [], cookie: [] })
+      .addResponse({
+        status: 502,
+        description: 'Bad gateway'
+      })
       .build();
 
     document = SwaggerModule.createDocument(app, options);

--- a/lib/document-builder.ts
+++ b/lib/document-builder.ts
@@ -1,10 +1,12 @@
 import { Logger } from '@nestjs/common';
-import { isString, isUndefined, negate, pickBy } from 'lodash';
+import { isString, isUndefined, negate, pickBy, omit } from 'lodash';
 import { buildDocumentBase } from './fixtures/document.base';
 import { OpenAPIObject } from './interfaces';
+import { ApiResponseOptions } from './decorators/';
 import {
   ExternalDocumentationObject,
   SecurityRequirementObject,
+  ResponseObject,
   SecuritySchemeObject,
   ServerVariableObject,
   TagObject
@@ -179,6 +181,15 @@ export class DocumentBuilder {
       name: cookieName,
       ...options
     });
+    return this;
+  }
+
+  public addResponse(options: ApiResponseOptions): this {
+    this.document.components.responses = {
+      ...(this.document.components.responses || {}),
+      [options.status]: omit(options, 'status') as ResponseObject
+    };
+
     return this;
   }
 

--- a/lib/document-builder.ts
+++ b/lib/document-builder.ts
@@ -7,6 +7,7 @@ import {
   ExternalDocumentationObject,
   SecurityRequirementObject,
   ResponseObject,
+  SecurityRequirementObject,
   SecuritySchemeObject,
   ServerVariableObject,
   TagObject

--- a/lib/explorers/api-response.explorer.ts
+++ b/lib/explorers/api-response.explorer.ts
@@ -1,20 +1,17 @@
 import { HttpStatus, RequestMethod, Type } from '@nestjs/common';
 import { HTTP_CODE_METADATA, METHOD_METADATA } from '@nestjs/common/constants';
-import { isEmpty } from '@nestjs/common/utils/shared.utils';
-import { get, mapValues, omit } from 'lodash';
+import { get } from 'lodash';
 import { DECORATORS } from '../constants';
 import { ApiResponseMetadata } from '../decorators';
 import { SchemaObject } from '../interfaces/open-api-spec.interface';
-import { ResponseObjectFactory } from '../services/response-object-factory';
+import { mapResponsesToSwaggerResponses } from '../utils/map-responses-to-swagger-responses.util';
 import { mergeAndUniq } from '../utils/merge-and-uniq.util';
-
-const responseObjectFactory = new ResponseObjectFactory();
 
 export const exploreGlobalApiResponseMetadata = (
   schemas: SchemaObject[],
   metatype: Type<unknown>
 ) => {
-  const responses: ApiResponseMetadata[] = Reflect.getMetadata(
+  const responses: Record<string, ApiResponseMetadata> = Reflect.getMetadata(
     DECORATORS.API_RESPONSE,
     metatype
   );
@@ -67,20 +64,4 @@ const getStatusCode = (method: Function) => {
     default:
       return HttpStatus.OK;
   }
-};
-
-const omitParamType = (param: Record<string, any>) => omit(param, 'type');
-const mapResponsesToSwaggerResponses = (
-  responses: ApiResponseMetadata[],
-  schemas: SchemaObject[],
-  produces: string[] = ['application/json']
-) => {
-  produces = isEmpty(produces) ? ['application/json'] : produces;
-
-  const openApiResponses = mapValues(
-    responses,
-    (response: ApiResponseMetadata) =>
-      responseObjectFactory.create(response, produces, schemas)
-  );
-  return mapValues(openApiResponses, omitParamType);
 };

--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -15,7 +15,7 @@ export class SwaggerModule {
     options: SwaggerDocumentOptions = {}
   ): OpenAPIObject {
     const swaggerScanner = new SwaggerScanner();
-    const document = swaggerScanner.scanApplication(app, options);
+    const document = swaggerScanner.scanApplication(app, options, config);
     document.components = {
       ...(config.components || {}),
       ...document.components

--- a/lib/swagger-scanner.ts
+++ b/lib/swagger-scanner.ts
@@ -3,10 +3,12 @@ import { MODULE_PATH } from '@nestjs/common/constants';
 import { NestContainer } from '@nestjs/core/injector/container';
 import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 import { Module } from '@nestjs/core/injector/module';
-import { extend, flatten, isEmpty, reduce } from 'lodash';
+import { extend, flatten, isEmpty, mapValues, reduce } from 'lodash';
+import { ApiResponseOptions } from './decorators/';
 import { OpenAPIObject, SwaggerDocumentOptions } from './interfaces';
 import {
   ReferenceObject,
+  ResponsesObject,
   SchemaObject
 } from './interfaces/open-api-spec.interface';
 import { ModelPropertiesAccessor } from './services/model-properties-accessor';
@@ -14,7 +16,9 @@ import { SchemaObjectFactory } from './services/schema-object-factory';
 import { SwaggerTypesMapper } from './services/swagger-types-mapper';
 import { SwaggerExplorer } from './swagger-explorer';
 import { SwaggerTransformer } from './swagger-transformer';
+import { mapResponsesToSwaggerResponses } from './utils/map-responses-to-swagger-responses.util';
 import { stripLastSlash } from './utils/strip-last-slash.util';
+import { transformResponsesToRefs } from './utils/transform-responses-to-refs.util';
 
 export class SwaggerScanner {
   private readonly transfomer = new SwaggerTransformer();
@@ -26,7 +30,8 @@ export class SwaggerScanner {
 
   public scanApplication(
     app: INestApplication,
-    options: SwaggerDocumentOptions
+    options: SwaggerDocumentOptions,
+    config: Omit<OpenAPIObject, 'paths'>
   ): Omit<OpenAPIObject, 'openapi' | 'info'> {
     const {
       deepScanRoutes,
@@ -35,6 +40,7 @@ export class SwaggerScanner {
       ignoreGlobalPrefix = false,
       operationIdFactory
     } = options;
+    const schemas = this.explorer.getSchemas();
 
     const container: NestContainer = (app as any).container;
     const modules: Module[] = this.getModules(
@@ -44,6 +50,10 @@ export class SwaggerScanner {
     const globalPrefix = !ignoreGlobalPrefix
       ? stripLastSlash(this.getGlobalPrefix(app))
       : '';
+    const globalResponses = mapResponsesToSwaggerResponses(
+      config.components.responses as Record<string, ApiResponseOptions>,
+      schemas
+    );
 
     const denormalizedPaths = modules.map(
       ({ routes, metatype, relatedModules }) => {
@@ -69,17 +79,18 @@ export class SwaggerScanner {
           allRoutes,
           path,
           globalPrefix,
+          transformResponsesToRefs(globalResponses),
           operationIdFactory
         );
       }
     );
 
-    const schemas = this.explorer.getSchemas();
     this.addExtraModels(schemas, extraModels);
 
     return {
       ...this.transfomer.normalizePaths(flatten(denormalizedPaths)),
       components: {
+        responses: globalResponses as ResponsesObject,
         schemas: reduce(this.explorer.getSchemas(), extend) as Record<
           string,
           SchemaObject | ReferenceObject
@@ -92,6 +103,7 @@ export class SwaggerScanner {
     routes: Map<string, InstanceWrapper>,
     modulePath?: string,
     globalPrefix?: string,
+    globalResponses?: ResponsesObject,
     operationIdFactory?: (controllerKey: string, methodKey: string) => string
   ): Array<Omit<OpenAPIObject, 'openapi' | 'info'> & Record<'root', any>> {
     const denormalizedArray = [...routes.values()].map((ctrl) =>
@@ -99,6 +111,7 @@ export class SwaggerScanner {
         ctrl,
         modulePath,
         globalPrefix,
+        globalResponses,
         operationIdFactory
       )
     );

--- a/lib/utils/map-responses-to-swagger-responses.util.ts
+++ b/lib/utils/map-responses-to-swagger-responses.util.ts
@@ -1,0 +1,23 @@
+import { mapValues, omit } from 'lodash';
+import { isEmpty } from '@nestjs/common/utils/shared.utils';
+import { ApiResponseMetadata } from '../decorators';
+import { SchemaObject } from '../interfaces/open-api-spec.interface';
+import { ResponseObjectFactory } from '../services/response-object-factory';
+
+const responseObjectFactory = new ResponseObjectFactory();
+const omitParamType = (param: Record<string, any>) => omit(param, 'type');
+
+export function mapResponsesToSwaggerResponses(
+  responses: Record<string, ApiResponseMetadata>,
+  schemas: SchemaObject[],
+  produces: string[] = ['application/json']
+) {
+  produces = isEmpty(produces) ? ['application/json'] : produces;
+
+  const openApiResponses = mapValues(
+    responses,
+    (response: ApiResponseMetadata) =>
+      responseObjectFactory.create(response, produces, schemas)
+  );
+  return mapValues(openApiResponses, omitParamType);
+}

--- a/lib/utils/transform-responses-to-refs.util.ts
+++ b/lib/utils/transform-responses-to-refs.util.ts
@@ -1,0 +1,11 @@
+import { mapValues } from 'lodash';
+import { ApiResponseOptions } from '../decorators';
+import { ReferenceObject } from '../interfaces/open-api-spec.interface';
+
+export function transformResponsesToRefs(
+  globalResponses: Record<string, ApiResponseOptions>
+): Record<string, ReferenceObject> {
+  return mapValues(globalResponses, (value, key) => ({
+    $ref: `#/components/responses/${key}`
+  }));
+}


### PR DESCRIPTION
Enables defining global responses which are inherited by all server routes.

fixes #884

PR Checklist
Please check if your PR fulfils the following requirements:

 The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
 Tests for the changes have been added (for bug fixes / features)
 Docs have been added / updated (for bug fixes / features)
PR Type
What kind of change does this PR introduce?

[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
What is the current behaviour?
Issue Number: #884

What is the new behaviour?
DocumentBuilder.addResponse has been added as a way to specify API responses globally. All server routes are then by default extending global responses.

SwaggerModule.createDocument(
  app,
  new DocumentBuilder()
    .addResponse({
      status: 500,
      description: 'Internal server error'
    }) // Same type as @ApiResponse decorator: ApiResponseOptions
   ...
)
Does this PR introduce a breaking change?
[ ] Yes
[x] No
Other information