### PR TITLE
Support changing the OpenAPI document based on the request

### DIFF
--- a/e2e/express.e2e-spec.ts
+++ b/e2e/express.e2e-spec.ts
@@ -113,7 +113,14 @@ describe('Express Swagger', () => {
       );
       SwaggerModule.setup('api', app, swaggerDocument, {
         jsonDocumentUrl: JSON_CUSTOM_URL,
-        yamlDocumentUrl: YAML_CUSTOM_URL
+        yamlDocumentUrl: YAML_CUSTOM_URL,
+        patchDocument: (req, res, document) => ({
+          ...document,
+          info: {
+            ...document.info,
+            description: (req as Record<string, any>).query.description
+          }
+        })
       });
 
       await app.init();
@@ -130,12 +137,24 @@ describe('Express Swagger', () => {
       expect(Object.keys(response.body).length).toBeGreaterThan(0);
     });
 
+    it('patched JSON document should be served', async () => {
+      const response = await request(app.getHttpServer()).get(`${JSON_CUSTOM_URL}?description=My%20custom%20description`);
+
+      expect(response.body.info.description).toBe("My custom description")
+    })
+
     it('yaml document should be server in the custom url', async () => {
       const response = await request(app.getHttpServer()).get(YAML_CUSTOM_URL);
 
       expect(response.status).toEqual(200);
       expect(response.text.length).toBeGreaterThan(0);
     });
+
+    it('patched YAML document should be served', async () => {
+      const response = await request(app.getHttpServer()).get(`${YAML_CUSTOM_URL}?description=My%20custom%20description`);
+
+      expect(response.text).toContain("My custom description")
+    })
   });
 
   describe('custom documents endpoints with global prefix', () => {
@@ -209,7 +228,15 @@ describe('Express Swagger', () => {
         customJsStr: CUSTOM_JS_STR,
         customfavIcon: CUSTOM_FAVICON,
         customSiteTitle: CUSTOM_SITE_TITLE,
-        customCssUrl: CUSTOM_CSS_URL
+        customCssUrl: CUSTOM_CSS_URL,
+        patchDocument<ExpressRequest, ExpressResponse> (req, res, document) {
+          return {
+            ...document,
+            info: {
+              description: req.query.description
+            }
+          }
+        }
       });
 
       await app.init();
@@ -248,6 +275,46 @@ describe('Express Swagger', () => {
         `<link href='${CUSTOM_CSS_URL}' rel='stylesheet'>`
       );
     });
+
+    it('should patch the OpenAPI document', async () => {
+      const response: Response = await request(app.getHttpServer()).get('/swagger-ui-init.js?description=Custom%20Swagger%20description%20passed%20by%20query%20param')
+      expect(response.text).toContain(
+        `"description": "Custom Swagger description passed by query param"`
+      )
+    })
+
+    it('should patch the OpenAPI document based on path param of the swagger prefix', async () => {
+      const app = await NestFactory.create<NestExpressApplication>(
+        ApplicationModule,
+        new ExpressAdapter(),
+        { logger: false }
+      );
+
+      app.setGlobalPrefix("/:customer/")
+
+      const swaggerDocument = SwaggerModule.createDocument(
+        app,
+        builder.build()
+      );
+
+      SwaggerModule.setup('/:customer/', app, swaggerDocument, {
+        patchDocument<ExpressRequest, ExpressResponse> (req, res, document) {
+          return {
+            ...document,
+            info: {
+              description: `${req.params.customer}'s API documentation`
+            }
+          }
+        }
+      });
+
+      await app.init();
+
+      const response: Response = await request(app.getHttpServer()).get('/customer-1/swagger-ui-init.js')
+
+      await app.close()
+      expect(response.text).toContain("customer-1's API documentation")
+    })
 
     afterEach(async () => {
       await app.close();

--- a/e2e/express.e2e-spec.ts
+++ b/e2e/express.e2e-spec.ts
@@ -138,10 +138,12 @@ describe('Express Swagger', () => {
     });
 
     it('patched JSON document should be served', async () => {
-      const response = await request(app.getHttpServer()).get(`${JSON_CUSTOM_URL}?description=My%20custom%20description`);
+      const response = await request(app.getHttpServer()).get(
+        `${JSON_CUSTOM_URL}?description=My%20custom%20description`
+      );
 
-      expect(response.body.info.description).toBe("My custom description")
-    })
+      expect(response.body.info.description).toBe("My custom description");
+    });
 
     it('yaml document should be server in the custom url', async () => {
       const response = await request(app.getHttpServer()).get(YAML_CUSTOM_URL);
@@ -151,10 +153,11 @@ describe('Express Swagger', () => {
     });
 
     it('patched YAML document should be served', async () => {
-      const response = await request(app.getHttpServer()).get(`${YAML_CUSTOM_URL}?description=My%20custom%20description`);
-
-      expect(response.text).toContain("My custom description")
-    })
+      const response = await request(app.getHttpServer()).get(
+        `${YAML_CUSTOM_URL}?description=My%20custom%20description`
+      );
+      expect(response.text).toContain("My custom description");
+    });
   });
 
   describe('custom documents endpoints with global prefix', () => {
@@ -277,11 +280,13 @@ describe('Express Swagger', () => {
     });
 
     it('should patch the OpenAPI document', async () => {
-      const response: Response = await request(app.getHttpServer()).get('/swagger-ui-init.js?description=Custom%20Swagger%20description%20passed%20by%20query%20param')
+      const response: Response = await request(app.getHttpServer()).get(
+        '/swagger-ui-init.js?description=Custom%20Swagger%20description%20passed%20by%20query%20param'
+      );
       expect(response.text).toContain(
         `"description": "Custom Swagger description passed by query param"`
-      )
-    })
+      );
+    });
 
     it('should patch the OpenAPI document based on path param of the swagger prefix', async () => {
       const app = await NestFactory.create<NestExpressApplication>(
@@ -289,8 +294,6 @@ describe('Express Swagger', () => {
         new ExpressAdapter(),
         { logger: false }
       );
-
-      app.setGlobalPrefix("/:customer/")
 
       const swaggerDocument = SwaggerModule.createDocument(
         app,
@@ -310,10 +313,10 @@ describe('Express Swagger', () => {
 
       await app.init();
 
-      const response: Response = await request(app.getHttpServer()).get('/customer-1/swagger-ui-init.js')
+      const response: Response = await request(app.getHttpServer()).get('/customer-1/swagger-ui-init.js');
 
-      await app.close()
-      expect(response.text).toContain("customer-1's API documentation")
+      await app.close();
+      expect(response.text).toContain("customer-1's API documentation");
     })
 
     afterEach(async () => {

--- a/e2e/express.e2e-spec.ts
+++ b/e2e/express.e2e-spec.ts
@@ -114,7 +114,7 @@ describe('Express Swagger', () => {
       SwaggerModule.setup('api', app, swaggerDocument, {
         jsonDocumentUrl: JSON_CUSTOM_URL,
         yamlDocumentUrl: YAML_CUSTOM_URL,
-        patchDocument: (req, res, document) => ({
+        patchDocumentOnRequest: (req, res, document) => ({
           ...document,
           info: {
             ...document.info,
@@ -232,7 +232,7 @@ describe('Express Swagger', () => {
         customfavIcon: CUSTOM_FAVICON,
         customSiteTitle: CUSTOM_SITE_TITLE,
         customCssUrl: CUSTOM_CSS_URL,
-        patchDocument<ExpressRequest, ExpressResponse> (req, res, document) {
+        patchDocumentOnRequest<ExpressRequest, ExpressResponse> (req, res, document) {
           return {
             ...document,
             info: {
@@ -301,7 +301,7 @@ describe('Express Swagger', () => {
       );
 
       SwaggerModule.setup('/:customer/', app, swaggerDocument, {
-        patchDocument<ExpressRequest, ExpressResponse> (req, res, document) {
+        patchDocumentOnRequest<ExpressRequest, ExpressResponse> (req, res, document) {
           return {
             ...document,
             info: {

--- a/e2e/fastify.e2e-spec.ts
+++ b/e2e/fastify.e2e-spec.ts
@@ -117,7 +117,7 @@ describe('Fastify Swagger', () => {
       SwaggerModule.setup('api', app, swaggerDocument, {
         jsonDocumentUrl: JSON_CUSTOM_URL,
         yamlDocumentUrl: YAML_CUSTOM_URL,
-        patchDocument: (req, res, document) => ({
+        patchDocumentOnRequest: (req, res, document) => ({
           ...document,
           info: {
             ...document.info,
@@ -237,7 +237,7 @@ describe('Fastify Swagger', () => {
         customfavIcon: CUSTOM_FAVICON,
         customSiteTitle: CUSTOM_SITE_TITLE,
         customCssUrl: CUSTOM_CSS_URL,
-        patchDocument: (req, res, document) => ({
+        patchDocumentOnRequest: (req, res, document) => ({
           ...document,
           info: {
             ...document.info,
@@ -318,7 +318,7 @@ describe('Fastify Swagger', () => {
       );
 
       SwaggerModule.setup('/:tenantId/', app, swaggerDocument, {
-        patchDocument<ExpressRequest, ExpressResponse> (req, res, document) {
+        patchDocumentOnRequest<ExpressRequest, ExpressResponse> (req, res, document) {
           return {
             ...document,
             info: {

--- a/e2e/fastify.e2e-spec.ts
+++ b/e2e/fastify.e2e-spec.ts
@@ -277,11 +277,11 @@ describe('Fastify Swagger', () => {
     it('should patch the OpenAPI document', async function () {
       const response: Response = await request(app.getHttpServer()).get(
         "/custom/swagger-ui-init.js?description=Custom%20Swagger%20description%20passed%20by%20query%20param"
-      )
+      );
       expect(response.text).toContain(
         `"description": "Custom Swagger description passed by query param"`
-      )
-    })
+      );
+    });
 
     it('should patch the OpenAPI document based on path param of the swagger prefix', async () => {
       const app = await NestFactory.create<NestFastifyApplication>(
@@ -309,10 +309,10 @@ describe('Fastify Swagger', () => {
       await app.init();
       await app.getHttpAdapter().getInstance().ready();
 
-      const response: Response = await request(app.getHttpServer()).get('/tenant-1/swagger-ui-init.js')
+      const response: Response = await request(app.getHttpServer()).get('/tenant-1/swagger-ui-init.js');
 
-      await app.close()
-      expect(response.text).toContain("tenant-1's API documentation")
+      await app.close();
+      expect(response.text).toContain("tenant-1's API documentation");
     })
 
     afterEach(async () => {

--- a/e2e/fastify.e2e-spec.ts
+++ b/e2e/fastify.e2e-spec.ts
@@ -116,7 +116,14 @@ describe('Fastify Swagger', () => {
       );
       SwaggerModule.setup('api', app, swaggerDocument, {
         jsonDocumentUrl: JSON_CUSTOM_URL,
-        yamlDocumentUrl: YAML_CUSTOM_URL
+        yamlDocumentUrl: YAML_CUSTOM_URL,
+        patchDocument: (req, res, document) => ({
+          ...document,
+          info: {
+            ...document.info,
+            description: (req as Record<string, any>).query.description
+          }
+        })
       });
 
       await app.init();
@@ -134,11 +141,26 @@ describe('Fastify Swagger', () => {
       expect(Object.keys(response.body).length).toBeGreaterThan(0);
     });
 
+    it('patched JSON document should be served', async () => {
+      const response = await request(app.getHttpServer()).get(
+        `${JSON_CUSTOM_URL}?description=My%20custom%20description`
+      );
+
+      expect(response.body.info.description).toBe("My custom description");
+    });
+
     it('yaml document should be server in the custom url', async () => {
       const response = await request(app.getHttpServer()).get(YAML_CUSTOM_URL);
 
       expect(response.status).toEqual(200);
       expect(response.text.length).toBeGreaterThan(0);
+    });
+
+    it('patched YAML document should be served', async () => {
+      const response = await request(app.getHttpServer()).get(
+        `${YAML_CUSTOM_URL}?description=My%20custom%20description`
+      );
+      expect(response.text).toContain("My custom description");
     });
   });
 

--- a/e2e/manual-e2e.ts
+++ b/e2e/manual-e2e.ts
@@ -124,7 +124,7 @@ async function bootstrap() {
   });
 
   SwaggerModule.setup("/:tenantId/api-docs", app, document, {
-    patchDocument: (req, res, document1) => ({
+    patchDocumentOnRequest: (req, res, document1) => ({
       ...document1,
       info: {
         ...document1.info,

--- a/e2e/manual-e2e.ts
+++ b/e2e/manual-e2e.ts
@@ -123,6 +123,16 @@ async function bootstrap() {
     }
   });
 
+  SwaggerModule.setup("/:tenantId/api-docs", app, document, {
+    patchDocument: (req, res, document1) => ({
+      ...document1,
+      info: {
+        ...document1.info,
+        title: `${(req as Record<string, any>).params.tenantId}'s API document`
+      }
+    })
+  })
+
   USE_FASTIFY
     ? (app as NestFastifyApplication).useStaticAssets({
         root: publicFolderPath,

--- a/lib/interfaces/swagger-custom-options.interface.ts
+++ b/lib/interfaces/swagger-custom-options.interface.ts
@@ -18,4 +18,5 @@ export interface SwaggerCustomOptions {
   urls?: Record<'url' | 'name', string>[];
   jsonDocumentUrl?: string;
   yamlDocumentUrl?: string;
+  patchDocument?: <TRequest = any, TResponse = any> (req: TRequest, res: TResponse, document: OpenAPIObject) => OpenAPIObject;
 }

--- a/lib/interfaces/swagger-custom-options.interface.ts
+++ b/lib/interfaces/swagger-custom-options.interface.ts
@@ -18,5 +18,5 @@ export interface SwaggerCustomOptions {
   urls?: Record<'url' | 'name', string>[];
   jsonDocumentUrl?: string;
   yamlDocumentUrl?: string;
-  patchDocument?: <TRequest = any, TResponse = any> (req: TRequest, res: TResponse, document: OpenAPIObject) => OpenAPIObject;
+  patchDocumentOnRequest?: <TRequest = any, TResponse = any> (req: TRequest, res: TResponse, document: OpenAPIObject) => OpenAPIObject;
 }

--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -103,8 +103,8 @@ export class SwaggerModule {
         if (!document) {
           document = lazyBuildDocument();
 
-          if (options.swaggerOptions.patchDocument) {
-            document = options.swaggerOptions.patchDocument(req, res, document);
+          if (options.swaggerOptions.patchDocumentOnRequest) {
+            document = options.swaggerOptions.patchDocumentOnRequest(req, res, document);
           }
         }
 
@@ -131,8 +131,8 @@ export class SwaggerModule {
           if (!document) {
             document = lazyBuildDocument();
 
-            if (options.swaggerOptions.patchDocument) {
-              document = options.swaggerOptions.patchDocument(
+            if (options.swaggerOptions.patchDocumentOnRequest) {
+              document = options.swaggerOptions.patchDocumentOnRequest(
                 req,
                 res,
                 document
@@ -163,8 +163,8 @@ export class SwaggerModule {
       if (!document) {
         document = lazyBuildDocument();
 
-        if (options.swaggerOptions.patchDocument) {
-          document = options.swaggerOptions.patchDocument(req, res, document);
+        if (options.swaggerOptions.patchDocumentOnRequest) {
+          document = options.swaggerOptions.patchDocumentOnRequest(req, res, document);
         }
       }
 
@@ -187,8 +187,8 @@ export class SwaggerModule {
         if (!document) {
           document = lazyBuildDocument();
 
-          if (options.swaggerOptions.patchDocument) {
-            document = options.swaggerOptions.patchDocument(req, res, document);
+          if (options.swaggerOptions.patchDocumentOnRequest) {
+            document = options.swaggerOptions.patchDocumentOnRequest(req, res, document);
           }
         }
 
@@ -220,8 +220,8 @@ export class SwaggerModule {
       if (!document) {
         document = lazyBuildDocument();
 
-        if (options.swaggerOptions.patchDocument) {
-          document = options.swaggerOptions.patchDocument(req, res, document);
+        if (options.swaggerOptions.patchDocumentOnRequest) {
+          document = options.swaggerOptions.patchDocumentOnRequest(req, res, document);
         }
       }
 
@@ -238,8 +238,8 @@ export class SwaggerModule {
       if (!document) {
         document = lazyBuildDocument();
 
-        if (options.swaggerOptions.patchDocument) {
-          document = options.swaggerOptions.patchDocument(req, res, document);
+        if (options.swaggerOptions.patchDocumentOnRequest) {
+          document = options.swaggerOptions.patchDocumentOnRequest(req, res, document);
         }
       }
 

--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -104,7 +104,7 @@ export class SwaggerModule {
           document = lazyBuildDocument();
 
           if (options.swaggerOptions.patchDocument) {
-            document = options.swaggerOptions.patchDocument(req, res, document)
+            document = options.swaggerOptions.patchDocument(req, res, document);
           }
         }
 
@@ -132,7 +132,11 @@ export class SwaggerModule {
             document = lazyBuildDocument();
 
             if (options.swaggerOptions.patchDocument) {
-              document = options.swaggerOptions.patchDocument(req, res, document);
+              document = options.swaggerOptions.patchDocument(
+                req,
+                res,
+                document
+              );
             }
           }
 
@@ -160,7 +164,7 @@ export class SwaggerModule {
         document = lazyBuildDocument();
 
         if (options.swaggerOptions.patchDocument) {
-          document = options.swaggerOptions.patchDocument(req, res, document)
+          document = options.swaggerOptions.patchDocument(req, res, document);
         }
       }
 
@@ -217,7 +221,7 @@ export class SwaggerModule {
         document = lazyBuildDocument();
 
         if (options.swaggerOptions.patchDocument) {
-          document = options.swaggerOptions.patchDocument(req, res, document)
+          document = options.swaggerOptions.patchDocument(req, res, document);
         }
       }
 
@@ -235,7 +239,7 @@ export class SwaggerModule {
         document = lazyBuildDocument();
 
         if (options.swaggerOptions.patchDocument) {
-          document = options.swaggerOptions.patchDocument(req, res, document)
+          document = options.swaggerOptions.patchDocument(req, res, document);
         }
       }
 

--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -102,6 +102,10 @@ export class SwaggerModule {
 
         if (!document) {
           document = lazyBuildDocument();
+
+          if (options.swaggerOptions.patchDocument) {
+            document = options.swaggerOptions.patchDocument(req, res, document)
+          }
         }
 
         if (!swaggerInitJS) {
@@ -126,6 +130,10 @@ export class SwaggerModule {
 
           if (!document) {
             document = lazyBuildDocument();
+
+            if (options.swaggerOptions.patchDocument) {
+              document = options.swaggerOptions.patchDocument(req, res, document);
+            }
           }
 
           if (!swaggerInitJS) {
@@ -150,6 +158,10 @@ export class SwaggerModule {
 
       if (!document) {
         document = lazyBuildDocument();
+
+        if (options.swaggerOptions.patchDocument) {
+          document = options.swaggerOptions.patchDocument(req, res, document)
+        }
       }
 
       if (!html) {
@@ -199,6 +211,10 @@ export class SwaggerModule {
 
       if (!document) {
         document = lazyBuildDocument();
+
+        if (options.swaggerOptions.patchDocument) {
+          document = options.swaggerOptions.patchDocument(req, res, document)
+        }
       }
 
       if (!jsonDocument) {
@@ -213,6 +229,10 @@ export class SwaggerModule {
 
       if (!document) {
         document = lazyBuildDocument();
+
+        if (options.swaggerOptions.patchDocument) {
+          document = options.swaggerOptions.patchDocument(req, res, document)
+        }
       }
 
       if (!yamlDocument) {

--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -182,6 +182,10 @@ export class SwaggerModule {
 
         if (!document) {
           document = lazyBuildDocument();
+
+          if (options.swaggerOptions.patchDocument) {
+            document = options.swaggerOptions.patchDocument(req, res, document);
+          }
         }
 
         if (!html) {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

It is impossible to patch the document after it is generated and before it is served.

Issue Number: #2502


## What is the new behavior?

A new option `patchDocument` can be passed to `SwaggerModule.setup`.
```typescript
SwaggerModule.setup("/:tenantId/api-docs", app, document, {
  patchDocument: (req: Request, res: Response, document1: OpenAPIObject) => ({
    ...document1,
    info: {
      ...document1.info,
      title: `${req.params.tenantId}'s API document`
    }
  })
})
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [ x ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
