### PR TITLE
fix(plugin): allow the use of "uiConfig" options to fastify-swagger and Swagger UI

### DIFF
--- a/e2e/fastify.e2e-spec.ts
+++ b/e2e/fastify.e2e-spec.ts
@@ -52,6 +52,28 @@ describe('Fastify Swagger', () => {
     }
   });
 
+  it('should pass uiConfig options to fastify-swagger', async () => {
+    const document1 = SwaggerModule.createDocument(app, builder.build());
+    const uiConfig = {
+      displayOperationId: true,
+      persistAuthorization: true
+    };
+    const options = { uiConfig };
+    SwaggerModule.setup('/swagger1', app, document1, options);
+
+    const instance = await app.getHttpAdapter().getInstance().ready();
+
+    instance.ready(async () => {
+      const response = await instance.inject({
+        method: 'GET',
+        url: '/swagger1/uiConfig'
+      });
+
+      expect(response.statusCode).toEqual(200);
+      expect(JSON.parse(response.body)).toEqual(uiConfig);
+    });
+  });
+
   it('should setup multiple routes', async () => {
     const document1 = SwaggerModule.createDocument(app, builder.build());
     SwaggerModule.setup('/swagger1', app, document1);

--- a/lib/interfaces/swagger-custom-options.interface.ts
+++ b/lib/interfaces/swagger-custom-options.interface.ts
@@ -8,6 +8,7 @@ export interface SwaggerCustomOptions {
   swaggerUrl?: string;
   customSiteTitle?: string;
   validatorUrl?: string;
+  uiConfig?: Record<string, any>;
   url?: string;
   urls?: Record<'url' | 'name', string>[];
 }

--- a/lib/interfaces/swagger-custom-options.interface.ts
+++ b/lib/interfaces/swagger-custom-options.interface.ts
@@ -1,4 +1,4 @@
-export interface SwaggerCustomOptions {
+export interface ExpressSwaggerCustomOptions {
   explorer?: boolean;
   swaggerOptions?: Record<string, any>;
   customCss?: string;
@@ -8,7 +8,14 @@ export interface SwaggerCustomOptions {
   swaggerUrl?: string;
   customSiteTitle?: string;
   validatorUrl?: string;
-  uiConfig?: Record<string, any>;
   url?: string;
   urls?: Record<'url' | 'name', string>[];
 }
+
+export interface FastifySwaggerCustomOptions {
+  uiConfig?: Record<string, any>;
+}
+
+export type SwaggerCustomOptions =
+  | FastifySwaggerCustomOptions
+  | ExpressSwaggerCustomOptions;

--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -1,6 +1,8 @@
 import { INestApplication } from '@nestjs/common';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
 import {
+  ExpressSwaggerCustomOptions,
+  FastifySwaggerCustomOptions,
   OpenAPIObject,
   SwaggerCustomOptions,
   SwaggerDocumentOptions
@@ -35,16 +37,26 @@ export class SwaggerModule {
   ) {
     const httpAdapter = app.getHttpAdapter();
     if (httpAdapter && httpAdapter.getType() === 'fastify') {
-      return this.setupFastify(path, httpAdapter, document, options);
+      return this.setupFastify(
+        path,
+        httpAdapter,
+        document,
+        options as FastifySwaggerCustomOptions
+      );
     }
-    return this.setupExpress(path, app, document, options);
+    return this.setupExpress(
+      path,
+      app,
+      document,
+      options as ExpressSwaggerCustomOptions
+    );
   }
 
   private static setupExpress(
     path: string,
     app: INestApplication,
     document: OpenAPIObject,
-    options?: SwaggerCustomOptions
+    options?: ExpressSwaggerCustomOptions
   ) {
     const httpAdapter = app.getHttpAdapter();
     const finalPath = validatePath(path);
@@ -62,7 +74,7 @@ export class SwaggerModule {
     path: string,
     httpServer: any,
     document: OpenAPIObject,
-    options?: SwaggerCustomOptions
+    options?: FastifySwaggerCustomOptions
   ) {
     // Workaround for older versions of the @nestjs/platform-fastify package
     // where "isParserRegistered" getter is not defined.

--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -35,7 +35,7 @@ export class SwaggerModule {
   ) {
     const httpAdapter = app.getHttpAdapter();
     if (httpAdapter && httpAdapter.getType() === 'fastify') {
-      return this.setupFastify(path, httpAdapter, document);
+      return this.setupFastify(path, httpAdapter, document, options);
     }
     return this.setupExpress(path, app, document, options);
   }
@@ -61,13 +61,14 @@ export class SwaggerModule {
   private static setupFastify(
     path: string,
     httpServer: any,
-    document: OpenAPIObject
+    document: OpenAPIObject,
+    options?: SwaggerCustomOptions
   ) {
     // Workaround for older versions of the @nestjs/platform-fastify package
     // where "isParserRegistered" getter is not defined.
-    const hasParserGetterDefined = (Object.getPrototypeOf(
-      httpServer
-    ) as Object).hasOwnProperty('isParserRegistered');
+    const hasParserGetterDefined = (
+      Object.getPrototypeOf(httpServer) as Object
+    ).hasOwnProperty('isParserRegistered');
     if (hasParserGetterDefined && !httpServer.isParserRegistered) {
       httpServer.registerParserMiddleware();
     }
@@ -84,7 +85,8 @@ export class SwaggerModule {
           mode: 'static',
           specification: {
             document
-          }
+          },
+          uiConfig: (options || {}).uiConfig
         }
       );
     });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Using `@nestjs/swagger` with Fastify, you cannot pass the `uiConfig` options at `fastify-swagger` plugin registration. 

Issue Number: N/A


## What is the new behavior?

You can pass on `uiConfig` as per [fastify-swagger's documentation](https://github.com/fastify/fastify-swagger#options). 

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
In order to get there, this PR adds a fourth argument to `setupFastify()` which is the `options: SwaggerCustomOptions` object. This PR also adds the `uiConfig?: Record<string, any>` property to `SwaggerCustomOptions` as hint.

With this update, we can make use of great features from [Swagger UI](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md) such as authorization persistence (`uiConfig.persistAuthorization`) and showing the operation's id (`uiConfig.displayOperationId`).