### PR TITLE
refactor: use Type instead of MappedType

### DIFF
--- a/lib/type-helpers/intersection-type.helper.ts
+++ b/lib/type-helpers/intersection-type.helper.ts
@@ -3,7 +3,6 @@ import {
   inheritTransformationMetadata,
   inheritValidationMetadata,
   inheritPropertyInitializers,
-  MappedType
 } from '@nestjs/mapped-types';
 import { DECORATORS } from '../constants';
 import { ApiProperty } from '../decorators';
@@ -22,7 +21,7 @@ type ClassRefsToConstructors<T extends Type[]> = {
   [U in keyof T]: T[U] extends Type<infer V> ? V : never;
 };
 
-type Intersection<T extends Type[]> = MappedType<
+type Intersection<T extends Type[]> = Type<
   UnionToIntersection<ClassRefsToConstructors<T>[number]>
 >;
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When using `@nestjs/swagger` with `pnpm` in NestJS application, when `IntersectionType` is used as extension for class, there is dependency error with `@nestjs/mapped-types`. When the intersection is used in `PickType`/`OmitType` or also in this hotfix:
```
const TypeTyper = <T>(classRef: Type<T>): Type<T> => classRef;
```
it behaves normal.


## What is the new behavior?
The `Intersection` type (which `IntersectionType` function is using) now returns `Type` instead of `MappedType` which, did nothing greater than wrap the whole type.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
