### PR TITLE
fix(swagger-module): change buildSwaggerHtml baseUrl from absolute to…

### DIFF
--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -108,7 +108,7 @@ export class SwaggerModule {
 
     const yamlDocument = jsyaml.dump(document);
     const jsonDocument = JSON.stringify(document);
-    const html = buildSwaggerHTML(finalPath, document, options);
+    const html = buildSwaggerHTML(`.${finalPath}`, document, options);
     const swaggerInitJS = buildSwaggerInitJS(document, options);
     const httpAdapter = app.getHttpAdapter();
 


### PR DESCRIPTION
… relative

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1965


## What is the new behavior?
`path` in `SwaggerModule.setup` or `app.setGlobalPrefix()` will be transformed to relative while build swagger-html.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
