### PR TITLE
fix: add getSchemaPath into shim

### DIFF
--- a/lib/extra/swagger-shim.ts
+++ b/lib/extra/swagger-shim.ts
@@ -165,5 +165,5 @@ export function PickType() {
   return () => {};
 }
 export function getSchemaPath() {
-  return () => {}
+  return () => ""
 }

--- a/lib/extra/swagger-shim.ts
+++ b/lib/extra/swagger-shim.ts
@@ -164,3 +164,6 @@ export function PartialType() {
 export function PickType() {
   return () => {};
 }
+export function getSchemaPath() {
+  return () => {}
+}

--- a/lib/extra/swagger-shim.ts
+++ b/lib/extra/swagger-shim.ts
@@ -165,5 +165,5 @@ export function PickType() {
   return () => {};
 }
 export function getSchemaPath() {
-  return () => ""
+  return () => ''
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

- [x ] Bugfix


## What is the current behavior?
getSchemaPath is missing in shims.


## What is the new behavior?
If you use decorators and also getSchemaPath in ui and use shim, doesnt find the function anymore

## Does this PR introduce a breaking change?
- [ ] Yes
- [ x] No

Only for shim. nothing changed
