### PR TITLE
feat: make introspectComments to be true by default

### DIFF
--- a/lib/plugin/merge-options.ts
+++ b/lib/plugin/merge-options.ts
@@ -15,7 +15,7 @@ const defaultOptions: PluginOptions = {
   classValidatorShim: true,
   dtoKeyOfComment: 'description',
   controllerKeyOfComment: 'description',
-  introspectComments: false
+  introspectComments: true
 };
 
 export const mergePluginOptions = (


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

Comments introspection is a convenient feature  for developer.

Here is best practice, which make the code more clean. And developer don't need to know the api of `@ApiProperty`.
```ts
// 👍
export class CreateUserDto {
  /**
   * A list of user's roles
   * @example ['admin']
   */
  roles: RoleEnum[] = [];
}
```
```ts
// 👎
export class CreateUserDto {
  @ApiProperty({
    description: `A list of user's roles`,
    example: ['admin'],
  })
  roles: RoleEnum[] = [];
}
```

This PR can help developer to keep code clean (by default). If developers don't want to follow the best practice, they can set  `introspectComments` to be `false` manually.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
If it make sense, I think it should be accepted in next major version. 