### PR TITLE
feat: Add default type to Api Error Responses

### DIFF
--- a/lib/decorators/api-response.decorator.ts
+++ b/lib/decorators/api-response.decorator.ts
@@ -9,6 +9,8 @@ import {
 } from '../interfaces/open-api-spec.interface';
 import { getTypeIsArrayTuple } from './helpers';
 
+import * as ErrorResponseDtos from '../types/error-responses.dto';
+
 export interface ApiResponseMetadata
   extends Omit<ResponseObject, 'description'> {
   status?: number | 'default';
@@ -117,18 +119,21 @@ export const ApiBadRequestResponse = (options: ApiResponseOptions = {}) =>
 
 export const ApiUnauthorizedResponse = (options: ApiResponseOptions = {}) =>
   ApiResponse({
+    type: ErrorResponseDtos.UnauthorizedResponseDto,
     ...options,
     status: HttpStatus.UNAUTHORIZED
   });
 
 export const ApiTooManyRequestsResponse = (options: ApiResponseOptions = {}) =>
   ApiResponse({
+    type: ErrorResponseDtos.TooManyRequestsResponseDto,
     ...options,
     status: HttpStatus.TOO_MANY_REQUESTS
   });
 
 export const ApiNotFoundResponse = (options: ApiResponseOptions = {}) =>
   ApiResponse({
+    type: ErrorResponseDtos.NotFoundResponseDto,
     ...options,
     status: HttpStatus.NOT_FOUND
   });
@@ -137,54 +142,63 @@ export const ApiInternalServerErrorResponse = (
   options: ApiResponseOptions = {}
 ) =>
   ApiResponse({
+    type: ErrorResponseDtos.InternalServerErrorResponseDto,
     ...options,
     status: HttpStatus.INTERNAL_SERVER_ERROR
   });
 
 export const ApiBadGatewayResponse = (options: ApiResponseOptions = {}) =>
   ApiResponse({
+    type: ErrorResponseDtos.BadGatewayResponseDto,
     ...options,
     status: HttpStatus.BAD_GATEWAY
   });
 
 export const ApiConflictResponse = (options: ApiResponseOptions = {}) =>
   ApiResponse({
+    type: ErrorResponseDtos.ConflictResponseDto,
     ...options,
     status: HttpStatus.CONFLICT
   });
 
 export const ApiForbiddenResponse = (options: ApiResponseOptions = {}) =>
   ApiResponse({
+    type: ErrorResponseDtos.ForbiddenResponseDto,
     ...options,
     status: HttpStatus.FORBIDDEN
   });
 
 export const ApiGatewayTimeoutResponse = (options: ApiResponseOptions = {}) =>
   ApiResponse({
+    type: ErrorResponseDtos.GatewayTimeoutResponseDto,
     ...options,
     status: HttpStatus.GATEWAY_TIMEOUT
   });
 
 export const ApiGoneResponse = (options: ApiResponseOptions = {}) =>
   ApiResponse({
+    type: ErrorResponseDtos.GoneResponseDto,
     ...options,
     status: HttpStatus.GONE
   });
 
 export const ApiMethodNotAllowedResponse = (options: ApiResponseOptions = {}) =>
   ApiResponse({
+    type: ErrorResponseDtos.MethodNotAllowedResponseDto,
     ...options,
     status: HttpStatus.METHOD_NOT_ALLOWED
   });
 
 export const ApiNotAcceptableResponse = (options: ApiResponseOptions = {}) =>
   ApiResponse({
+    type: ErrorResponseDtos.NotAcceptableResponseDto,
     ...options,
     status: HttpStatus.NOT_ACCEPTABLE
   });
 
 export const ApiNotImplementedResponse = (options: ApiResponseOptions = {}) =>
   ApiResponse({
+    type: ErrorResponseDtos.NotImplementedResponseDto,
     ...options,
     status: HttpStatus.NOT_IMPLEMENTED
   });
@@ -193,18 +207,21 @@ export const ApiPreconditionFailedResponse = (
   options: ApiResponseOptions = {}
 ) =>
   ApiResponse({
+    type: ErrorResponseDtos.PreconditionFailedResponseDto,
     ...options,
     status: HttpStatus.PRECONDITION_FAILED
   });
 
 export const ApiPayloadTooLargeResponse = (options: ApiResponseOptions = {}) =>
   ApiResponse({
+    type: ErrorResponseDtos.PayloadTooLargeResponseDto,
     ...options,
     status: HttpStatus.PAYLOAD_TOO_LARGE
   });
 
 export const ApiRequestTimeoutResponse = (options: ApiResponseOptions = {}) =>
   ApiResponse({
+    type: ErrorResponseDtos.RequestTimeoutResponseDto,
     ...options,
     status: HttpStatus.REQUEST_TIMEOUT
   });
@@ -213,6 +230,7 @@ export const ApiServiceUnavailableResponse = (
   options: ApiResponseOptions = {}
 ) =>
   ApiResponse({
+    type: ErrorResponseDtos.ServiceUnavailableResponseDto,
     ...options,
     status: HttpStatus.SERVICE_UNAVAILABLE
   });
@@ -221,6 +239,7 @@ export const ApiUnprocessableEntityResponse = (
   options: ApiResponseOptions = {}
 ) =>
   ApiResponse({
+    type: ErrorResponseDtos.UnprocessableEntityResponseDto,
     ...options,
     status: HttpStatus.UNPROCESSABLE_ENTITY
   });
@@ -229,6 +248,7 @@ export const ApiUnsupportedMediaTypeResponse = (
   options: ApiResponseOptions = {}
 ) =>
   ApiResponse({
+    type: ErrorResponseDtos.UnsupportedMediaTypeResponseDto,
     ...options,
     status: HttpStatus.UNSUPPORTED_MEDIA_TYPE
   });

--- a/lib/types/error-responses.dto.ts
+++ b/lib/types/error-responses.dto.ts
@@ -1,0 +1,233 @@
+import { HttpStatus } from '@nestjs/common/enums/http-status.enum';
+import { ApiProperty } from "../decorators";
+
+export class BadRequestResponseDto {
+  @ApiProperty({
+    enum: [HttpStatus.BAD_REQUEST]
+  })
+  statusCode: number
+
+  @ApiProperty()
+  message: string[];
+
+  @ApiProperty({
+    enum: ['Bad Request']
+  })
+  error: string;
+}
+
+export class UnauthorizedResponseDto {
+  @ApiProperty({
+    enum: [HttpStatus.UNAUTHORIZED]
+  })
+  statusCode: number
+
+  @ApiProperty({
+    enum: ['Unauthorized']
+  })
+  message: string;
+}
+
+export class TooManyRequestsResponseDto {
+  @ApiProperty({
+    enum: [HttpStatus.TOO_MANY_REQUESTS]
+  })
+  statusCode: number
+
+  @ApiProperty({
+    enum: ['Too Many Requests']
+  })
+  message: string;
+}
+
+export class NotFoundResponseDto {
+  @ApiProperty({
+    enum: [HttpStatus.NOT_FOUND]
+  })
+  statusCode: number
+
+  @ApiProperty({
+    enum: ['Not Found']
+  })
+  message: string;
+}
+
+export class InternalServerErrorResponseDto {
+  @ApiProperty({
+    enum: [HttpStatus.INTERNAL_SERVER_ERROR]
+  })
+  statusCode: number
+
+  @ApiProperty({
+    enum: ['Internal Server Error']
+  })
+  message: string;
+}
+
+export class BadGatewayResponseDto {
+  @ApiProperty({
+    enum: [HttpStatus.BAD_GATEWAY]
+  })
+  statusCode: number
+
+  @ApiProperty({
+    enum: ['Bad Gateway']
+  })
+  message: string;
+}
+
+export class ConflictResponseDto {
+  @ApiProperty({
+    enum: [HttpStatus.CONFLICT]
+  })
+  statusCode: number
+
+  @ApiProperty({
+    enum: ['Conflict']
+  })
+  message: string;
+}
+
+export class ForbiddenResponseDto {
+  @ApiProperty({
+    enum: [HttpStatus.FORBIDDEN]
+  })
+  statusCode: number
+
+  @ApiProperty({
+    enum: ['Forbidden']
+  })
+  message: string;
+}
+
+export class GatewayTimeoutResponseDto {
+  @ApiProperty({
+    enum: [HttpStatus.GATEWAY_TIMEOUT]
+  })
+  statusCode: number
+
+  @ApiProperty({
+    enum: ['Gateway Timeout']
+  })
+  message: string;
+}
+
+export class GoneResponseDto {
+  @ApiProperty({
+    enum: [HttpStatus.GONE]
+  })
+  statusCode: number
+
+  @ApiProperty({
+    enum: ['Gone']
+  })
+  message: string;
+}
+
+export class MethodNotAllowedResponseDto {
+  @ApiProperty({
+    enum: [HttpStatus.METHOD_NOT_ALLOWED]
+  })
+  statusCode: number
+
+  @ApiProperty({
+    enum: ['Method Not Allowed']
+  })
+  message: string;
+}
+
+export class NotAcceptableResponseDto {
+  @ApiProperty({
+    enum: [HttpStatus.NOT_ACCEPTABLE]
+  })
+  statusCode: number
+
+  @ApiProperty({
+    enum: ['Not Acceptable']
+  })
+  message: string;
+}
+
+export class NotImplementedResponseDto {
+  @ApiProperty({
+    enum: [HttpStatus.NOT_IMPLEMENTED]
+  })
+  statusCode: number
+
+  @ApiProperty({
+    enum: ['Not Implemented']
+  })
+  message: string;
+}
+
+export class PreconditionFailedResponseDto {
+  @ApiProperty({
+    enum: [HttpStatus.PRECONDITION_FAILED]
+  })
+  statusCode: number
+
+  @ApiProperty({
+    enum: ['Precondition Failed']
+  })
+  message: string;
+}
+
+export class PayloadTooLargeResponseDto {
+  @ApiProperty({
+    enum: [HttpStatus.PAYLOAD_TOO_LARGE]
+  })
+  statusCode: number
+
+  @ApiProperty({
+    enum: ['Payload Too Large']
+  })
+  message: string;
+}
+
+export class RequestTimeoutResponseDto {
+  @ApiProperty({
+    enum: [HttpStatus.REQUEST_TIMEOUT]
+  })
+  statusCode: number
+
+  @ApiProperty({
+    enum: ['Request Timeout']
+  })
+  message: string;
+}
+
+export class ServiceUnavailableResponseDto {
+  @ApiProperty({
+    enum: [HttpStatus.SERVICE_UNAVAILABLE]
+  })
+  statusCode: number
+
+  @ApiProperty({
+    enum: ['Service Unavailable']
+  })
+  message: string;
+}
+
+export class UnprocessableEntityResponseDto {
+  @ApiProperty({
+    enum: [HttpStatus.UNPROCESSABLE_ENTITY]
+  })
+  statusCode: number
+
+  @ApiProperty({
+    enum: ['Unprocessable Entity']
+  })
+  message: string;
+}
+
+export class UnsupportedMediaTypeResponseDto {
+  @ApiProperty({
+    enum: [HttpStatus.UNSUPPORTED_MEDIA_TYPE]
+  })
+  statusCode: number
+
+  @ApiProperty({
+    enum: ['Unsupported Media Type']
+  })
+  message: string;
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently each of the error api response decorators do not specify a type, despite the responses having common information. 

## What is the new behavior?

This PR adds a DTO class for each response type and sets them as the default value for `type`.  It is set before the spread operator so that the use can still pass in their own type.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

This adds a default type to each response, which may not be expected.
