### PR TITLE
fix(swagger): @ApiHeader default type instead of overwriting

### DIFF
--- a/lib/decorators/api-header.decorator.ts
+++ b/lib/decorators/api-header.decorator.ts
@@ -26,8 +26,8 @@ export function ApiHeader(
       description: options.description,
       required: options.required,
       schema: {
-        ...(options.schema || {}),
-        type: 'string'
+        type: 'string',
+        ...(options.schema || {})
       }
     },
     negate(isUndefined)


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1653


## What is the new behavior?
string ist the default type for ApiHeader, but can be overwritten.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information