### PR TITLE
fix(@nestjs/swagger): prevent routes with "undefined" path from getting…

### DIFF
--- a/lib/swagger-explorer.ts
+++ b/lib/swagger-explorer.ts
@@ -178,6 +178,8 @@ export class SwaggerExplorer {
         prototype,
         targetCallback
       );
+    }).filter((path) => {
+      return path.root !== undefined && path.root.path !== undefined;
     });
     return denormalizedPaths;
   }


### PR DESCRIPTION
… into the generated doc

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
"undefined" route appears in the output openapi document, which makes the doc invalid.
Steps to reproduce:
1. Create a controller by implementing CrudController from '@nestjsx/crud' package.
2. Override any controller's crud action (for example, getMany) using @Override(), but utilize "base" logic inside
![image](https://user-images.githubusercontent.com/10167453/122743128-60bbaa80-d28f-11eb-8072-0d2bd33bc263.png)
3. Build a document off of app's module using @nestjs/swagger
As a result of these actions, "getMany" operation will be duplicated in the output doc: a correct one and an invalid one:
![image](https://user-images.githubusercontent.com/10167453/122742066-459c6b00-d28e-11eb-956e-1d4c67c126b3.png)
![image](https://user-images.githubusercontent.com/10167453/122742112-4f25d300-d28e-11eb-97d7-0209f7d90f13.png)

As a result, we get an invalid document, which can't be used for generating api client code.

## What is the new behavior?
Routes with "undefined" path are not getting into the output, generated docs are valid.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information
In my particular case the root cause is a "getManyBase" method from controller's prototype which get's added into the api doc along with the actual overriding crud method.
Current workaround is to remove "undefined" path from the generated doc manually.