### PR TITLE
fix: type helpers metadata inheriting

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,10 +66,18 @@
     "@fastify/static": "^6.0.0",
     "@nestjs/common": "^9.0.0",
     "@nestjs/core": "^9.0.0",
+    "class-transformer": "*",
+    "class-validator": "*",
     "reflect-metadata": "^0.1.12"
   },
   "peerDependenciesMeta": {
     "@fastify/static": {
+      "optional": true
+    },
+    "class-transformer": {
+      "optional": true
+    },
+    "class-validator": {
       "optional": true
     }
   },


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Yarn PnP doesn't implicitly inherit transitive peer dependencies class-validator and class-transformer from @nestjs/mapped-types.

Issue Number: #2169

## What is the new behavior?

Specify class-validator and class-transformer as optional dependencies.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No