### PR TITLE
fix(@nestjs/swagger): fix use swagger prefix based on nestjs applicat…

### DIFF
--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -9,6 +9,7 @@ import {
 } from './interfaces';
 import { SwaggerScanner } from './swagger-scanner';
 import { assignTwoLevelsDeep } from './utils/assign-two-levels-deep';
+import { getGlobalPrefix } from './utils/get-global-prefix';
 import { validatePath } from './utils/validate-path.util';
 
 export class SwaggerModule {
@@ -64,7 +65,8 @@ export class SwaggerModule {
     options?: ExpressSwaggerCustomOptions
   ) {
     const httpAdapter = app.getHttpAdapter();
-    const finalPath = validatePath(path);
+    const globalPrefix = getGlobalPrefix(app);
+    const finalPath = `${validatePath(globalPrefix)}${validatePath(path)}`;
     const swaggerUi = loadPackage('swagger-ui-express', 'SwaggerModule', () =>
       require('swagger-ui-express')
     );

--- a/lib/swagger-scanner.ts
+++ b/lib/swagger-scanner.ts
@@ -15,6 +15,7 @@ import { SchemaObjectFactory } from './services/schema-object-factory';
 import { SwaggerTypesMapper } from './services/swagger-types-mapper';
 import { SwaggerExplorer } from './swagger-explorer';
 import { SwaggerTransformer } from './swagger-transformer';
+import { getGlobalPrefix } from './utils/get-global-prefix';
 import { stripLastSlash } from './utils/strip-last-slash.util';
 
 export class SwaggerScanner {
@@ -45,7 +46,7 @@ export class SwaggerScanner {
       includedModules
     );
     const globalPrefix = !ignoreGlobalPrefix
-      ? stripLastSlash(this.getGlobalPrefix(app))
+      ? stripLastSlash(getGlobalPrefix(app))
       : '';
 
     const denormalizedPaths = modules.map(
@@ -137,11 +138,6 @@ export class SwaggerScanner {
     extraModels.forEach((item) => {
       this.schemaObjectFactory.exploreModelSchema(item, schemas);
     });
-  }
-
-  private getGlobalPrefix(app: INestApplication): string {
-    const internalConfigRef = (app as any).config;
-    return (internalConfigRef && internalConfigRef.getGlobalPrefix()) || '';
   }
 
   private getModulePathMetadata(

--- a/lib/utils/get-global-prefix.ts
+++ b/lib/utils/get-global-prefix.ts
@@ -1,0 +1,6 @@
+import { INestApplication } from "@nestjs/common";
+
+export function getGlobalPrefix(app: INestApplication): string {
+  const internalConfigRef = (app as any).config;
+  return (internalConfigRef && internalConfigRef.getGlobalPrefix()) || '';
+}


### PR DESCRIPTION
Fixes the swagger UI prefix based on nestjs application global prefix using express server.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When the server is express, the swagger endpoint (first parameter of `SwaggerModule.setup` function) is not prepended to global prefix set in Nestjs Application.

Example of code:
```ts
const app = await NestFactory.create(AppModule);
app.setGlobalPrefix('my-prefix');

const swaggerConfig = new DocumentBuilder()
  .setTitle('My API')
  .setDescription('My API')
  .setVersion('1.0')
  .build();
const swaggerDocument = SwaggerModule.createDocument(app, swaggerConfig);
SwaggerModule.setup('api-docs', app, swaggerDocument);

await app.listen(3000);
```

The expected swagger UI endpoint is `http://localhost:3000/my-prefix/api-docs`, but it gets `http://localhost:3000/api-docs` - the prefix is not applied.

Related issues #1469, #105 and #786.


## What is the new behavior?
Based on previous code example, the swagger UI endpoint is now `http://localhost:3000/my-prefix/api-docs`, instead `http://localhost:3000/api-docs`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
1. I removed the `getGlobalPrefix` function from Swagger-Scanner and put at Utils;
2. Sorry for my english.