### PR TITLE
#2645 nullable types are not wrapped in allOf

### DIFF
--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -168,14 +168,24 @@ export class SchemaObjectFactory {
 
       const schemaCombinators = ['oneOf', 'anyOf', 'allOf'];
       let keyOfCombinators = '';
-      if (schemaCombinators.some((_key) => { keyOfCombinators = _key; return _key in property; })) {
-          if (((property as SchemaObjectMetadata)?.type === 'array' || (property as SchemaObjectMetadata).isArray) && keyOfCombinators) {
-              (property as SchemaObjectMetadata).items = {};
-              (property as SchemaObjectMetadata).items[keyOfCombinators] = property[keyOfCombinators];
-              delete property[keyOfCombinators];
-          } else {
-              delete (property as SchemaObjectMetadata).type;
-          }
+      if (
+        schemaCombinators.some((_key) => {
+          keyOfCombinators = _key;
+          return _key in property;
+        })
+      ) {
+        if (
+          ((property as SchemaObjectMetadata)?.type === 'array' ||
+            (property as SchemaObjectMetadata).isArray) &&
+          keyOfCombinators
+        ) {
+          (property as SchemaObjectMetadata).items = {};
+          (property as SchemaObjectMetadata).items[keyOfCombinators] =
+            property[keyOfCombinators];
+          delete property[keyOfCombinators];
+        } else {
+          delete (property as SchemaObjectMetadata).type;
+        }
       }
       return property as ParameterObject;
     });
@@ -301,7 +311,7 @@ export class SchemaObjectFactory {
 
     if (!(enumName in schemas)) {
       schemas[enumName] = {
-        type: metadata.type as string ?? 'string',
+        type: (metadata.type as string) ?? 'string',
         enum:
           metadata.isArray && metadata.items
             ? metadata.items['enum']
@@ -354,13 +364,14 @@ export class SchemaObjectFactory {
     if (metadata.isArray) {
       return this.transformToArraySchemaProperty(metadata, key, { $ref });
     }
-    const keysToRemove = ['type', 'isArray', 'required'];
+    const keysToRemove = ['type', 'isArray', 'nullable', 'required'];
     const validMetadataObject = omit(metadata, keysToRemove);
     const extraMetadataKeys = Object.keys(validMetadataObject);
 
     if (extraMetadataKeys.length > 0) {
       return {
         name: metadata.name || key,
+        nullable: metadata.nullable,
         required: metadata.required,
         ...validMetadataObject,
         allOf: [{ $ref }]
@@ -368,6 +379,7 @@ export class SchemaObjectFactory {
     }
     return {
       name: metadata.name || key,
+      nullable: metadata.nullable,
       required: metadata.required,
       $ref
     } as SchemaObjectMetadata;

--- a/test/services/fixtures/create-user.dto.ts
+++ b/test/services/fixtures/create-user.dto.ts
@@ -41,6 +41,12 @@ export class CreateUserDto {
   })
   profile: CreateProfileDto;
 
+  @ApiProperty({
+    nullable: false,
+    type: () => CreateProfileDto
+  })
+  nonNullProfile: CreateProfileDto;
+
   @ApiProperty()
   tags: string[];
 

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -149,6 +149,10 @@ describe('SchemaObjectFactory', () => {
               }
             ]
           },
+          nonNullProfile: {
+            nullable: false,
+            $ref: '#/components/schemas/CreateProfileDto'
+          },
           tags: {
             items: {
               type: 'string'
@@ -209,6 +213,7 @@ describe('SchemaObjectFactory', () => {
           'login',
           'password',
           'profile',
+          'nonNullProfile',
           'tags',
           'twoDimensionPrimitives',
           'twoDimensionModels',
@@ -276,9 +281,9 @@ describe('SchemaObjectFactory', () => {
         isArray: false
       };
       const schemas = {};
-      
+
       schemaObjectFactory.createEnumSchemaType('field', metadata, schemas);
-      
+
       expect(schemas).toEqual({ MyEnum: { enum: [1, 2, 3], type: 'number' } });
     });
   });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2645


## What is the new behavior?

ApiProperty with `nullable` keyword set does not wrap the type `$ref` in `allOf`

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
