### PR TITLE
fix(): make swaggerUrl option work

### DIFF
--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -78,7 +78,8 @@ export class SwaggerModule {
     app.use(path, swaggerUi.serveFiles(document, options));
 
     httpAdapter.get(path, (req, res) => res.send(swaggerHtml));
-    httpAdapter.get(path + '-json', (req, res) => res.json(document));
+    const swaggerUrl = options?.swaggerUrl ?? (path + '-json');
+    httpAdapter.get(swaggerUrl, (req, res) => res.json(document));
   }
 
   private static setupFastify(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently it serves the swagger.json at /**api**-json path. But if you prefer to use root (/) as base path instead of api, your json url will become [http://localhost:3000/-json](http://localhost:3000/-json)


## What is the new behavior?
With this change, swaggerUrl option lets developer to decide where to serve swagger.json


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
