### PR TITLE
fix: add dedicated typing for oauth2 and oidc

### DIFF
--- a/e2e/api-spec.json
+++ b/e2e/api-spec.json
@@ -931,6 +931,10 @@
         "type": "oauth2",
         "flows": {}
       },
+      "openIdConnect": {
+        "type": "openIdConnect",
+        "openIdConnectUrl": "https://oauth.example.com/.well-known/openid-configuration"
+      },
       "api_key": {
         "type": "apiKey",
         "in": "header",

--- a/e2e/express.e2e-spec.ts
+++ b/e2e/express.e2e-spec.ts
@@ -27,6 +27,7 @@ describe('Express Swagger', () => {
       .addBasicAuth()
       .addBearerAuth()
       .addOAuth2()
+      .addOpenIdConnect({ openIdConnectUrl: 'https://oauth.example.com/.well-known/openid-configuration' })
       .addApiKey()
       .addApiKey({ type: 'apiKey' }, 'key1')
       .addApiKey({ type: 'apiKey' }, 'key2')

--- a/e2e/fastify.e2e-spec.ts
+++ b/e2e/fastify.e2e-spec.ts
@@ -27,6 +27,7 @@ describe('Fastify Swagger', () => {
       .addBasicAuth()
       .addBearerAuth()
       .addOAuth2()
+      .addOpenIdConnect({ openIdConnectUrl: 'https://oauth.example.com/.well-known/openid-configuration' })
       .addApiKey()
       .addApiKey({ type: 'apiKey' }, 'key1')
       .addApiKey({ type: 'apiKey' }, 'key2')

--- a/e2e/manual-e2e.ts
+++ b/e2e/manual-e2e.ts
@@ -84,6 +84,7 @@ async function bootstrap() {
     .addBasicAuth()
     .addBearerAuth()
     .addOAuth2()
+    .addOpenIdConnect({ openIdConnectUrl: 'https://oauth.example.com/.well-known/openid-configuration' })
     .addApiKey()
     .addApiKey({ type: 'apiKey' }, 'key1')
     .addApiKey({ type: 'apiKey' }, 'key2')

--- a/e2e/validate-schema.e2e-spec.ts
+++ b/e2e/validate-schema.e2e-spec.ts
@@ -34,6 +34,7 @@ describe('Validate OpenAPI schema', () => {
       .addBasicAuth()
       .addBearerAuth()
       .addOAuth2()
+      .addOpenIdConnect({ openIdConnectUrl: 'https://oauth.example.com/.well-known/openid-configuration' })
       .addApiKey()
       .addApiKey({ type: 'apiKey' }, 'key1')
       .addApiKey({ type: 'apiKey' }, 'key2')

--- a/lib/document-builder.ts
+++ b/lib/document-builder.ts
@@ -4,6 +4,9 @@ import { buildDocumentBase } from './fixtures/document.base';
 import { OpenAPIObject } from './interfaces';
 import {
   ExternalDocumentationObject,
+  HttpSecuritySchemeObject,
+  OAuth2SecuritySchemeObject,
+  OpenIdSecurityConnectSchemeObject,
   ParameterObject,
   SecurityRequirementObject,
   SecuritySchemeObject,
@@ -117,7 +120,7 @@ export class DocumentBuilder {
   }
 
   public addBearerAuth(
-    options: SecuritySchemeObject = {
+    options: HttpSecuritySchemeObject = {
       type: 'http'
     },
     name = 'bearer'
@@ -131,7 +134,7 @@ export class DocumentBuilder {
   }
 
   public addOAuth2(
-    options: SecuritySchemeObject = {
+    options: OAuth2SecuritySchemeObject | OpenIdSecurityConnectSchemeObject = {
       type: 'oauth2'
     },
     name = 'oauth2'
@@ -144,8 +147,21 @@ export class DocumentBuilder {
     return this;
   }
 
+  public addOpenIdConnect(
+    options: Partial<OpenIdSecurityConnectSchemeObject> = {
+      type: 'openIdConnect'
+    },
+    name = 'openIdConnect'
+  ): this {
+    this.addSecurity(name, {
+      type: 'openIdConnect',
+      ...options
+    });
+    return this;
+  }
+
   public addApiKey(
-    options: SecuritySchemeObject = {
+    options: HttpSecuritySchemeObject = {
       type: 'apiKey'
     },
     name = 'api_key'
@@ -160,7 +176,7 @@ export class DocumentBuilder {
   }
 
   public addBasicAuth(
-    options: SecuritySchemeObject = {
+    options: HttpSecuritySchemeObject = {
       type: 'http'
     },
     name = 'basic'
@@ -175,7 +191,7 @@ export class DocumentBuilder {
 
   public addCookieAuth(
     cookieName = 'connect.sid',
-    options: SecuritySchemeObject = {
+    options: HttpSecuritySchemeObject = {
       type: 'apiKey'
     },
     securityName = 'cookie'

--- a/lib/interfaces/open-api-spec.interface.ts
+++ b/lib/interfaces/open-api-spec.interface.ts
@@ -251,15 +251,26 @@ export interface XmlObject {
 
 export type SecuritySchemeType = 'apiKey' | 'http' | 'oauth2' | 'openIdConnect';
 
-export interface SecuritySchemeObject {
+export type SecuritySchemeObject = HttpSecuritySchemeObject | OAuth2SecuritySchemeObject | OpenIdSecurityConnectSchemeObject;
+
+interface CommonSecuritySchemeObject {
   type: SecuritySchemeType;
   description?: string;
   name?: string;
+}
+
+export interface HttpSecuritySchemeObject extends CommonSecuritySchemeObject {
   in?: string;
   scheme?: string;
   bearerFormat?: string;
+}
+
+export interface OAuth2SecuritySchemeObject extends CommonSecuritySchemeObject {
   flows?: OAuthFlowsObject;
-  openIdConnectUrl?: string;
+}
+
+export interface OpenIdSecurityConnectSchemeObject extends CommonSecuritySchemeObject {
+  openIdConnectUrl: string;
 }
 
 export interface OAuthFlowsObject {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Feature

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
Currently, there is no typing dedicated for OpenId Connect or OAuth2. Additional properties like the `bearerFormat` may be invalid and the typing is not protecting against this case.

## What is the new behavior?
Dedicated typing has been added so a typing error will show in case a wrong options is passed

## Does this PR introduce a breaking change?
- [x] Yes

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
This PR removes some properties for the `addOAuth2` options argument.

## Other information
