### PR TITLE
fix: allow missing paramtypes metadata when extracting method parameter types

### DIFF
--- a/lib/services/parameter-metadata-accessor.ts
+++ b/lib/services/parameter-metadata-accessor.ts
@@ -38,7 +38,7 @@ export class ParameterMetadataAccessor {
       PARAMTYPES_METADATA,
       instance,
       method.name
-    );
+    ) ?? [];
     const routeArgsMetadata: ParamsMetadata =
       Reflect.getMetadata(
         ROUTE_ARGS_METADATA,

--- a/test/services/parameter-metadata-accessor.spec.ts
+++ b/test/services/parameter-metadata-accessor.spec.ts
@@ -1,0 +1,40 @@
+import { Controller, Get, Query } from '@nestjs/common';
+import { PARAMTYPES_METADATA } from '@nestjs/common/constants';
+import { ParameterMetadataAccessor } from '../../lib/services/parameter-metadata-accessor';
+
+describe('ParameterMetadataAccessor', () => {
+  @Controller()
+  class UserController {
+    @Get()
+    findUser(@Query('userID') userID: string) { }
+  }
+
+  let parameterMetadataAccessor: ParameterMetadataAccessor;
+
+  beforeEach(() => {
+    parameterMetadataAccessor = new ParameterMetadataAccessor();
+  });
+
+  describe('explore', () => {
+    it('should handle missing paramtypes metadata', () => {
+      const controller = new UserController();
+      jest.spyOn(Reflect, 'getMetadata')
+        .mockReturnValueOnce(undefined)
+        .mockReturnValueOnce({
+          '4:0': { index: 0, data: 'userID', pipes: [] }
+        });
+
+      Reflect.defineMetadata(PARAMTYPES_METADATA, undefined, controller.findUser);
+
+      expect(
+        parameterMetadataAccessor.explore(
+          controller,
+          UserController,
+          controller.findUser
+        )
+      ).toEqual({
+        '4:0': { in: 'query', name: 'userID', required: true, type: undefined }
+      });
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When using `@nestjs/swagger` in environments that do not support TypeScript's `emitDecoratorMetadata` configuration this library will throw an exception if any parameter decorator is discovered because the `design:paramtypes` metadata array it expects to find in `parameter-metadata-accessor.ts` will not exist.

Issue Number: N/A

## What is the new behavior?

With this change the `types` array – which is searched for the default type of each parameter – will be an empty array if `design:paramtypes` does not exist on the controller method. This is a safe value to default to as it will at worst result in routes with no schema details for their parameters.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
