### PR TITLE
feat: add `customSwaggerUiPath`

### DIFF
--- a/e2e/express.e2e-spec.ts
+++ b/e2e/express.e2e-spec.ts
@@ -7,6 +7,7 @@ import * as request from 'supertest';
 import * as SwaggerParser from 'swagger-parser';
 import { DocumentBuilder, SwaggerModule } from '../lib';
 import { ApplicationModule } from './src/app.module';
+import * as path from 'path';
 
 describe('Express Swagger', () => {
   let app: NestExpressApplication;
@@ -83,7 +84,10 @@ describe('Express Swagger', () => {
         app,
         builder.build()
       );
-      SwaggerModule.setup(SWAGGER_RELATIVE_URL, app, swaggerDocument);
+      SwaggerModule.setup(SWAGGER_RELATIVE_URL, app, swaggerDocument, {
+        // to showcase that in new implementation u can use custom swagger-ui path. Useful when using e.g. webpack
+        customSwaggerUiPath: path.resolve(`./node_modules/swagger-ui-dist`),
+      });
 
       await app.init();
     });
@@ -99,6 +103,14 @@ describe('Express Swagger', () => {
 
       expect(response.status).toEqual(200);
       expect(Object.keys(response.body).length).toBeGreaterThan(0);
+    });
+
+    it('content type of served static should be available', async () => {
+      const response = await request(app.getHttpServer()).get(
+        `${SWAGGER_RELATIVE_URL}/swagger-ui-bundle.js`
+      );
+
+      expect(response.status).toEqual(200);
     });
   });
 

--- a/e2e/fastify.e2e-spec.ts
+++ b/e2e/fastify.e2e-spec.ts
@@ -7,6 +7,7 @@ import * as request from 'supertest';
 import * as SwaggerParser from 'swagger-parser';
 import { DocumentBuilder, SwaggerModule } from '../lib';
 import { ApplicationModule } from './src/app.module';
+import * as path from 'path';
 
 describe('Fastify Swagger', () => {
   let app: NestFastifyApplication;
@@ -83,9 +84,12 @@ describe('Fastify Swagger', () => {
     beforeEach(async () => {
       const swaggerDocument = SwaggerModule.createDocument(
         app,
-        builder.build()
+        builder.build(),
       );
-      SwaggerModule.setup(SWAGGER_RELATIVE_URL, app, swaggerDocument);
+      SwaggerModule.setup(SWAGGER_RELATIVE_URL, app, swaggerDocument, {
+        // to showcase that in new implementation u can use custom swagger-ui path. Useful when using e.g. webpack
+        customSwaggerUiPath: path.resolve(`./node_modules/swagger-ui-dist`),
+      });
 
       await app.init();
       await app.getHttpAdapter().getInstance().ready();
@@ -102,6 +106,14 @@ describe('Fastify Swagger', () => {
 
       expect(response.status).toEqual(200);
       expect(Object.keys(response.body).length).toBeGreaterThan(0);
+    });
+
+    it('content type of served static should be available', async () => {
+      const response = await request(app.getHttpServer()).get(
+        `${SWAGGER_RELATIVE_URL}/swagger-ui-bundle.js`
+      );
+
+      expect(response.status).toEqual(200);
     });
   });
 

--- a/lib/interfaces/swagger-custom-options.interface.ts
+++ b/lib/interfaces/swagger-custom-options.interface.ts
@@ -11,6 +11,7 @@ export interface SwaggerCustomOptions {
   customJs?: string | string[];
   customJsStr?: string | string[];
   customfavIcon?: string;
+  customSwaggerUiPath?: string;
   swaggerUrl?: string;
   customSiteTitle?: string;
   validatorUrl?: string;

--- a/lib/utils/resolve-path.util.ts
+++ b/lib/utils/resolve-path.util.ts
@@ -1,0 +1,5 @@
+import * as pathLib from 'path';
+
+export function resolvePath(path: string): string {
+  return path ? pathLib.resolve(path) : path;
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/nestjs/swagger/issues/2543


## What is the new behavior?
Adds the ability to override the default location `swagger-ui-dist`. This is useful when using, for example, `webpack`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
https://github.com/nestjs/docs.nestjs.com/pull/2813