### PR TITLE
feat: add support for string mapping types

### DIFF
--- a/lib/plugin/utils/ast-utils.ts
+++ b/lib/plugin/utils/ast-utils.ts
@@ -46,6 +46,10 @@ export function isStringLiteral(type: Type) {
   return hasFlag(type, TypeFlags.StringLiteral) && !type.isUnion();
 }
 
+export function isStringMapping(type: Type) {
+  return hasFlag(type, TypeFlags.StringMapping);
+}
+
 export function isNumber(type: Type) {
   return hasFlag(type, TypeFlags.Number);
 }

--- a/lib/plugin/utils/plugin-utils.ts
+++ b/lib/plugin/utils/plugin-utils.ts
@@ -13,7 +13,8 @@ import {
   isInterface,
   isNumber,
   isString,
-  isStringLiteral
+  isStringLiteral,
+  isStringMapping
 } from './ast-utils';
 
 export function getDecoratorOrUndefinedByNames(
@@ -65,7 +66,7 @@ export function getTypeReferenceAsString(
   if (isBigInt(type)) {
     return { typeName: BigInt.name, arrayDepth };
   }
-  if (isString(type) || isStringLiteral(type)) {
+  if (isString(type) || isStringLiteral(type) || isStringMapping(type)) {
     return { typeName: String.name, arrayDepth };
   }
   if (isPromiseOrObservable(getText(type, typeChecker))) {

--- a/test/plugin/fixtures/project/cats/classes/cat.class.ts
+++ b/test/plugin/fixtures/project/cats/classes/cat.class.ts
@@ -25,4 +25,12 @@ export class Cat {
   enum: LettersEnum;
 
   enumArr: LettersEnum;
+
+  uppercaseString: Uppercase<string>;
+  
+  lowercaseString: Lowercase<string>;
+
+  capitalizeString: Capitalize<string>;
+
+  uncapitalizeString: Uncapitalize<string>;
 }

--- a/test/plugin/fixtures/serialized-meta.fixture.ts
+++ b/test/plugin/fixtures/serialized-meta.fixture.ts
@@ -64,7 +64,11 @@ export default async () => {
               enumArr: {
                 required: true,
                 enum: t['./cats/dto/pagination-query.dto'].LettersEnum
-              }
+              },
+              uppercaseString: { required: true, type: () => String },
+              lowercaseString: { required: true, type: () => String },
+              capitalizeString: { required: true, type: () => String },
+              uncapitalizeString: { required: true, type: () => String }
             }
           }
         ],


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

String mappings like `Uppercase<string>` or `Lowercase<string>` are not recognized as string type.

Issue Number: #2606


## What is the new behavior?

String mappings are recognized as string type.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

Closes #2606 