### PR TITLE
perf: added possibility to lazy initialize the document

### DIFF
--- a/lib/interfaces/swagger-custom-options.interface.ts
+++ b/lib/interfaces/swagger-custom-options.interface.ts
@@ -1,4 +1,6 @@
 import { SwaggerUiOptions } from './swagger-ui-options.interface';
+import { SwaggerDocumentOptions } from './swagger-document-options.interface';
+import { OpenAPIObject } from './open-api-spec.interface';
 
 export interface SwaggerCustomOptions {
   useGlobalPrefix?: boolean;

--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -1,5 +1,6 @@
 import { INestApplication } from '@nestjs/common';
 import { HttpServer } from '@nestjs/common/interfaces/http/http-server.interface';
+import { isFunction } from '@nestjs/common/utils/shared.utils';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { NestFastifyApplication } from '@nestjs/platform-fastify';
 import * as jsyaml from 'js-yaml';
@@ -65,21 +66,39 @@ export class SwaggerModule {
     finalPath: string,
     urlLastSubdirectory: string,
     httpAdapter: HttpServer,
-    swaggerInitJS: string,
+    documentOrFactory: OpenAPIObject | (() => OpenAPIObject),
     options: {
-      html: string;
-      yamlDocument: string;
-      jsonDocument: string;
       jsonDocumentUrl: string;
       yamlDocumentUrl: string;
-    }
+      swaggerOptions: SwaggerCustomOptions
+    },
   ) {
+    let document: OpenAPIObject;
+
+    const lazyBuildDocument = () => {
+      return typeof documentOrFactory === 'function' ? documentOrFactory() : documentOrFactory;
+    }
+
+    const baseUrlForSwaggerUI = normalizeRelPath(`./${urlLastSubdirectory}/`);
+
+    let html: string;
+    let swaggerInitJS: string;
+
     httpAdapter.get(
       normalizeRelPath(`${finalPath}/swagger-ui-init.js`),
       (req, res) => {
         res.type('application/javascript');
+
+        if (!document) {
+          document = lazyBuildDocument();
+        }
+
+        if (!swaggerInitJS) {
+          swaggerInitJS = buildSwaggerInitJS(document, options);
+        }
+
         res.send(swaggerInitJS);
-      }
+      },
     );
 
     /**
@@ -89,12 +108,21 @@ export class SwaggerModule {
     try {
       httpAdapter.get(
         normalizeRelPath(
-          `${finalPath}/${urlLastSubdirectory}/swagger-ui-init.js`
+          `${finalPath}/${urlLastSubdirectory}/swagger-ui-init.js`,
         ),
         (req, res) => {
           res.type('application/javascript');
+
+          if (!document) {
+            document = lazyBuildDocument();
+          }
+
+          if (!swaggerInitJS) {
+            swaggerInitJS = buildSwaggerInitJS(document, options);
+          }
+
           res.send(swaggerInitJS);
-        }
+        },
       );
     } catch (err) {
       /**
@@ -105,14 +133,32 @@ export class SwaggerModule {
 
     httpAdapter.get(finalPath, (req, res) => {
       res.type('text/html');
-      res.send(options.html);
+
+      if (!document) {
+        document = lazyBuildDocument();
+      }
+
+      if (!html) {
+        html = buildSwaggerHTML(baseUrlForSwaggerUI, document, options);
+      }
+
+      res.send(html);
     });
 
     // fastify doesn't resolve 'routePath/' -> 'routePath', that's why we handle it manually
     try {
       httpAdapter.get(normalizeRelPath(`${finalPath}/`), (req, res) => {
         res.type('text/html');
-        res.send(options.html);
+
+        if (!document) {
+          document = lazyBuildDocument();
+        }
+
+        if (!html) {
+          html = buildSwaggerHTML(baseUrlForSwaggerUI, document, options);
+        }
+
+        res.send(html);
       });
     } catch (err) {
       /**
@@ -123,33 +169,51 @@ export class SwaggerModule {
        */
     }
 
+    let yamlDocument: string;
+    let jsonDocument: string;
+
     httpAdapter.get(normalizeRelPath(options.jsonDocumentUrl), (req, res) => {
       res.type('application/json');
-      res.send(options.jsonDocument);
+
+      if (!document) {
+         document = lazyBuildDocument();
+      }
+
+      if (!jsonDocument) {
+         jsonDocument = JSON.stringify(document);
+      }
+
+      res.send(jsonDocument);
     });
 
     httpAdapter.get(normalizeRelPath(options.yamlDocumentUrl), (req, res) => {
       res.type('text/yaml');
-      res.send(options.yamlDocument);
+
+      if (!document) {
+        document = lazyBuildDocument();
+      }
+
+      if (!yamlDocument) {
+         yamlDocument = jsyaml.dump(document, { skipInvalid: true });
+      }
+
+      res.send(yamlDocument);
     });
   }
 
   public static setup(
     path: string,
     app: INestApplication,
-    document: OpenAPIObject,
+    documentOrFactory: OpenAPIObject | (() => OpenAPIObject),
     options?: SwaggerCustomOptions
   ) {
     const globalPrefix = getGlobalPrefix(app);
     const finalPath = validatePath(
       options?.useGlobalPrefix && validateGlobalPrefix(globalPrefix)
         ? `${globalPrefix}${validatePath(path)}`
-        : path
+        : path,
     );
-    const urlLastSubdirectory = finalPath.split('/').slice(-1).pop();
-
-    const yamlDocument = jsyaml.dump(document, { skipInvalid: true });
-    const jsonDocument = JSON.stringify(document);
+    const urlLastSubdirectory = finalPath.split('/').slice(-1).pop() || '';
 
     const validatedGlobalPrefix =
       options?.useGlobalPrefix && validateGlobalPrefix(globalPrefix)
@@ -164,24 +228,18 @@ export class SwaggerModule {
       ? `${validatedGlobalPrefix}${validatePath(options.yamlDocumentUrl)}`
       : `${finalPath}-yaml`;
 
-    const baseUrlForSwaggerUI = normalizeRelPath(`./${urlLastSubdirectory}/`);
-
-    const html = buildSwaggerHTML(baseUrlForSwaggerUI, document, options);
-    const swaggerInitJS = buildSwaggerInitJS(document, options);
     const httpAdapter = app.getHttpAdapter();
 
     SwaggerModule.serveDocuments(
       finalPath,
       urlLastSubdirectory,
       httpAdapter,
-      swaggerInitJS,
+      documentOrFactory,
       {
-        html,
-        yamlDocument,
-        jsonDocument,
         jsonDocumentUrl: finalJSONDocumentPath,
-        yamlDocumentUrl: finalYAMLDocumentPath
-      }
+        yamlDocumentUrl: finalYAMLDocumentPath,
+        swaggerOptions: options || {},
+      },
     );
 
     SwaggerModule.serveStatic(finalPath, app);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently, NestJS builds the Swagger document synchronously on startup, which it's a waste of time since we don't care about the swagger routes until we need to make a call to it.

## What is the new behavior?

So, I added an option to lazy initialize the Swagger document, the document will only be built when we have some request for it.

In my API, it reduced about 70~75ms from initialization, it will vary according to the API and the amount of routes but now it will only take 2ms to initialize the Swagger Module.

### Usage

Now, to use the new lazy loading feature, just change these lines:

```diff
const swaggerDocument = new DocumentBuilder()
  .setTitle(config.get<string>('SWAGGER_TITLE') ?? 'Base')
  .setDescription(config.get<string>('SWAGGER_DESCRIPTION') ?? 'The base API')
  .setVersion(config.get<string>('VERSION') ?? '1.0.0')
  .addTag('main')
  .addBearerAuth()
  .build();

-const document = SwaggerModule.createDocument(app, swaggerDocument);
+const document = () => SwaggerModule.createDocument(app, swaggerDocument);

SwaggerModule.setup('/swagger', app, document, {
  swaggerOptions: { docExpansion: 'none' },
});
```

Just one line to use it.

### Reproduction

To use it: https://stackblitz.com/edit/nestjs-starter-bql4af?file=src/main.ts

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
