### PR TITLE
feat: Disable refs in the generated Yaml file

### DIFF
--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -266,7 +266,8 @@ export class SwaggerModule {
         : document;
 
       const yamlDocument = jsyaml.dump(documentToSerialize, {
-        skipInvalid: true
+        skipInvalid: true,
+        noRefs: true
       });
       res.send(yamlDocument);
     });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

I don't think tests or docs changes are needed, but let me know if you disagree.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The generated Yaml specification includes [content refs](https://lzone.de/cheat-sheet/YAML#content-references-aliases) at seemingly arbitrary places. While this is a perfectly valid Yaml, some of the tools may not be able to deal with this (e.g. Redocly preview in the WebStorm) and it makes the file harder to read or diff because one does not control where references are used in the generated specification.

Issue Number: N/A


## What is the new behavior?

The library is configured to not use content refs in the generated Yaml specification.

Example:

```diff
  /resources:
    post:
      operationId: create
      parameters: []
      requestBody:
        required: true
        content:
          application/json:
            schema:
              $ref: '#/components/schemas/CreateDto'
      responses:
        '201':
          description: ''
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/ResponseDto'
-      tags: &ref_0
+      tags:
        - MyTag
-      security: &ref_1
+      security:
        - ServiceKey: []
  /resources/{id}:
    put:
      operationId: update
      parameters:
        - name: id
          required: true
          in: path
          schema:
            type: string
      responses:
        '204':
          description: ''
-      tags: *ref_0
-      security: *ref_1
+      tags:
+        - MyTag
+      security:
+        - ServiceKey: []
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
