### PR TITLE
fix(plugin): check if a importPath is a package

### DIFF
--- a/lib/plugin/utils/plugin-utils.ts
+++ b/lib/plugin/utils/plugin-utils.ts
@@ -111,8 +111,6 @@ export function hasPropertyKey(
     .some((item) => item.name.getText() === key);
 }
 
-const NATIVE_NODEJS_LIBRARIES = 'stream';
-
 export function replaceImportPath(typeReference: string, fileName: string) {
   if (!typeReference.includes('import')) {
     return typeReference;
@@ -124,9 +122,10 @@ export function replaceImportPath(typeReference: string, fileName: string) {
   importPath = convertPath(importPath);
   importPath = importPath.slice(2, importPath.length - 1);
 
-  if (NATIVE_NODEJS_LIBRARIES.includes(importPath)) {
+  try {
+    require.resolve(importPath)
     return typeReference.replace('import', 'require');
-  } else {
+  } catch (_error) {
     let relativePath = posix.relative(posix.dirname(fileName), importPath);
     relativePath = relativePath[0] !== '.' ? './' + relativePath : relativePath;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
When using a type provided by a node module the plugin would try to assemble a relative path that led to an error when trying to run the server, on release `4.8.0` an exception was added for the `stream` package, that fix worked only for that specific package, but other packages still were throwing out the same error (refer to issue #1106) 

Issue Number: #1106 


## What is the new behavior?
Using `require.resolve(name: string)` we can check if a string is a package, this function throws an error if the package is not found in the project's installed packages, we can catch this error and default to the usual behavior that works for all other files in the project. 

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```


## Other information
node's `require.resolve(name:string)` documentation:
https://nodejs.org/api/modules.html#modules_require_resolve_request_options