### PR TITLE
perf(swagger-module): lazy load swagger-ui-dist module

### DIFF
--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -12,7 +12,7 @@ import { SwaggerScanner } from './swagger-scanner';
 import {
   buildSwaggerHTML,
   buildSwaggerInitJS,
-  swaggerAssetsAbsoluteFSPath
+  getSwaggerAssetsAbsoluteFSPath
 } from './swagger-ui';
 import { assignTwoLevelsDeep } from './utils/assign-two-levels-deep';
 import { getGlobalPrefix } from './utils/get-global-prefix';
@@ -44,6 +44,7 @@ export class SwaggerModule {
 
   private static serveStatic(finalPath: string, app: INestApplication) {
     const httpAdapter = app.getHttpAdapter();
+    const swaggerAssetsAbsoluteFSPath = getSwaggerAssetsAbsoluteFSPath();
 
     if (httpAdapter && httpAdapter.getType() === 'fastify') {
       (app as NestFastifyApplication).useStaticAssets({

--- a/lib/swagger-ui/swagger-ui.ts
+++ b/lib/swagger-ui/swagger-ui.ts
@@ -1,4 +1,3 @@
-import * as swaggerUi from 'swagger-ui-dist';
 import { favIconHtml, htmlTemplateString, jsTemplateString } from './constants';
 import { OpenAPIObject, SwaggerCustomOptions } from '../interfaces';
 import { buildJSInitOptions } from './helpers';
@@ -21,10 +20,21 @@ export function buildSwaggerInitJS(
   return jsTemplateString.replace('<% swaggerOptions %>', jsInitOptions);
 }
 
+let swaggerAssetsAbsoluteFSPath;
+
 /**
- * Stores absolute path to swagger-ui assets
+ * Returns the absolute path to swagger-ui assets.
  */
-export const swaggerAssetsAbsoluteFSPath = swaggerUi.getAbsoluteFSPath();
+export function getSwaggerAssetsAbsoluteFSPath() {
+  if (!swaggerAssetsAbsoluteFSPath) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const swaggerUi = require('swagger-ui-dist');
+    swaggerAssetsAbsoluteFSPath = swaggerUi.getAbsoluteFSPath();
+  }
+
+  return swaggerAssetsAbsoluteFSPath;
+}
+
 /**
  * Used to build swagger-ui custom html
  */

--- a/lib/swagger-ui/swagger-ui.ts
+++ b/lib/swagger-ui/swagger-ui.ts
@@ -20,7 +20,7 @@ export function buildSwaggerInitJS(
   return jsTemplateString.replace('<% swaggerOptions %>', jsInitOptions);
 }
 
-let swaggerAssetsAbsoluteFSPath;
+let swaggerAssetsAbsoluteFSPath: string | undefined;
 
 /**
  * Returns the absolute path to swagger-ui assets.


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
- The `swagger-ui-dist` module is loaded before its utilization, and it loads two large files (listed below), causing some overhead on the app initialization (~800ms in a medium app).
  - https://github.com/swagger-api/swagger-ui/blob/master/swagger-ui-dist-package/index.js#L2-L3, 
  -  https://github.com/swagger-api/swagger-ui/blob/master/dist/swagger-ui-standalone-preset.js
  -  https://github.com/swagger-api/swagger-ui/blob/master/dist/swagger-ui-bundle.js

Issue Number: N/A


## What is the new behavior?
- The `swagger-ui-dist` module is loaded only when serving the Swagger HTML (`SwaggerModule.serveStatic`).

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Bubbleprof from Clinicjs using the E2E app.

| Before  | After  | 
|---|---|
| ![image](https://user-images.githubusercontent.com/11046907/183890575-7042023f-8ee8-4cfc-a271-8e70685df884.png)  | ![image](https://user-images.githubusercontent.com/11046907/183890025-82dd9976-7099-47e7-bea8-a2bcd8f7a385.png) |

