### PR TITLE
fix(transformer): prefer explicit config over auto-detected schema

### DIFF
--- a/e2e/api-spec.json
+++ b/e2e/api-spec.json
@@ -729,6 +729,58 @@
           }
         ]
       }
+    },
+    "/api/cats/download": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "binary file for download",
+            "content": {
+              "application/pdf": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              },
+              "image/jpeg": {
+                "schema": {
+                  "type": "string",
+                  "format": "binary"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "cats"
+        ],
+        "security": [
+          {
+            "key2": [],
+            "key1": []
+          },
+          {
+            "bearer": []
+          },
+          {
+            "basic": []
+          }
+        ],
+        "operationId": "CatsController_download",
+        "summary": "",
+        "parameters": [
+          {
+            "name": "header",
+            "in": "header",
+            "description": "Test",
+            "required": false,
+            "schema": {
+              "default": "test",
+              "type": "string"
+            }
+          }
+        ]
+      }
     }
   },
   "info": {

--- a/e2e/src/cats/cats.controller.ts
+++ b/e2e/src/cats/cats.controller.ts
@@ -108,4 +108,18 @@ export class CatsController {
     maxLength: 100
   } as any)
   getWithRandomQuery(@Query('type') type: string) {}
+
+  @Get('download')
+  @ApiOperation({
+    responses: {
+      '200': {
+        description: 'binary file for download',
+        content: {
+          'application/pdf': { schema: { type: 'string', format: 'binary' } },
+          'image/jpeg': { schema: { type: 'string', format: 'binary' } }
+        }
+      }
+    }
+  })
+  download() {}
 }

--- a/e2e/validate-schema.e2e-spec.ts
+++ b/e2e/validate-schema.e2e-spec.ts
@@ -116,4 +116,20 @@ describe('Validate OpenAPI schema', () => {
     expect(api.components.schemas).toHaveProperty('Person');
     expect(api.components.schemas).toHaveProperty('Cat');
   });
+
+  it('should consider explicit config over auto-detected schema', async () => {
+    const document = SwaggerModule.createDocument(app, options);
+    console.log('document.paths[\'/api/cats/download\'][\'responses\']', document.paths['/api/cats/download']['responses']);
+    expect(document.paths['/api/cats/download'].get.responses).toEqual({
+      '200': {
+        description: 'binary file for download',
+        content: {
+          'application/pdf': {
+            schema: { type: 'string', format: 'binary' }
+          },
+          'image/jpeg': { schema: { type: 'string', format: 'binary' } }
+        }
+      }
+    })
+  });
 });

--- a/e2e/validate-schema.e2e-spec.ts
+++ b/e2e/validate-schema.e2e-spec.ts
@@ -119,7 +119,6 @@ describe('Validate OpenAPI schema', () => {
 
   it('should consider explicit config over auto-detected schema', async () => {
     const document = SwaggerModule.createDocument(app, options);
-    console.log('document.paths[\'/api/cats/download\'][\'responses\']', document.paths['/api/cats/download']['responses']);
     expect(document.paths['/api/cats/download'].get.responses).toEqual({
       '200': {
         description: 'binary file for download',

--- a/lib/swagger-transformer.ts
+++ b/lib/swagger-transformer.ts
@@ -18,9 +18,9 @@ export class SwaggerTransformer {
         ({ root }: Record<'root', any>) => root.method
       );
       return mapValues(keyByMethod, (route: any) => {
-        return {
-          ...omit(route.root, ['method', 'path']),
-          ...omit(route, 'root')
+        return {	
+          ...omit(route, 'root'),
+          ...omit(route.root, ['method', 'path'])
         };
       });
     });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
@ApiOperation.responses was disregarded as the auto-detected responses were given preference. Auto-detection happens always, even if no return type is configured.

Issue Number: #1420


## What is the new behavior?
Explicit config is given preference over auto-detected schema

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
This PR only fixes the issue on a smaller level, however there is a scope for improving how the actual merging should happen for the schema extracted from different areas.

Each schema extracted should be assigned a priority status (like constants in the library code). For example, body extracted from controller function argument should be given a priority of 0, one that is defined as @ApiParam should be given a priority of 10, and the one in @ApiOperation a priority of 50. When making the final schema, we should be able to order all the configured schemas by priority and pick first one.

This is a very vague suggestion, and not sure if there is a way to implement this as we'd be dealing with nested json structures, but may provide a solution for easily deciding what's important over what!