### PR TITLE
fix(@nestjs/swagger): replace quoted functionPlaceholder completely

### DIFF
--- a/lib/swagger-ui/helpers.ts
+++ b/lib/swagger-ui/helpers.ts
@@ -18,7 +18,7 @@ export function buildJSInitOptions(initOptions: SwaggerUIInitOptions) {
     2
   );
 
-  json = json.replace(new RegExp(functionPlaceholder, 'g'), () => fns.shift());
+  json = json.replace(new RegExp('"' + functionPlaceholder + '"', 'g'), () => fns.shift());
 
   return `let options = ${json};`;
 }


### PR DESCRIPTION
When building JS InitOptions, functions get replaced by a placeholder.
JSON.stringify quotes strings, so we need to replace the placeholder
including the quotes.

Fixes:  nestjs/swagger#1962

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: 1962


## What is the new behavior?


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
