### PR TITLE
fix: Routes are now undefined and have been replaced with controllers

### DIFF
--- a/lib/swagger-scanner.ts
+++ b/lib/swagger-scanner.ts
@@ -2,7 +2,8 @@ import { INestApplication, Type } from '@nestjs/common';
 import { MODULE_PATH } from '@nestjs/common/constants';
 import { ApplicationConfig, NestContainer } from '@nestjs/core';
 import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
-import { InstanceToken, Module } from '@nestjs/core/injector/module';
+import { InjectionToken } from '@nestjs/common';
+import { Module } from '@nestjs/core/injector/module';
 import { flatten, isEmpty } from 'lodash';
 import { OpenAPIObject, SwaggerDocumentOptions } from './interfaces';
 import { ModuleRoute } from './interfaces/module-route.interface';
@@ -50,7 +51,7 @@ export class SwaggerScanner {
       : '';
 
     const denormalizedPaths = modules.map(
-      ({ routes, metatype, relatedModules }) => {
+      ({ controllers, metatype, imports }) => {
         let result: ModuleRoute[] = [];
 
         if (deepScanRoutes) {
@@ -58,16 +59,16 @@ export class SwaggerScanner {
           const isGlobal = (module: Type<any>) =>
             !container.isGlobalModule(module);
 
-          Array.from(relatedModules.values())
+          Array.from(imports.values())
             .filter(isGlobal as any)
-            .forEach(({ metatype, routes }) => {
+            .forEach(({ metatype, controllers }) => {
               const modulePath = this.getModulePathMetadata(
                 container,
                 metatype
               );
               result = result.concat(
                 this.scanModuleRoutes(
-                  routes,
+                  controllers,
                   modulePath,
                   globalPrefix,
                   internalConfigRef,
@@ -79,7 +80,7 @@ export class SwaggerScanner {
         const modulePath = this.getModulePathMetadata(container, metatype);
         result = result.concat(
           this.scanModuleRoutes(
-            routes,
+            controllers,
             modulePath,
             globalPrefix,
             internalConfigRef,
@@ -102,7 +103,7 @@ export class SwaggerScanner {
   }
 
   public scanModuleRoutes(
-    routes: Map<InstanceToken, InstanceWrapper>,
+    routes: Map<InjectionToken, InstanceWrapper>,
     modulePath: string | undefined,
     globalPrefix: string | undefined,
     applicationConfig: ApplicationConfig,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The value of `routes` is undefined when being accessed in `swagger-scanner.js:49`

Issue Number: #2476 

## What is the new behavior?
No errors display when trying to check the value of `routes` as it has now been replaced with `controllers`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
`routes` has been previously deprecated and replaced with `controllers` but access to the value had remained for backwards compatibility. Nest 10.0.0 has removed all previous deprecations, meaning the use of `routes` now has to be changed to `controllers`.

`InstanceToken` has also been replaced by `InjectionToken`, with the same reasoning as `routes` and `controllers`.