### PR TITLE
feat(swagger): JSON and YAML document endpoints customizable

### DIFF
--- a/e2e/express.e2e-spec.ts
+++ b/e2e/express.e2e-spec.ts
@@ -96,4 +96,91 @@ describe('Express Swagger', () => {
       expect(Object.keys(response.body).length).toBeGreaterThan(0);
     });
   });
+
+  describe('custom documents endpoints', () => {
+    const JSON_CUSTOM_URL = '/apidoc-json';
+    const YAML_CUSTOM_URL = '/apidoc-yaml';
+
+    beforeEach(async () => {
+      const swaggerDocument = SwaggerModule.createDocument(
+        app,
+        builder.build()
+      );
+      SwaggerModule.setup('api', app, swaggerDocument, {
+        jsonDocumentUrl: JSON_CUSTOM_URL,
+        yamlDocumentUrl: YAML_CUSTOM_URL
+      });
+
+      await app.init();
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+
+    it('json document should be server in the custom url', async () => {
+      const response = await request(app.getHttpServer()).get(JSON_CUSTOM_URL);
+
+      expect(response.status).toEqual(200);
+      expect(Object.keys(response.body).length).toBeGreaterThan(0);
+    });
+
+    it('yaml document should be server in the custom url', async () => {
+      const response = await request(app.getHttpServer()).get(YAML_CUSTOM_URL);
+
+      expect(response.status).toEqual(200);
+      expect(response.text.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('custom documents endpoints with global prefix', () => {
+    let appGlobalPrefix: NestExpressApplication;
+
+    const GLOBAL_PREFIX = '/v1';
+    const JSON_CUSTOM_URL = '/apidoc-json';
+    const YAML_CUSTOM_URL = '/apidoc-yaml';
+
+    beforeEach(async () => {
+      appGlobalPrefix = await NestFactory.create<NestExpressApplication>(
+        ApplicationModule,
+        new ExpressAdapter(),
+        { logger: false }
+      );
+      appGlobalPrefix.setGlobalPrefix(GLOBAL_PREFIX);
+
+      const swaggerDocument = SwaggerModule.createDocument(
+        appGlobalPrefix,
+        builder.build()
+      );
+      SwaggerModule.setup('api', appGlobalPrefix, swaggerDocument, {
+        useGlobalPrefix: true,
+        jsonDocumentUrl: JSON_CUSTOM_URL,
+        yamlDocumentUrl: YAML_CUSTOM_URL
+      });
+
+      await appGlobalPrefix.init();
+    });
+
+    afterEach(async () => {
+      await appGlobalPrefix.close();
+    });
+
+    it('json document should be server in the custom url', async () => {
+      const response = await request(appGlobalPrefix.getHttpServer()).get(
+        `${GLOBAL_PREFIX}${JSON_CUSTOM_URL}`
+      );
+
+      expect(response.status).toEqual(200);
+      expect(Object.keys(response.body).length).toBeGreaterThan(0);
+    });
+
+    it('yaml document should be server in the custom url', async () => {
+      const response = await request(appGlobalPrefix.getHttpServer()).get(
+        `${GLOBAL_PREFIX}${YAML_CUSTOM_URL}`
+      );
+
+      expect(response.status).toEqual(200);
+      expect(response.text.length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/e2e/fastify.e2e-spec.ts
+++ b/e2e/fastify.e2e-spec.ts
@@ -99,4 +99,93 @@ describe('Fastify Swagger', () => {
       expect(Object.keys(response.body).length).toBeGreaterThan(0);
     });
   });
+
+  describe('custom documents endpoints', () => {
+    const JSON_CUSTOM_URL = '/apidoc-json';
+    const YAML_CUSTOM_URL = '/apidoc-yaml';
+
+    beforeEach(async () => {
+      const swaggerDocument = SwaggerModule.createDocument(
+        app,
+        builder.build()
+      );
+      SwaggerModule.setup('api', app, swaggerDocument, {
+        jsonDocumentUrl: JSON_CUSTOM_URL,
+        yamlDocumentUrl: YAML_CUSTOM_URL
+      });
+
+      await app.init();
+      await app.getHttpAdapter().getInstance().ready();
+    });
+
+    afterEach(async () => {
+      await app.close();
+    });
+
+    it('json document should be server in the custom url', async () => {
+      const response = await request(app.getHttpServer()).get(JSON_CUSTOM_URL);
+
+      expect(response.status).toEqual(200);
+      expect(Object.keys(response.body).length).toBeGreaterThan(0);
+    });
+
+    it('yaml document should be server in the custom url', async () => {
+      const response = await request(app.getHttpServer()).get(YAML_CUSTOM_URL);
+
+      expect(response.status).toEqual(200);
+      expect(response.text.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('custom documents endpoints with global prefix', () => {
+    let appGlobalPrefix: NestFastifyApplication;
+
+    const GLOBAL_PREFIX = '/v1';
+    const JSON_CUSTOM_URL = '/apidoc-json';
+    const YAML_CUSTOM_URL = '/apidoc-yaml';
+
+    beforeEach(async () => {
+      appGlobalPrefix = await NestFactory.create<NestFastifyApplication>(
+        ApplicationModule,
+        new FastifyAdapter(),
+        { logger: false }
+      );
+      appGlobalPrefix.setGlobalPrefix(GLOBAL_PREFIX);
+
+      const swaggerDocument = SwaggerModule.createDocument(
+        appGlobalPrefix,
+        builder.build()
+      );
+      SwaggerModule.setup('api', appGlobalPrefix, swaggerDocument, {
+        useGlobalPrefix: true,
+        jsonDocumentUrl: JSON_CUSTOM_URL,
+        yamlDocumentUrl: YAML_CUSTOM_URL
+      });
+
+      await appGlobalPrefix.init();
+      await appGlobalPrefix.getHttpAdapter().getInstance().ready();
+    });
+
+    afterEach(async () => {
+      await appGlobalPrefix.close();
+    });
+
+    it('json document should be server in the custom url', async () => {
+      const response = await request(appGlobalPrefix.getHttpServer()).get(
+        `${GLOBAL_PREFIX}${JSON_CUSTOM_URL}`
+      );
+
+      expect(response.status).toEqual(200);
+      expect(Object.keys(response.body).length).toBeGreaterThan(0);
+    });
+
+    it('yaml document should be server in the custom url', async () => {
+      const response = await request(appGlobalPrefix.getHttpServer()).get(
+        `${GLOBAL_PREFIX}${YAML_CUSTOM_URL}`
+      );
+
+      expect(response.status).toEqual(200);
+      expect(response.text.length).toBeGreaterThan(0);
+    });
+  });
 });

--- a/lib/interfaces/swagger-custom-options.interface.ts
+++ b/lib/interfaces/swagger-custom-options.interface.ts
@@ -12,4 +12,6 @@ export interface SwaggerCustomOptions {
   url?: string;
   urls?: Record<'url' | 'name', string>[];
   initOAuth?: Record<string, any>; // https://swagger.io/docs/open-source-tools/swagger-ui/usage/oauth2/
+  jsonDocumentUrl?: string;
+  yamlDocumentUrl?: string;
 }

--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -150,15 +150,15 @@ export class SwaggerModule {
 
     const validatedGlobalPrefix =
       options?.useGlobalPrefix && validateGlobalPrefix(globalPrefix)
-        ? globalPrefix
+        ? validatePath(globalPrefix)
         : '';
 
     const finalJSONDocumentPath = options?.jsonDocumentUrl
-      ? validatePath(`${validatedGlobalPrefix}${options.jsonDocumentUrl}`)
+      ? `${validatedGlobalPrefix}${validatePath(options.jsonDocumentUrl)}`
       : `${finalPath}-json`;
 
     const finalYAMLDocumentPath = options?.yamlDocumentUrl
-      ? validatePath(`${validatedGlobalPrefix}${options.yamlDocumentUrl}`)
+      ? `${validatedGlobalPrefix}${validatePath(options.yamlDocumentUrl)}`
       : `${finalPath}-yaml`;
 
     const baseUrlForSwaggerUI = normalizeRelPath(`./${urlLastSubdirectory}/`);

--- a/lib/utils/validate-global-prefix.util.ts
+++ b/lib/utils/validate-global-prefix.util.ts
@@ -1,0 +1,2 @@
+export const validateGlobalPrefix = (globalPrefix: string): boolean =>
+  globalPrefix && !globalPrefix.match(/^(\/?)$/);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Right now the swagger json and yam are deployed in `${finalPath}-json` and  `${finalPath}-yaml`, without possibility of customization:

```
http://localhost:3000/api-json
http://localhost:3000/api-yaml
```

Issue Number: [#1968](https://github.com/nestjs/swagger/issues/1968)


## What is the new behavior?

Added the options `jsonDocumentUrl` and `yamlDocumentUrl` in the interface `SwaggerCustomOptions`
If the option value is present, json and/or yaml documents are served in the specified url.
Furthermore, if `globalPrefix` is specified in the nest options, it's used as prefix for the custom urls.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

## Other information
