### PR TITLE
fix(@nestjs/swagger): Fix generated types for single string literals

### DIFF
--- a/lib/explorers/api-parameters.explorer.ts
+++ b/lib/explorers/api-parameters.explorer.ts
@@ -42,9 +42,10 @@ export const exploreApiParametersMetadata = (
   if (noExplicitMetadata && isNil(parametersMetadata)) {
     return undefined;
   }
-  const reflectedParametersAsProperties = parametersMetadataMapper.transformModelToProperties(
-    parametersMetadata || {}
-  );
+  const reflectedParametersAsProperties =
+    parametersMetadataMapper.transformModelToProperties(
+      parametersMetadata || {}
+    );
 
   let properties = reflectedParametersAsProperties;
   if (!noExplicitMetadata) {

--- a/lib/plugin/utils/ast-utils.ts
+++ b/lib/plugin/utils/ast-utils.ts
@@ -39,6 +39,10 @@ export function isString(type: Type) {
   return hasFlag(type, TypeFlags.String);
 }
 
+export function isStringLiteral(type: Type) {
+  return hasFlag(type, TypeFlags.StringLiteral) && !type.isUnion();
+}
+
 export function isNumber(type: Type) {
   return hasFlag(type, TypeFlags.Number);
 }
@@ -110,7 +114,8 @@ export function getMainCommentAndExamplesOfNode(
 ): [string, string[]] {
   const sourceText = sourceFile.getFullText();
   // in case we decide to include "// comments"
-  const replaceRegex = /^ *\** *@.*$|^ *\/\*+ *|^ *\/\/+.*|^ *\/+ *|^ *\*+ *| +$| *\**\/ *$/gim;
+  const replaceRegex =
+    /^ *\** *@.*$|^ *\/\*+ *|^ *\/\/+.*|^ *\/+ *|^ *\*+ *| +$| *\**\/ *$/gim;
   //const replaceRegex = /^ *\** *@.*$|^ *\/\*+ *|^ *\/+ *|^ *\*+ *| +$| *\**\/ *$/gim;
 
   const commentResult = [];
@@ -123,7 +128,8 @@ export function getMainCommentAndExamplesOfNode(
         commentResult.push(oneComment);
       }
       if (includeExamples) {
-        const regexOfExample = /@example *((['"](?<exampleAsString>.+?)['"])|(?<exampleAsBooleanOrNumber>[^ ]+?)|(?<exampleAsArray>(\[.+?\]))) *$/gim;
+        const regexOfExample =
+          /@example *((['"](?<exampleAsString>.+?)['"])|(?<exampleAsBooleanOrNumber>[^ ]+?)|(?<exampleAsArray>(\[.+?\]))) *$/gim;
         let execResult: RegExpExecArray;
         while (
           (execResult = regexOfExample.exec(commentSource)) &&

--- a/lib/plugin/utils/plugin-utils.ts
+++ b/lib/plugin/utils/plugin-utils.ts
@@ -10,7 +10,8 @@ import {
   isEnum,
   isInterface,
   isNumber,
-  isString
+  isString,
+  isStringLiteral
 } from './ast-utils';
 
 export function getDecoratorOrUndefinedByNames(
@@ -45,7 +46,7 @@ export function getTypeReferenceAsString(
   if (isNumber(type)) {
     return Number.name;
   }
-  if (isString(type)) {
+  if (isString(type) || isStringLiteral(type)) {
     return String.name;
   }
   if (isPromiseOrObservable(getText(type, typeChecker))) {

--- a/lib/plugin/visitors/controller-class.visitor.ts
+++ b/lib/plugin/visitors/controller-class.visitor.ts
@@ -132,11 +132,12 @@ export class ControllerClassVisitor extends AbstractFileVisitor {
         ),
         ...(apiOperationExprProperties ?? ts.createNodeArray())
       ];
-      const apiOperationDecoratorArguments: ts.NodeArray<ts.Expression> = ts.createNodeArray(
-        [ts.createObjectLiteral(compact(properties))]
-      );
+      const apiOperationDecoratorArguments: ts.NodeArray<ts.Expression> =
+        ts.createNodeArray([ts.createObjectLiteral(compact(properties))]);
       if (apiOperationDecorator) {
-        ((apiOperationDecorator.expression as ts.CallExpression) as any).arguments = apiOperationDecoratorArguments;
+        (
+          apiOperationDecorator.expression as ts.CallExpression as any
+        ).arguments = apiOperationDecoratorArguments;
       } else {
         return [
           ts.createDecorator(

--- a/lib/plugin/visitors/model-class.visitor.ts
+++ b/lib/plugin/visitors/model-class.visitor.ts
@@ -32,41 +32,41 @@ export class ModelClassVisitor extends AbstractFileVisitor {
     const typeChecker = program.getTypeChecker();
     sourceFile = this.updateImports(sourceFile, ctx.factory);
 
-    const propertyNodeVisitorFactory = (metadata: ClassMetadata) => (
-      node: ts.Node
-    ): ts.Node => {
-      if (ts.isPropertyDeclaration(node)) {
-        const decorators = node.decorators;
-        const hidePropertyDecorator = getDecoratorOrUndefinedByNames(
-          [ApiHideProperty.name],
-          decorators
-        );
-        if (hidePropertyDecorator) {
-          return node;
-        }
-
-        const isPropertyStatic = (node.modifiers || []).some(
-          (modifier: ts.Modifier) =>
-            modifier.kind === ts.SyntaxKind.StaticKeyword
-        );
-        if (isPropertyStatic) {
-          return node;
-        }
-        try {
-          this.inspectPropertyDeclaration(
-            node,
-            typeChecker,
-            options,
-            sourceFile.fileName,
-            sourceFile,
-            metadata
+    const propertyNodeVisitorFactory =
+      (metadata: ClassMetadata) =>
+      (node: ts.Node): ts.Node => {
+        if (ts.isPropertyDeclaration(node)) {
+          const decorators = node.decorators;
+          const hidePropertyDecorator = getDecoratorOrUndefinedByNames(
+            [ApiHideProperty.name],
+            decorators
           );
-        } catch (err) {
-          return node;
+          if (hidePropertyDecorator) {
+            return node;
+          }
+
+          const isPropertyStatic = (node.modifiers || []).some(
+            (modifier: ts.Modifier) =>
+              modifier.kind === ts.SyntaxKind.StaticKeyword
+          );
+          if (isPropertyStatic) {
+            return node;
+          }
+          try {
+            this.inspectPropertyDeclaration(
+              node,
+              typeChecker,
+              options,
+              sourceFile.fileName,
+              sourceFile,
+              metadata
+            );
+          } catch (err) {
+            return node;
+          }
         }
-      }
-      return node;
-    };
+        return node;
+      };
 
     const visitClassNode = (node: ts.Node): ts.Node => {
       if (ts.isClassDeclaration(node)) {
@@ -104,9 +104,11 @@ export class ModelClassVisitor extends AbstractFileVisitor {
       undefined,
       ts.createBlock([ts.createReturn(returnValue)], true)
     );
-    ((classMutableNode as ts.ClassDeclaration) as any).members = ts.createNodeArray(
-      [...(classMutableNode as ts.ClassDeclaration).members, method]
-    );
+    (classMutableNode as ts.ClassDeclaration as any).members =
+      ts.createNodeArray([
+        ...(classMutableNode as ts.ClassDeclaration).members,
+        method
+      ]);
     return classMutableNode;
   }
 

--- a/lib/services/parameters-metadata-mapper.ts
+++ b/lib/services/parameters-metadata-mapper.ts
@@ -34,9 +34,8 @@ export class ParametersMetadataMapper {
       const { prototype } = param.type;
 
       this.modelPropertiesAccessor.applyMetadataFactory(prototype);
-      const modelProperties = this.modelPropertiesAccessor.getModelProperties(
-        prototype
-      );
+      const modelProperties =
+        this.modelPropertiesAccessor.getModelProperties(prototype);
 
       return modelProperties.map((key) =>
         this.mergeImplicitWithExplicit(key, prototype, param)

--- a/lib/services/response-object-factory.ts
+++ b/lib/services/response-object-factory.ts
@@ -34,9 +34,8 @@ export class ResponseObjectFactory {
     if (isBuiltInType(type as Function)) {
       const typeName =
         type && isFunction(type) ? (type as Function).name : (type as string);
-      const swaggerType = this.swaggerTypesMapper.mapTypeToOpenAPIType(
-        typeName
-      );
+      const swaggerType =
+        this.swaggerTypesMapper.mapTypeToOpenAPIType(typeName);
 
       if (isArray) {
         const content = this.mimetypeContentWrapper.wrap(produces, {

--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -151,9 +151,8 @@ export class SchemaObjectFactory {
     );
 
     this.modelPropertiesAccessor.applyMetadataFactory(prototype);
-    const modelProperties = this.modelPropertiesAccessor.getModelProperties(
-      prototype
-    );
+    const modelProperties =
+      this.modelPropertiesAccessor.getModelProperties(prototype);
     const propertiesWithType = modelProperties.map((key) => {
       const property = this.mergePropertyWithMetadata(
         key,

--- a/lib/services/swagger-types-mapper.ts
+++ b/lib/services/swagger-types-mapper.ts
@@ -151,7 +151,7 @@ export class SwaggerTypesMapper {
       'title',
       'format',
       'pattern',
-      'default',
+      'default'
     ];
   }
 }

--- a/lib/swagger-explorer.ts
+++ b/lib/swagger-explorer.ts
@@ -263,19 +263,18 @@ export class SwaggerExplorer {
     if (methodMetadata.root && !methodMetadata.root.parameters) {
       methodMetadata.root.parameters = [];
     }
-    const deepMerge = (metadata: Record<string, any>) => (
-      value: Record<string, unknown>,
-      key: string
-    ) => {
-      if (!metadata[key]) {
-        return value;
-      }
-      const globalValue = metadata[key];
-      if (metadata.depth) {
-        return this.deepMergeMetadata(globalValue, value, metadata.depth);
-      }
-      return this.mergeValues(globalValue, value);
-    };
+    const deepMerge =
+      (metadata: Record<string, any>) =>
+      (value: Record<string, unknown>, key: string) => {
+        if (!metadata[key]) {
+          return value;
+        }
+        const globalValue = metadata[key];
+        if (metadata.depth) {
+          return this.deepMergeMetadata(globalValue, value, metadata.depth);
+        }
+        return this.mergeValues(globalValue, value);
+      };
 
     if (globalMetadata.chunks) {
       const { chunks } = globalMetadata;

--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -65,9 +65,9 @@ export class SwaggerModule {
   ) {
     // Workaround for older versions of the @nestjs/platform-fastify package
     // where "isParserRegistered" getter is not defined.
-    const hasParserGetterDefined = (Object.getPrototypeOf(
-      httpServer
-    ) as Object).hasOwnProperty('isParserRegistered');
+    const hasParserGetterDefined = (
+      Object.getPrototypeOf(httpServer) as Object
+    ).hasOwnProperty('isParserRegistered');
     if (hasParserGetterDefined && !httpServer.isParserRegistered) {
       httpServer.registerParserMiddleware();
     }

--- a/lib/utils/merge-and-uniq.util.ts
+++ b/lib/utils/merge-and-uniq.util.ts
@@ -1,5 +1,5 @@
 import { merge, uniq } from 'lodash';
 
 export function mergeAndUniq<T = any>(a: unknown = [], b: unknown = []): T {
-  return (uniq(merge(a, b) as any) as unknown) as T;
+  return uniq(merge(a, b) as any) as unknown as T;
 }

--- a/test/plugin/fixtures/string-literal.dto.ts
+++ b/test/plugin/fixtures/string-literal.dto.ts
@@ -1,0 +1,21 @@
+export const stringLiteralDtoText = `
+export class StringLiteralDto {
+  @ApiProperty()
+  valueOne: "one";
+  @ApiProperty()
+  valueTwo: "one" | "two";
+}
+`;
+
+export const stringLiteralDtoTextTranspiled = `export class StringLiteralDto {
+    static _OPENAPI_METADATA_FACTORY() {
+        return { valueOne: { required: true, type: () => String }, valueTwo: { required: true, type: () => Object } };
+    }
+}
+__decorate([
+    ApiProperty()
+], StringLiteralDto.prototype, "valueOne", void 0);
+__decorate([
+    ApiProperty()
+], StringLiteralDto.prototype, "valueTwo", void 0);
+`;

--- a/test/plugin/model-class-visitor.spec.ts
+++ b/test/plugin/model-class-visitor.spec.ts
@@ -25,6 +25,10 @@ import {
   nullableDtoText,
   nullableDtoTextTranspiled
 } from './fixtures/nullable.dto';
+import {
+  stringLiteralDtoText,
+  stringLiteralDtoTextTranspiled
+} from './fixtures/string-literal.dto';
 
 describe('API model properties', () => {
   it('should add the metadata factory when no decorators exist, and generated propertyKey is title', () => {
@@ -194,5 +198,31 @@ describe('API model properties', () => {
     });
 
     expect(changedResult.outputText).toEqual(changedCatDtoTextTranspiled);
+  });
+
+  it('should support & understand string literals', () => {
+    const options: ts.CompilerOptions = {
+      module: ts.ModuleKind.ESNext,
+      target: ts.ScriptTarget.ESNext,
+      newLine: ts.NewLineKind.LineFeed,
+      noEmitHelpers: true,
+      strict: true
+    };
+    const filename = 'string-literal.dto.ts';
+    const fakeProgram = ts.createProgram([filename], options);
+
+    const result = ts.transpileModule(stringLiteralDtoText, {
+      compilerOptions: options,
+      fileName: filename,
+      transformers: {
+        before: [
+          before(
+            { introspectComments: true, classValidatorShim: true },
+            fakeProgram
+          )
+        ]
+      }
+    });
+    expect(result.outputText).toEqual(stringLiteralDtoTextTranspiled);
   });
 });


### PR DESCRIPTION
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Single string literal types don't generate a type property metadata, leading to parsing errors.

Ex:

```ts
interface Test { stringLiteral: "one"  }
```

Results in:

```ts
{ stringLiteral: { required: true } }
```

Issue Number: N/A


## What is the new behavior?

Single string literals get assigned the type of String, ex:

```ts
{ stringLiteral: { required: true, type: () => String } }
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```