### PR TITLE
Revert "fix(swagger-module): change buildSwaggerHtml baseUrl from absolute to…"

### DIFF
--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -117,7 +117,7 @@ export class SwaggerModule {
 
     const yamlDocument = jsyaml.dump(document);
     const jsonDocument = JSON.stringify(document);
-    const html = buildSwaggerHTML(`.${finalPath}`, document, options);
+    const html = buildSwaggerHTML(finalPath, document, options);
     const swaggerInitJS = buildSwaggerInitJS(document, options);
     const httpAdapter = app.getHttpAdapter();
 


### PR DESCRIPTION
Reverts nestjs/swagger#1966

As mentioned in #1965 , this change may cause errors in the `useGlobalPrefix` scenario, and the case mentioned in the issue can actually be resolved by changing the configuration of `nginx`