### PR TITLE
fix(plugin): empty comment do not emit @ApiOperation decorator

### DIFF
--- a/lib/plugin/visitors/controller-class.visitor.ts
+++ b/lib/plugin/visitors/controller-class.visitor.ts
@@ -163,6 +163,9 @@ export class ControllerClassVisitor extends AbstractFileVisitor {
       (apiOperationExpr.properties as ts.NodeArray<ts.PropertyAssignment>);
 
     const extractedComments = getMainCommentOfNode(node, sourceFile);
+    if (!extractedComments) {
+      return [];
+    }
     const tags = getTsDocTagsOfNode(node, sourceFile, typeChecker);
 
     const properties = [

--- a/test/plugin/fixtures/app.controller-without-modifiers.ts
+++ b/test/plugin/fixtures/app.controller-without-modifiers.ts
@@ -56,6 +56,10 @@ export class AppController {
   @Get()
   @HttpCode(HttpStatus.NO_CONTENT)
   findAll(): Promise<Cat[]> {}
+  
+  @Get()
+  @HttpCode(HttpStatus.NO_CONTENT)
+  noComment() {}
 }`;
 
 export const appControllerWithoutModifiersTextTranspiled = `\"use strict\";
@@ -102,6 +106,7 @@ let AppController = class AppController {
      * @memberof AppController
      */
     findAll() { }
+    noComment() { }
 };
 __decorate([
     openapi.ApiOperation({ summary: "create a Cat" }),
@@ -129,6 +134,11 @@ __decorate([
     HttpCode(common_1.HttpStatus.NO_CONTENT),
     openapi.ApiResponse({ status: common_1.HttpStatus.NO_CONTENT, type: [Cat] })
 ], AppController.prototype, \"findAll\", null);
+__decorate([
+    Get(),
+    HttpCode(common_1.HttpStatus.NO_CONTENT),
+    openapi.ApiResponse({ status: common_1.HttpStatus.NO_CONTENT })
+], AppController.prototype, \"noComment\", null);
 AppController = __decorate([
     (0, common_1.Controller)('cats')
 ], AppController);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2153


## What is the new behavior?
no empty `ApiOperation` will be emitted.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
reserve this: https://github.com/nestjs/swagger/commit/06ec7ec6b5d9393e42f51254e3fdd6ba4dd4425b#diff-d9ab9cd42b694de692963638564f4d9df7a45ccc68838feac4550bd8a61ec1f5L146