### PR TITLE
feat(swagger): Provide URI version to operationIdFactory 

### DIFF
--- a/lib/interfaces/swagger-document-options.interface.ts
+++ b/lib/interfaces/swagger-document-options.interface.ts
@@ -1,7 +1,7 @@
 export type OperationIdFactory = (
   controllerKey: string,
   methodKey: string,
-  pathVersionKey?: string
+  version?: string
 ) => string;
 
 export interface SwaggerDocumentOptions {

--- a/lib/interfaces/swagger-document-options.interface.ts
+++ b/lib/interfaces/swagger-document-options.interface.ts
@@ -1,3 +1,15 @@
+export type OperationIdFactory =
+  | ((
+      controllerKey: string,
+      methodKey: string,
+      pathVersionKey?: string
+    ) => string)
+  | ((
+      controllerKey: string,
+      methodKey: string,
+      pathVersionKey?: string
+    ) => string);
+
 export interface SwaggerDocumentOptions {
   /**
    * List of modules to include in the specification
@@ -24,5 +36,5 @@ export interface SwaggerDocumentOptions {
    * based on the `controllerKey` and `methodKey`
    * @default () => controllerKey_methodKey
    */
-  operationIdFactory?: (controllerKey: string, methodKey: string) => string;
+  operationIdFactory?: OperationIdFactory;
 }

--- a/lib/interfaces/swagger-document-options.interface.ts
+++ b/lib/interfaces/swagger-document-options.interface.ts
@@ -1,14 +1,8 @@
-export type OperationIdFactory =
-  | ((
-      controllerKey: string,
-      methodKey: string,
-      pathVersionKey?: string
-    ) => string)
-  | ((
-      controllerKey: string,
-      methodKey: string,
-      pathVersionKey?: string
-    ) => string);
+export type OperationIdFactory = (
+  controllerKey: string,
+  methodKey: string,
+  pathVersionKey?: string
+) => string;
 
 export interface SwaggerDocumentOptions {
   /**

--- a/lib/swagger-scanner.ts
+++ b/lib/swagger-scanner.ts
@@ -4,7 +4,11 @@ import { ApplicationConfig, NestContainer } from '@nestjs/core';
 import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 import { Module } from '@nestjs/core/injector/module';
 import { flatten, isEmpty } from 'lodash';
-import { OpenAPIObject, SwaggerDocumentOptions } from './interfaces';
+import {
+  OpenAPIObject,
+  OperationIdFactory,
+  SwaggerDocumentOptions
+} from './interfaces';
 import { ModuleRoute } from './interfaces/module-route.interface';
 import {
   ReferenceObject,
@@ -106,7 +110,7 @@ export class SwaggerScanner {
     modulePath: string | undefined,
     globalPrefix: string | undefined,
     applicationConfig: ApplicationConfig,
-    operationIdFactory?: (controllerKey: string, methodKey: string) => string
+    operationIdFactory?: OperationIdFactory
   ): ModuleRoute[] {
     const denormalizedArray = [...controller.values()].map((ctrl) =>
       this.explorer.exploreController(


### PR DESCRIPTION
This is based on the work completed in #1949. Those changes were reverted due to test failures.
This change adapts those changes to also support neutral versions which resolves the test failures.

Adds a new optional parameter to operationIdFactory to allow providing the API version prefix added to the operation's path.

This allows the operationIdFactory to generate unique IDs in the case of the same controller method being used for multiple API versions.

Default behavior is unchanged - the operation IDs will be of the form controllerKey_methodKey, but where necessary this can be customised using the URI version prefix.

Closes nestjs#2537

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When using Nest's API versioning feature, and having a controller method cover multiple versions, `nestjs-swagger `generates invalid OpenAPI spec, due to duplicate operation IDs.

It generates duplicate operation IDs because only the controller and method names are available to `operationIdFactory - but in these cases the same controller and method is used multiple times.

Issue Number: 2537


## What is the new behavior?

When URI versioning is used, an additional parameter containing the version is provided to `operationIdFactory`. This allows developers to provide unique operation IDs in the case of a method being used in multiple versions.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
