### PR TITLE
fix: allof client generation handling

### DIFF
--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -161,7 +161,7 @@ export class SchemaObjectFactory {
 
       const schemaCombinators = ['oneOf', 'anyOf', 'allOf'];
       if (schemaCombinators.some((key) => key in property)) {
-        delete (property as SchemaObjectMetadata).type;
+        (property as SchemaObjectMetadata).type = 'object';
       }
       return property as ParameterObject;
     });

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -136,6 +136,7 @@ describe('SchemaObjectFactory', () => {
           profile: {
             description: 'Profile',
             nullable: true,
+            type: 'object',
             allOf: [
               {
                 $ref: '#/components/schemas/CreateProfileDto'
@@ -195,6 +196,7 @@ describe('SchemaObjectFactory', () => {
               { $ref: '#/components/schemas/Cat' },
               { $ref: '#/components/schemas/Dog' }
             ],
+            type: 'object',
             discriminator: { propertyName: 'pet_type' }
           }
         },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

NestJS swagger currently uses `allOf` in somewhat of a weird usage based on examples within the documentation. This is fine for rendering the specification, but causes issues when attempting to generate models and clients off of the emitted specification. [OpenAPI Generator](https://github.com/OpenAPITools/openapi-generator) is not inspect the `required` flag for composite schemas.

This is not the only solution to this issue, but was the simplest. I spent some time evaluating fixing this within the generator code, but it was significantly more involved. This change does not feel like an explicitly inerrant as the resulting object of compose schema use is an object.  

```yaml
properties:
  id:
    description: Identifier
    allOf:
      - $ref: '#/components/schemas/Identifier'
  name:
    type: string
required:
  - eventId
```

## What is the new behavior?

Typing these properties as `objects` helps the generator inspect the expected fields for correct generation. 

```yaml
properties:
  id:
    description: Identifier
    type: object
    allOf:
      - $ref: '#/components/schemas/Identifier'
  name:
    type: string
required:
  - eventId
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
