### PR TITLE
fix: allow get type reference from node_modules

### DIFF
--- a/lib/plugin/visitors/controller-class.visitor.ts
+++ b/lib/plugin/visitors/controller-class.visitor.ts
@@ -227,9 +227,6 @@ export class ControllerClassVisitor extends AbstractFileVisitor {
     if (!typeReference) {
       return undefined;
     }
-    if (typeReference.includes('node_modules')) {
-      return undefined;
-    }
     typeReference = replaceImportPath(typeReference, hostFilename);
     return factory.createPropertyAssignment(
       'type',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

We have a big project with some microservices on NestJS. And we like to share dtos between microservices through npm packages. But we can't use this dtos in swagger, because swagger compiler plugin don't resolve path to dto when path to dto contain `node_modules`. Workaround is use `ApiOkResponse` to set type manually.

Source code:

```typescript
import {ProductDto} from '@enterprise-scope/some-nest-api-client';
import {Controller, Post} from '@nestjs/common';

@Controller({
  path: '/products',
  version: '1',
})
export class ProductsController {
  @Post('/')
  public createProduct(): Promise<ProductDto> {
    throw new Error('NotImplementedException');
  }
}
````

How swagger looks:

![изображение](https://user-images.githubusercontent.com/18448635/133620373-ebb52460-87db-43a5-a696-36f0131ea9f3.png)

Compiled code don't contains `type` property in `openapi.ApiResponse`:

```typescript
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
exports.ProductsController = void 0;
const tslib_1 = require("tslib");
const openapi = require("@nestjs/swagger");
const common_1 = require("@nestjs/common");
let ProductsController = class ProductsController {
    createProduct() {
        throw new Error('NotImplementedException');
    }
};
tslib_1.__decorate([
    common_1.Post('/'),
    openapi.ApiResponse({ status: 201 }),
    tslib_1.__metadata("design:type", Function),
    tslib_1.__metadata("design:paramtypes", []),
    tslib_1.__metadata("design:returntype", Promise)
], ProductsController.prototype, "createProduct", null);
ProductsController = tslib_1.__decorate([
    common_1.Controller({
        path: '/products',
        version: '1',
    })
], ProductsController);
exports.ProductsController = ProductsController;
````

## What is the new behavior?

I think some preparatory work was done in #1411 and all that remains is to remove the extra if.

How swagger looks:

![изображение](https://user-images.githubusercontent.com/18448635/133622745-0f8e3d7c-d5b9-4c6d-8bee-f05cef87ff5f.png)

Compiled code contains `type` property in `openapi.ApiResponse`:

```typescript
"use strict";
Object.defineProperty(exports, "__esModule", { value: true });
exports.ProductsController = void 0;
const tslib_1 = require("tslib");
const openapi = require("@nestjs/swagger");
const common_1 = require("@nestjs/common");
let ProductsController = class ProductsController {
    createProduct() {
        throw new Error('NotImplementedException');
    }
};
tslib_1.__decorate([
    common_1.Post('/'),
    openapi.ApiResponse({ status: 201, type: require("@enterprise-scope/some-nest-api-client/dist/dtos/common/product.dto").ProductDto }),
    tslib_1.__metadata("design:type", Function),
    tslib_1.__metadata("design:paramtypes", []),
    tslib_1.__metadata("design:returntype", Promise)
], ProductsController.prototype, "createProduct", null);
ProductsController = tslib_1.__decorate([
    common_1.Controller({
        path: '/products',
        version: '1',
    })
], ProductsController);
exports.ProductsController = ProductsController;
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

- `@nestjs/swagger`: `5.0.9`
