### PR TITLE
feat(@nestjs/swagger) support HTTP range status codes

### DIFF
--- a/lib/decorators/api-response.decorator.ts
+++ b/lib/decorators/api-response.decorator.ts
@@ -10,7 +10,7 @@ import { getTypeIsArrayTuple } from './helpers';
 
 export interface ApiResponseMetadata
   extends Omit<ResponseObject, 'description'> {
-  status?: number | 'default';
+  status?: number | 'default' | '1XX' | '2XX' | '3XX' | '4XX' | '5XX';
   type?: Type<unknown> | Function | [Function] | string;
   isArray?: boolean;
   description?: string;


### PR DESCRIPTION
Allow 1XX, 2XX, 3XX, 4XX, 5XX range HTTP response codes.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Only numeric or 'default' HTTP response codes were allowed.

Issue Number: N/A


## What is the new behavior?
[Range codes](https://swagger.io/docs/specification/describing-responses/) '1XX', '2XX', '3XX', '4XX' and '5XX' are now allowed as well.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

- Doc was not updated as there is no doc in this repo.
- No test was added as there does not appear to be a test for `default` either.