### PR TITLE
fix: add missing ui config param 'queryConfigEnabled'

### DIFF
--- a/lib/interfaces/swagger-custom-options.interface.ts
+++ b/lib/interfaces/swagger-custom-options.interface.ts
@@ -44,6 +44,7 @@ export interface FastifySwaggerCustomOptions
     persistAuthorization: boolean;
     tagsSorter: string;
     operationsSorter: string;
+    queryConfigEnabled: boolean;
   }>;
   initOAuth?: Record<string, any>;
   staticCSP?: boolean | string | Record<string, string | string[]>;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Before updating swagger-ui to recent version, we could pass query param to the ui to configure it, such as: `https://swagger-api.com/my-swagger.html?url=a-custom-swagger-document.json`.

Now, it is disabled by default.

Issue Number: N/A


## What is the new behavior?
It can be activated with option [`queryConfigEnabled`](https://github.com/swagger-api/swagger-ui/blob/master/docs/usage/configuration.md#parameters).

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
