### PR TITLE
feat(): add shim file for browsers

### DIFF
--- a/lib/extra/swagger-shim.ts
+++ b/lib/extra/swagger-shim.ts
@@ -1,0 +1,166 @@
+/* eslint-disable @typescript-eslint/no-empty-function */
+export function ApiProperty() {
+  return () => {};
+}
+export function ApiPropertyOptional() {
+  return () => {};
+}
+export function ApiResponseProperty() {
+  return () => {};
+}
+export function ApiBasicAuth() {
+  return () => {};
+}
+export function ApiBearerAuth() {
+  return () => {};
+}
+export function ApiBody() {
+  return () => {};
+}
+export function ApiConsumes() {
+  return () => {};
+}
+export function ApiCookieAuth() {
+  return () => {};
+}
+export function ApiExcludeEndpoint() {
+  return () => {};
+}
+export function ApiExcludeController() {
+  return () => {};
+}
+export function ApiExtraModels() {
+  return () => {};
+}
+export function ApiHeader() {
+  return () => {};
+}
+export function ApiHeaders() {
+  return () => {};
+}
+export function ApiHideProperty() {
+  return () => {};
+}
+export function ApiOAuth2() {
+  return () => {};
+}
+export function ApiOperation() {
+  return () => {};
+}
+export function ApiParam() {
+  return () => {};
+}
+export function ApiProduces() {
+  return () => {};
+}
+export function ApiQuery() {
+  return () => {};
+}
+export function ApiResponse() {
+  return () => {};
+}
+export function ApiOkResponse() {
+  return () => {};
+}
+export function ApiCreatedResponse() {
+  return () => {};
+}
+export function ApiAcceptedResponse() {
+  return () => {};
+}
+export function ApiNoContentResponse() {
+  return () => {};
+}
+export function ApiMovedPermanentlyResponse() {
+  return () => {};
+}
+export function ApiFoundResponse() {
+  return () => {};
+}
+export function ApiBadRequestResponse() {
+  return () => {};
+}
+export function ApiUnauthorizedResponse() {
+  return () => {};
+}
+export function ApiTooManyRequestsResponse() {
+  return () => {};
+}
+export function ApiNotFoundResponse() {
+  return () => {};
+}
+export function ApiInternalServerErrorResponse() {
+  return () => {};
+}
+export function ApiBadGatewayResponse() {
+  return () => {};
+}
+export function ApiConflictResponse() {
+  return () => {};
+}
+export function ApiForbiddenResponse() {
+  return () => {};
+}
+export function ApiGatewayTimeoutResponse() {
+  return () => {};
+}
+export function ApiGoneResponse() {
+  return () => {};
+}
+export function ApiMethodNotAllowedResponse() {
+  return () => {};
+}
+export function ApiNotAcceptableResponse() {
+  return () => {};
+}
+export function ApiNotImplementedResponse() {
+  return () => {};
+}
+export function ApiPreconditionFailedResponse() {
+  return () => {};
+}
+export function ApiPayloadTooLargeResponse() {
+  return () => {};
+}
+export function ApiRequestTimeoutResponse() {
+  return () => {};
+}
+export function ApiServiceUnavailableResponse() {
+  return () => {};
+}
+export function ApiUnprocessableEntityResponse() {
+  return () => {};
+}
+export function ApiUnsupportedMediaTypeResponse() {
+  return () => {};
+}
+export function ApiDefaultResponse() {
+  return () => {};
+}
+export function ApiSecurity() {
+  return () => {};
+}
+export function ApiTags() {
+  return () => {};
+}
+export function ApiExtension() {
+  return () => {};
+}
+export function DocumentBuilder() {
+  return () => {};
+}
+export function SwaggerModule() {
+  return () => {};
+}
+export function IntersectionType() {
+  return () => {};
+}
+export function OmitType() {
+  return () => {};
+}
+export function PartialType() {
+  return () => {};
+}
+export function PickType() {
+  return () => {};
+}

--- a/test/extra/shim.spec.ts
+++ b/test/extra/shim.spec.ts
@@ -1,0 +1,19 @@
+import * as Shim from '../../lib/extra/swagger-shim';
+import * as Actual from '../../lib';
+
+describe('Shim file', () => {
+  it('contains all types export by package', () => {
+    const exceptions = ['getSchemaPath', 'refs'];
+
+    const shimExportNames = Object.keys(Shim);
+    const packageExportNames = Object.keys(Actual);
+
+    const exportsMissingInShim = packageExportNames.filter(
+      (exportName) =>
+        shimExportNames.indexOf(exportName) === -1 &&
+        exceptions.indexOf(exportName) === -1
+    );
+
+    expect(exportsMissingInShim).toEqual([]);
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfils the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1037


## What is the new behavior?

Developers can use classes decorated with decorators from `@nestjs/swagger` in typescript applications that are run in the browser. This is done by telling either the typescript compiler or a bundler used in the browser application to use the newly added shim file instead of the actual package. The shim file is a lot smaller in size and does not introduce any dependencies on node packages that would otherwise require even larger polyfills.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information