### PR TITLE
feat(@nestjs/swagger): add option in SwaggerModule.setup to use nestjs application global prefix

### DIFF
--- a/lib/interfaces/swagger-custom-options.interface.ts
+++ b/lib/interfaces/swagger-custom-options.interface.ts
@@ -1,4 +1,8 @@
-export interface ExpressSwaggerCustomOptions {
+interface CommonSwaggerCustomOptions {
+  useGlobalPrefix?: boolean,
+}
+
+export interface ExpressSwaggerCustomOptions extends CommonSwaggerCustomOptions {
   explorer?: boolean;
   swaggerOptions?: Record<string, any>;
   customCss?: string;
@@ -12,7 +16,7 @@ export interface ExpressSwaggerCustomOptions {
   urls?: Record<'url' | 'name', string>[];
 }
 
-export interface FastifySwaggerCustomOptions {
+export interface FastifySwaggerCustomOptions extends CommonSwaggerCustomOptions {
   uiConfig?: Record<string, any>;
 }
 

--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -9,6 +9,7 @@ import {
 } from './interfaces';
 import { SwaggerScanner } from './swagger-scanner';
 import { assignTwoLevelsDeep } from './utils/assign-two-levels-deep';
+import { getGlobalPrefix } from './utils/get-global-prefix';
 import { validatePath } from './utils/validate-path.util';
 
 export class SwaggerModule {
@@ -41,16 +42,22 @@ export class SwaggerModule {
     options?: SwaggerCustomOptions
   ) {
     const httpAdapter = app.getHttpAdapter();
+    const globalPrefix = getGlobalPrefix(app);
+    const finalPath = validatePath(
+      (options?.useGlobalPrefix && globalPrefix && !globalPrefix.match(/^(\/?)$/))
+      ? `${globalPrefix}${validatePath(path)}`
+      : path
+    );
     if (httpAdapter && httpAdapter.getType() === 'fastify') {
       return this.setupFastify(
-        path,
+        finalPath,
         httpAdapter,
         document,
         options as FastifySwaggerCustomOptions
       );
     }
     return this.setupExpress(
-      path,
+      finalPath,
       app,
       document,
       options as ExpressSwaggerCustomOptions
@@ -64,15 +71,14 @@ export class SwaggerModule {
     options?: ExpressSwaggerCustomOptions
   ) {
     const httpAdapter = app.getHttpAdapter();
-    const finalPath = validatePath(path);
     const swaggerUi = loadPackage('swagger-ui-express', 'SwaggerModule', () =>
       require('swagger-ui-express')
     );
     const swaggerHtml = swaggerUi.generateHTML(document, options);
-    app.use(finalPath, swaggerUi.serveFiles(document, options));
+    app.use(path, swaggerUi.serveFiles(document, options));
 
-    httpAdapter.get(finalPath, (req, res) => res.send(swaggerHtml));
-    httpAdapter.get(finalPath + '-json', (req, res) => res.json(document));
+    httpAdapter.get(path, (req, res) => res.send(swaggerHtml));
+    httpAdapter.get(path + '-json', (req, res) => res.json(document));
   }
 
   private static setupFastify(

--- a/lib/swagger-scanner.ts
+++ b/lib/swagger-scanner.ts
@@ -15,6 +15,7 @@ import { SchemaObjectFactory } from './services/schema-object-factory';
 import { SwaggerTypesMapper } from './services/swagger-types-mapper';
 import { SwaggerExplorer } from './swagger-explorer';
 import { SwaggerTransformer } from './swagger-transformer';
+import { getGlobalPrefix } from './utils/get-global-prefix';
 import { stripLastSlash } from './utils/strip-last-slash.util';
 
 export class SwaggerScanner {
@@ -45,7 +46,7 @@ export class SwaggerScanner {
       includedModules
     );
     const globalPrefix = !ignoreGlobalPrefix
-      ? stripLastSlash(this.getGlobalPrefix(app))
+      ? stripLastSlash(getGlobalPrefix(app))
       : '';
 
     const denormalizedPaths = modules.map(
@@ -137,11 +138,6 @@ export class SwaggerScanner {
     extraModels.forEach((item) => {
       this.schemaObjectFactory.exploreModelSchema(item, schemas);
     });
-  }
-
-  private getGlobalPrefix(app: INestApplication): string {
-    const internalConfigRef = (app as any).config;
-    return (internalConfigRef && internalConfigRef.getGlobalPrefix()) || '';
   }
 
   private getModulePathMetadata(

--- a/lib/utils/get-global-prefix.ts
+++ b/lib/utils/get-global-prefix.ts
@@ -1,0 +1,6 @@
+import { INestApplication } from "@nestjs/common";
+
+export function getGlobalPrefix(app: INestApplication): string {
+  const internalConfigRef = (app as any).config;
+  return (internalConfigRef && internalConfigRef.getGlobalPrefix()) || '';
+}


### PR DESCRIPTION
Added an option in SwaggerModule.setup to use nestjs application global prefix. It is optional and the thefault value is `false`. The default behavior of the application is the same.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The swagger path (first parameter of SwaggerModule.setup function) is not prepended to global prefix set in Nestjs Application.

Example of code:

```ts
const app = await NestFactory.create(AppModule);
app.setGlobalPrefix('my-prefix');

const swaggerConfig = new DocumentBuilder()
  .setTitle('My API')
  .setDescription('My API')
  .setVersion('1.0')
  .build();
const swaggerDocument = SwaggerModule.createDocument(app, swaggerConfig);
SwaggerModule.setup('api-docs', app, swaggerDocument);

await app.listen(3000);
```

If the developer wants to serve Swagger UI using the global prefix, he should set the swagger path manually:

```ts
const app = await NestFactory.create(AppModule);
app.setGlobalPrefix('my-prefix');

const swaggerConfig = ...;
const swaggerDocument = ...;
SwaggerModule.setup('my-prefix/api-docs', app, swaggerDocument);

await app.listen(3000);
```

Related issues #1469, #105 and #786.

## What is the new behavior?

A new optional option was added to `SwaggerCustomOptions` called `useGlobalPrefix` allowing the develper specify if the Swagger UI should be served behind the global prefix.

Using the example above, he just add the `useGlobalPrefix` option in `SwaggerModule.setup`:

```ts
...
SwaggerModule.setup('api-docs', app, swaggerDocument, {
  useGlobalPrefix: true,
});
...
```

The Swagger UI will be served at `http://localhost:3000/my-prefix/api-docs`.

The default behavior is `useGlobalPrefix = false`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
1. I removed the getGlobalPrefix function from Swagger-Scanner and put at Utils;
2. Sorry for my english.