### PR TITLE
feat: Added interface for swagger options

### DIFF
--- a/lib/interfaces/swagger-custom-options.interface.ts
+++ b/lib/interfaces/swagger-custom-options.interface.ts
@@ -1,5 +1,5 @@
 interface CommonSwaggerCustomOptions {
-  useGlobalPrefix?: boolean,
+  useGlobalPrefix?: boolean;
 }
 
 /**
@@ -7,108 +7,116 @@ interface CommonSwaggerCustomOptions {
  * {@link https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md}
  */
 export interface SwaggerConfigurationOptions {
+  /**
+   * If set to true, enables deep linking for tags and operations.
+   * @link https://swagger.io/docs/open-source-tools/swagger-ui/usage/deep-linking/
+   */
+  deepLinking?: boolean;
 
-    /**
-     * If set to true, enables deep linking for tags and operations.
-     * @link https://swagger.io/docs/open-source-tools/swagger-ui/usage/deep-linking/ 
-     */
-    deepLinking?: boolean;
+  /**
+   * Controls the display of operationId in operations list. The default is `false`.
+   */
+  displayOperationId?: boolean;
 
-    /**
-     * Controls the display of operationId in operations list. The default is `false`.
-     */
-    displayOperationId?: boolean;
+  /**
+   * The default expansion depth for models (set to -1 completely hide the models).
+   */
+  defaultModelsExpandDepth?: number;
 
-    /**
-     * The default expansion depth for models (set to -1 completely hide the models).
-     */
-    defaultModelsExpandDepth?: number;
+  /**
+   * The default expansion depth for the model on the model-example section.
+   */
+  defaultModelExpandDepth?: number;
 
-    /**
-     * The default expansion depth for the model on the model-example section.
-     */
-    defaultModelExpandDepth?: number;
+  /**
+   * Controls how the model is shown when the API is first rendered.
+   * (The user can always switch the rendering for a given model by clicking the 'Model' and 'Example Value' links.)
+   */
+  defaultModelRendering?: 'example' | 'model';
 
-    /**
-     * Controls how the model is shown when the API is first rendered.  
-     * (The user can always switch the rendering for a given model by clicking the 'Model' and 'Example Value' links.)
-     */
-    defaultModelRendering?: 'example' | 'model';
+  /**
+   * Controls the display of the request duration (in milliseconds) for "Try it out" requests.
+   */
+  displayRequestDuration?: boolean;
 
-    /**
-     * Controls the display of the request duration (in milliseconds) for "Try it out" requests.
-     */
-    displayRequestDuration?: boolean;
+  /**
+   * Apply a sort to the operation list of each API.
+   *
+   * It can be `alpha` (sort by paths alphanumerically), `method` (sort by HTTP method) or a function (see `Array.prototype.sort()` to know how sort function works).
+   * Default is the order returned by the server unchanged.
+   */
+  operationsSorter?: 'alpha' | 'method' | ((a: any, b: any) => number);
 
-    /**
-     * Apply a sort to the operation list of each API.
-     * 
-     * It can be `alpha` (sort by paths alphanumerically), `method` (sort by HTTP method) or a function (see `Array.prototype.sort()` to know how sort function works).  
-     * Default is the order returned by the server unchanged.
-     */
-    operationsSorter?: 'alpha' | 'method' | ((a: any, b: any) => number);
+  /**
+   * Controls the display of vendor extension (x-) fields and values for Operations, Parameters, Responses, and Schema.
+   */
+  showExtensions?: boolean;
 
-    /**
-     * Controls the display of vendor extension (x-) fields and values for Operations, Parameters, Responses, and Schema.
-     */
-    showExtensions?: boolean;
+  /**
+   * Controls the display of extensions (`pattern, maxLength, minLength, maximum, minimum`) fields and values for Parameters.
+   */
+  showCommonExtensions?: boolean;
 
-    /**
-     * Controls the display of extensions (`pattern, maxLength, minLength, maximum, minimum`) fields and values for Parameters.
-     */
-    showCommonExtensions?: boolean;
+  /**
+   * Apply a sort to the tag list of each API.
+   *
+   * It can be `alpha` (sort by paths alphanumerically) or a function (see `Array.prototype.sort()` to learn how to write a sort function).
+   * Two tag name strings are passed to the sorter for each pass.
+   * Default is the order determined by Swagger UI.
+   */
+  tagsSorter?: 'alpha' | ((a: any, b: any) => number);
 
-    /**
-     * Apply a sort to the tag list of each API.
-     * 
-     * It can be `alpha` (sort by paths alphanumerically) or a function (see `Array.prototype.sort()` to learn how to write a sort function).  
-     * Two tag name strings are passed to the sorter for each pass.  
-     * Default is the order determined by Swagger UI.
-     */
-    tagsSorter?: 'alpha' | ((a: any, b: any) => number);
+  /**
+   * When enabled, sanitizer will leave `style`, `class` and `data-*` attributes untouched on all HTML Elements declared inside markdown strings.
+   * This parameter is Deprecated and will be removed in `4.0.0`.
+   */
+  useUnsafeMarkdown?: boolean;
 
-    /**
-     * When enabled, sanitizer will leave `style`, `class` and `data-*` attributes untouched on all HTML Elements declared inside markdown strings.  
-     * This parameter is Deprecated and will be removed in `4.0.0`.
-     */
-    useUnsafeMarkdown?: boolean;
-
-    /**
-     * Set to `false` to deactivate syntax highlighting of payloads and cURL command, can be otherwise an object with the `activate` and `theme` properties.
-     */
-    syntaxHighlight?: false | {
+  /**
+   * Set to `false` to deactivate syntax highlighting of payloads and cURL command, can be otherwise an object with the `activate` and `theme` properties.
+   */
+  syntaxHighlight?:
+    | false
+    | {
         /**
          * Whether syntax highlighting should be activated or not.
          */
-        activate: boolean,
+        activate: boolean;
         /**
          * Highlight.js syntax coloring theme to use. (Only these 6 styles are available.)
          */
-        theme: 'agate' | 'arta' | 'monokai' | 'nord' | 'obsidian' | 'tomorrow-night'
-    };
+        theme:
+          | 'agate'
+          | 'arta'
+          | 'monokai'
+          | 'nord'
+          | 'obsidian'
+          | 'tomorrow-night';
+      };
 
-    /**
-     * Controls whether the "Try it out" section should be enabled by default.
-     */
-    tryItOutEnabled?: boolean;
+  /**
+   * Controls whether the "Try it out" section should be enabled by default.
+   */
+  tryItOutEnabled?: boolean;
 
-    /**
-     * If set, enables filtering.
-     * 
-     * The top bar will show an edit box that you can use to filter the tagged operations that are shown.  
-     * Can be Boolean to enable or disable, or a string, in which case filtering will be enabled using that string as the filter expression.  
-     * Filtering is case sensitive matching the filter expression anywhere inside the tag.
-     */
-    filter?: false | String;
-    /**
-     * If set to `true`, it persists authorization data and it would not be lost on browser close/refresh
-     */
-    persistAuthorization?: boolean;
+  /**
+   * If set, enables filtering.
+   *
+   * The top bar will show an edit box that you can use to filter the tagged operations that are shown.
+   * Can be Boolean to enable or disable, or a string, in which case filtering will be enabled using that string as the filter expression.
+   * Filtering is case sensitive matching the filter expression anywhere inside the tag.
+   */
+  filter?: false | String;
+  /**
+   * If set to `true`, it persists authorization data and it would not be lost on browser close/refresh
+   */
+  persistAuthorization?: boolean;
 
-    [key: string]: any;
+  [key: string]: any;
 }
 
-export interface ExpressSwaggerCustomOptions extends CommonSwaggerCustomOptions {
+export interface ExpressSwaggerCustomOptions
+  extends CommonSwaggerCustomOptions {
   explorer?: boolean;
   swaggerOptions?: SwaggerConfigurationOptions;
   customCss?: string;
@@ -122,7 +130,8 @@ export interface ExpressSwaggerCustomOptions extends CommonSwaggerCustomOptions 
   urls?: Record<'url' | 'name', string>[];
 }
 
-export interface FastifySwaggerCustomOptions extends CommonSwaggerCustomOptions {
+export interface FastifySwaggerCustomOptions
+  extends CommonSwaggerCustomOptions {
   uiConfig?: Partial<{
     deepLinking: boolean;
     displayOperationId: boolean;

--- a/lib/interfaces/swagger-custom-options.interface.ts
+++ b/lib/interfaces/swagger-custom-options.interface.ts
@@ -2,6 +2,10 @@ interface CommonSwaggerCustomOptions {
   useGlobalPrefix?: boolean,
 }
 
+/**
+ * Check out all available `swagger-ui` options here:
+ * {@link https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md}
+ */
 export interface SwaggerConfigurationOptions {
 
     /**

--- a/lib/interfaces/swagger-custom-options.interface.ts
+++ b/lib/interfaces/swagger-custom-options.interface.ts
@@ -2,9 +2,111 @@ interface CommonSwaggerCustomOptions {
   useGlobalPrefix?: boolean,
 }
 
+export interface SwaggerConfigurationOptions {
+
+    /**
+     * If set to true, enables deep linking for tags and operations.
+     * @link https://swagger.io/docs/open-source-tools/swagger-ui/usage/deep-linking/ 
+     */
+    deepLinking?: boolean;
+
+    /**
+     * Controls the display of operationId in operations list. The default is `false`.
+     */
+    displayOperationId?: boolean;
+
+    /**
+     * The default expansion depth for models (set to -1 completely hide the models).
+     */
+    defaultModelsExpandDepth?: number;
+
+    /**
+     * The default expansion depth for the model on the model-example section.
+     */
+    defaultModelExpandDepth?: number;
+
+    /**
+     * Controls how the model is shown when the API is first rendered.  
+     * (The user can always switch the rendering for a given model by clicking the 'Model' and 'Example Value' links.)
+     */
+    defaultModelRendering?: 'example' | 'model';
+
+    /**
+     * Controls the display of the request duration (in milliseconds) for "Try it out" requests.
+     */
+    displayRequestDuration?: boolean;
+
+    /**
+     * Apply a sort to the operation list of each API.
+     * 
+     * It can be `alpha` (sort by paths alphanumerically), `method` (sort by HTTP method) or a function (see `Array.prototype.sort()` to know how sort function works).  
+     * Default is the order returned by the server unchanged.
+     */
+    operationsSorter?: 'alpha' | 'method' | ((a: any, b: any) => number);
+
+    /**
+     * Controls the display of vendor extension (x-) fields and values for Operations, Parameters, Responses, and Schema.
+     */
+    showExtensions?: boolean;
+
+    /**
+     * Controls the display of extensions (`pattern, maxLength, minLength, maximum, minimum`) fields and values for Parameters.
+     */
+    showCommonExtensions?: boolean;
+
+    /**
+     * Apply a sort to the tag list of each API.
+     * 
+     * It can be `alpha` (sort by paths alphanumerically) or a function (see `Array.prototype.sort()` to learn how to write a sort function).  
+     * Two tag name strings are passed to the sorter for each pass.  
+     * Default is the order determined by Swagger UI.
+     */
+    tagsSorter?: 'alpha' | ((a: any, b: any) => number);
+
+    /**
+     * When enabled, sanitizer will leave `style`, `class` and `data-*` attributes untouched on all HTML Elements declared inside markdown strings.  
+     * This parameter is Deprecated and will be removed in `4.0.0`.
+     */
+    useUnsafeMarkdown?: boolean;
+
+    /**
+     * Set to `false` to deactivate syntax highlighting of payloads and cURL command, can be otherwise an object with the `activate` and `theme` properties.
+     */
+    syntaxHighlight?: false | {
+        /**
+         * Whether syntax highlighting should be activated or not.
+         */
+        activate: boolean,
+        /**
+         * Highlight.js syntax coloring theme to use. (Only these 6 styles are available.)
+         */
+        theme: 'agate' | 'arta' | 'monokai' | 'nord' | 'obsidian' | 'tomorrow-night'
+    };
+
+    /**
+     * Controls whether the "Try it out" section should be enabled by default.
+     */
+    tryItOutEnabled?: boolean;
+
+    /**
+     * If set, enables filtering.
+     * 
+     * The top bar will show an edit box that you can use to filter the tagged operations that are shown.  
+     * Can be Boolean to enable or disable, or a string, in which case filtering will be enabled using that string as the filter expression.  
+     * Filtering is case sensitive matching the filter expression anywhere inside the tag.
+     */
+    filter?: false | String;
+    /**
+     * If set to `true`, it persists authorization data and it would not be lost on browser close/refresh
+     */
+    persistAuthorization?: boolean;
+
+    [key: string]: any;
+}
+
 export interface ExpressSwaggerCustomOptions extends CommonSwaggerCustomOptions {
   explorer?: boolean;
-  swaggerOptions?: Record<string, any>;
+  swaggerOptions?: SwaggerConfigurationOptions;
   customCss?: string;
   customCssUrl?: string;
   customJs?: string;


### PR DESCRIPTION
Options object defined from this page: https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Other... Please describe: 

## What is the current behavior?
Currently, Swagger Options have no interface object, meaning that anyone that wants to customize swagger needs to google the options, and read stackoverflow answers in order to learn how to customize
Issue Number: N/A


## What is the new behavior?
I've added a documented interface from swagger docs with some commonly used options

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
