### PR TITLE
feat(document-builder): create setOpenApiVersion method

### DIFF
--- a/lib/document-builder.ts
+++ b/lib/document-builder.ts
@@ -16,6 +16,15 @@ export class DocumentBuilder {
   private readonly logger = new Logger(DocumentBuilder.name);
   private readonly document: Omit<OpenAPIObject, 'paths'> = buildDocumentBase();
 
+  public setOpenAPIVersion(version: string): this {
+    if (!version.match(/^\d+\.\d+\.\d+$/)) {
+      throw new Error('nestjs-swagger: Invalid OpenApi version.');
+    }
+
+    this.document.openapi = version;
+    return this;
+  }
+
   public setTitle(title: string): this {
     this.document.info.title = title;
     return this;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Today, the Open Api Spec version is hard coded at `lib/fixtures/document.base.ts` and there's no way to change it. 

Issue Number: #2361 

## What is the new behavior?
Creates a new method at the `DocumentBuilder` called `setOpenApiVersion` that receives a string, checks if its a valid Open Api Spec Version and if so override the default versions previously defined.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
