### PR TITLE
Add customJsStr to swagger-custom-options

### DIFF
--- a/lib/interfaces/swagger-custom-options.interface.ts
+++ b/lib/interfaces/swagger-custom-options.interface.ts
@@ -5,6 +5,7 @@ export interface SwaggerCustomOptions {
   customCss?: string;
   customCssUrl?: string;
   customJs?: string;
+  customJsStr?: string;
   customfavIcon?: string;
   swaggerUrl?: string;
   customSiteTitle?: string;

--- a/lib/swagger-ui/constants.ts
+++ b/lib/swagger-ui/constants.ts
@@ -74,6 +74,7 @@ export const htmlTemplateString = `
 <script src="<% baseUrl %>swagger-ui-standalone-preset.js"> </script>
 <script src="<% baseUrl %>swagger-ui-init.js"> </script>
 <% customJs %>
+<% customJsStr %>
 <% customCssUrl %>
 <style>
   <% customCss %>

--- a/lib/swagger-ui/swagger-ui.ts
+++ b/lib/swagger-ui/swagger-ui.ts
@@ -36,6 +36,7 @@ export function buildSwaggerHTML(
   const {
     customCss = '',
     customJs = '',
+    customJsStr = '',
     customfavIcon = false,
     customSiteTitle = 'Swagger UI',
     customCssUrl = '',
@@ -58,6 +59,8 @@ export function buildSwaggerHTML(
       '<% customJs %>',
       customJs ? `<script src="${customJs}"></script>` : ''
     )
+    .replace(
+      '<% customJsStr %>', customJsStr ? `<script> ${customJsStr} </script>` : '')
     .replace(
       '<% customCssUrl %>',
       customCssUrl ? `<link href="${customCssUrl}" rel="stylesheet">` : ''


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

nestjs/swagger currently doesn't support customJsStr option introduced to swagger-ui-express.

This causes one to use customJs which requires an api endpoint to serve the js file since customJs takes a public url path as input.

Issue Number: #2037


## What is the new behavior?

SwaggerCustomOptions now allows for customJsStr to pass javascript as a string equal to customCss.

The provided string is encased in an HTML `<script>` tag and added to the constants html below the other customJs option. 

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

No test or documentation changes due to look the same as the customJs option.