### PR TITLE
feat(IntersectionType): add support for composing multiple classes

### DIFF
--- a/test/type-helpers/intersection-type.helper.spec.ts
+++ b/test/type-helpers/intersection-type.helper.spec.ts
@@ -1,6 +1,12 @@
 import { Type } from '@nestjs/common';
 import { Expose, Transform } from 'class-transformer';
-import { IsDateString, IsEmail, IsString, MinLength, validateSync } from 'class-validator';
+import {
+  IsDateString,
+  IsEmail,
+  IsString,
+  MinLength,
+  validateSync
+} from 'class-validator';
 import { ApiProperty } from '../../lib/decorators';
 import { METADATA_FACTORY_NAME } from '../../lib/plugin/plugin-constants';
 import { ModelPropertiesAccessor } from '../../lib/services/model-properties-accessor';
@@ -73,26 +79,26 @@ describe('IntersectionType', () => {
     it('should validate property values', () => {
       const dto = new UpdateUserDto();
 
-      expect(validateSync(dto)).toHaveLength(4)
+      expect(validateSync(dto)).toHaveLength(4);
 
-      dto.firstName = "John"
-      dto.email = "john.doe@test.com"
-      dto.createdAt = "2022-05-25T10:46:00"
+      dto.firstName = 'John';
+      dto.email = 'john.doe@test.com';
+      dto.createdAt = '2022-05-25T10:46:00';
 
-      expect(validateSync(dto)).toHaveLength(1)
-      
-      dto.password = "Test123!"
+      expect(validateSync(dto)).toHaveLength(1);
 
-      expect(validateSync(dto)).toHaveLength(0)
-      
-      dto.email = "john.doe@test.x"
-      dto.password = "2short!"
+      dto.password = 'Test123!';
 
-      const errors = validateSync(dto)
+      expect(validateSync(dto)).toHaveLength(0);
 
-      expect(errors).toHaveLength(2)
-      expect(errors[0].constraints).toHaveProperty("isEmail")
-      expect(errors[1].constraints).toHaveProperty("minLength")
+      dto.email = 'john.doe@test.x';
+      dto.password = '2short!';
+
+      const errors = validateSync(dto);
+
+      expect(errors).toHaveLength(2);
+      expect(errors[0].constraints).toHaveProperty('isEmail');
+      expect(errors[1].constraints).toHaveProperty('minLength');
     });
   });
 });

--- a/test/type-helpers/intersection-type.helper.spec.ts
+++ b/test/type-helpers/intersection-type.helper.spec.ts
@@ -1,6 +1,6 @@
 import { Type } from '@nestjs/common';
 import { Expose, Transform } from 'class-transformer';
-import { IsString } from 'class-validator';
+import { IsDateString, IsEmail, IsString, MinLength, validateSync } from 'class-validator';
 import { ApiProperty } from '../../lib/decorators';
 import { METADATA_FACTORY_NAME } from '../../lib/plugin/plugin-constants';
 import { ModelPropertiesAccessor } from '../../lib/services/model-properties-accessor';
@@ -8,13 +8,15 @@ import { IntersectionType } from '../../lib/type-helpers';
 
 describe('IntersectionType', () => {
   class CreateUserDto {
+    @IsEmail()
     @ApiProperty({ required: true })
-    login: string;
+    email: string;
 
     @Expose()
     @Transform((str) => str + '_transformed')
+    @MinLength(8)
     @IsString()
-    @ApiProperty({ minLength: 10 })
+    @ApiProperty({ minLength: 8 })
     password: string;
 
     static [METADATA_FACTORY_NAME]() {
@@ -26,13 +28,23 @@ describe('IntersectionType', () => {
     @IsString()
     @ApiProperty({ required: false })
     firstName: string;
+  }
+
+  class MetaDto {
+    @IsDateString()
+    @ApiProperty({ required: false })
+    createdAt: string;
 
     static [METADATA_FACTORY_NAME]() {
-      return { dateOfBirth2: { required: true, type: () => String } };
+      return { userId: { required: true, type: () => String } };
     }
   }
 
-  class UpdateUserDto extends IntersectionType(UserDto, CreateUserDto) {}
+  class UpdateUserDto extends IntersectionType(
+    MetaDto,
+    UserDto,
+    CreateUserDto
+  ) {}
 
   let modelPropertiesAccessor: ModelPropertiesAccessor;
 
@@ -40,18 +52,47 @@ describe('IntersectionType', () => {
     modelPropertiesAccessor = new ModelPropertiesAccessor();
   });
 
-  describe('OpenAPI metadata', () => {
+  describe('OpenAPI Metadata', () => {
     it('should return combined class', () => {
-      const prototype = (UpdateUserDto.prototype as any) as Type<unknown>;
+      const prototype = UpdateUserDto.prototype as any as Type<unknown>;
 
       modelPropertiesAccessor.applyMetadataFactory(prototype);
+
       expect(modelPropertiesAccessor.getModelProperties(prototype)).toEqual([
+        'createdAt',
         'firstName',
-        'login',
+        'email',
         'password',
-        'dateOfBirth2',
+        'userId',
         'dateOfBirth'
       ]);
+    });
+  });
+
+  describe('Class Validation', () => {
+    it('should validate property values', () => {
+      const dto = new UpdateUserDto();
+
+      expect(validateSync(dto)).toHaveLength(4)
+
+      dto.firstName = "John"
+      dto.email = "john.doe@test.com"
+      dto.createdAt = "2022-05-25T10:46:00"
+
+      expect(validateSync(dto)).toHaveLength(1)
+      
+      dto.password = "Test123!"
+
+      expect(validateSync(dto)).toHaveLength(0)
+      
+      dto.email = "john.doe@test.x"
+      dto.password = "2short!"
+
+      const errors = validateSync(dto)
+
+      expect(errors).toHaveLength(2)
+      expect(errors[0].constraints).toHaveProperty("isEmail")
+      expect(errors[1].constraints).toHaveProperty("minLength")
     });
   });
 });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
  - Potentially the [OpenAPI / Mapped Types / Intersection](https://docs.nestjs.com/openapi/mapped-types#intersection) docs and example could be updated to show that the updated `IntersectionType` mapper now supports multiple classes.
  - Happy to open another PR for the docs.nestjs.com repo if that would be desirable.

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

The current Swagger `IntersectionType` mapper only supports passing _2 classes_ eg.

```ts
class CreateUserDto {
  @ApiProperty({ required: true })
  @IsEmail()
  login: string

  @ApiProperty({ required: true })
  @MinLength(8)
  password: string
}

class UserDto {
  @ApiProperty({ required: true })
  @IsString()
  firstName: string

  @ApiProperty({ required: true })
  @IsString()
  lastName: string
}

class UpdateUserDto extends IntersectionType(UserDto, CreateUserDto)
```

You cannot pass more than 2 classes eg.

```ts
class MappedClass1 extends IntersectionType(Class1, Class2, Class3) // Expected 2 arguments, but got 3.
class MappedClass2 extends IntersectionType(Class1, Class2, Class3, Class4) // Expected 2 arguments, but got 4.
```

## What is the new behavior?

1. The updated Swagger `IntersectionType` mapper supports 2-8 classes

```ts
class MappedClass1 extends IntersectionType(Class1, Class2) // sure
class MappedClass2 extends IntersectionType(Class1, Class2, Class3) // nice
class MappedClass3 extends IntersectionType(Class1, Class2, Class3, Class4) // keep going
class MappedClass4 extends IntersectionType(Class1, Class2, Class3, Class4, Class5, Class6, Class7, Class8) // no sweat
```

The implementation actually supports an infinite number of classes (just like `@nestjs/mapped-types` does) ...however I have only added interfaces for up to 8 classes...hopefully that will be suffice!

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I have leveraged the `IntersectionType` mapper function from `@nestjs/mapped-types` rather than rewriting that logic as it had been implemented previously.

The upside to this approach is it reduces the surface area of the Swagger `IntersectionType` mapper—leveraging the [existing implementation](https://github.com/nestjs/mapped-types/blob/master/lib/intersection-type.helper.ts) and [test suite](https://github.com/nestjs/mapped-types/blob/master/tests/intersection-type-multiple.helper.spec.ts). 

The downside is that there are a couple of loops over the passed classes—one for the call to the `mapped-types IntersectionType` mapper and another to add the Swagger OpenAPI decorators in this `IntersectionType` mapper. 

However this really is a _moot point_ given that the number of classes will be at most 8 😅 

Essentially this solution just augments the target class with the Swagger/OpenAPI related decorators. It leaves the validation and transformation inheritance to the `IntersectionType` function from `mapped-types`.

Finally, I have added another test to validate that the `class-validator` decorators are working as expected when composing 3 classes together. This is somewhat duplicative of the tests in `mapped-types` but I don't think it hurts to be extra safe!