### PR TITLE
fix(interfaces): remove 'examples' property

### DIFF
--- a/lib/interfaces/open-api-spec.interface.ts
+++ b/lib/interfaces/open-api-spec.interface.ts
@@ -202,7 +202,6 @@ export interface SchemaObject {
   xml?: XmlObject;
   externalDocs?: ExternalDocumentationObject;
   example?: any;
-  examples?: any[] | Record<string, any>;
   deprecated?: boolean;
   type?: string;
   allOf?: (SchemaObject | ReferenceObject)[];

--- a/test/services/fixtures/create-user.dto.ts
+++ b/test/services/fixtures/create-user.dto.ts
@@ -9,7 +9,7 @@ export class CreateUserDto {
   login: string;
 
   @ApiProperty({
-    examples: ['test', 'test2']
+    example: 'password123'
   })
   password: string;
 

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -102,7 +102,7 @@ describe('SchemaObjectFactory', () => {
           },
           password: {
             type: 'string',
-            examples: ['test', 'test2']
+            example: 'password123'
           },
           houses: {
             items: {


### PR DESCRIPTION
The definition of 'SchemaObject' currently includes the 'examples' property. However, this property is not valid according to the Open API specification. The typescript compiler does not warn against adding the examples  property, and thus users are able to generate invalid specifications.

[Here ](https://swagger.io/docs/specification/adding-examples/)is the documentation for the examples property. The last line of the section 'Object and Property Examples' states

>  'Note that schemas and properties support single example but not multiple examples.'


## PR Checklist
Please check if your PR fulfills the following requirements:

-  [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The key 'examples' is optional, but allowed in the  'SchemaObject' type.


## What is the new behavior?

The key is not allowed. This adheres to the spec.

## Does this PR introduce a breaking change?
```
[X ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Any values passed to decorators that accept the "SchemaObject" type, will need to ensure that the object does not contain the 'examples' property. 

## Other information