### PR TITLE
feat(): add fastify-swagger options

### DIFF
--- a/lib/interfaces/swagger-custom-options.interface.ts
+++ b/lib/interfaces/swagger-custom-options.interface.ts
@@ -14,6 +14,9 @@ export interface ExpressSwaggerCustomOptions {
 
 export interface FastifySwaggerCustomOptions {
   uiConfig?: Record<string, any>;
+  initOAuth?: Record<string, any>;
+  staticCSP?: boolean | string | Record<string, string | string[]>;
+  transformStaticCSP?: (header: string) => string;
 }
 
 export type SwaggerCustomOptions =

--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -103,7 +103,10 @@ export class SwaggerModule {
           specification: {
             document
           },
-          uiConfig: (options || {}).uiConfig
+          uiConfig: options?.uiConfig,
+          initOAuth: options?.initOAuth,
+          staticCSP: options?.staticCSP,
+          transformStaticCSP: options?.transformStaticCSP
         }
       );
     });


### PR DESCRIPTION
Allow the use of "initOAuth", "staticCSP" and "transformStaticCSP" options to fastify-swagger

Closes #932

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Using @nestjs/swagger with Fastify, you cannot pass the "initOAuth", "staticCSP" and "transformStaticCSP" options at fastify-swagger plugin registration.

Issue Number: #932


## What is the new behavior?

You can pass on "initOAuth", "staticCSP" and "transformStaticCSP" as per [fastify-swagger's documentation](https://github.com/fastify/fastify-swagger#options).

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The existing solution to the problem #932 does not satisfy Content Security Policy (CSP) ["unsafe-inline keyword"](https://content-security-policy.com/unsafe-inline/)
I found the staticCSP option in the fastify-swagger module. If this option is set to "true", then [the hash is used](https://content-security-policy.com/hash/
)
Analysis of the other available parameters showed that the associated transformStaticCSP parameter could also be transfer. And also the initOAuth parameter, which may be useful to someone.