### PR TITLE
fix: `enumName` is ignored in @Api[Param|Query|Header]

### DIFF
--- a/e2e/api-spec.json
+++ b/e2e/api-spec.json
@@ -875,6 +875,58 @@
         ]
       }
     },
+    "/api/cats/with-enum-named/{type}": {
+      "get": {
+        "operationId": "CatsController_getWithEnumNamedParam",
+        "parameters": [
+          {
+            "name": "header",
+            "in": "header",
+            "description": "Test",
+            "required": false,
+            "schema": {
+              "default": "test",
+              "type": "string"
+            }
+          },
+          {
+            "name": "type",
+            "required": true,
+            "in": "path",
+            "schema": {
+              "$ref": "#/components/schemas/Letter"
+            }
+          },
+          {
+            "name": "x-tenant-id",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          }
+        },
+        "tags": [
+          "cats"
+        ],
+        "security": [
+          {
+            "key2": [],
+            "key1": []
+          },
+          {
+            "bearer": []
+          },
+          {
+            "basic": []
+          }
+        ]
+      }
+    },
     "/api/cats/with-random-query": {
       "get": {
         "operationId": "CatsController_getWithRandomQuery",

--- a/e2e/api-spec.json
+++ b/e2e/api-spec.json
@@ -837,12 +837,12 @@
             "required": true,
             "in": "path",
             "schema": {
-              "type": "string",
               "enum": [
                 "A",
                 "B",
                 "C"
-              ]
+              ],
+              "type": "string"
             }
           },
           {

--- a/e2e/src/cats/cats.controller.ts
+++ b/e2e/src/cats/cats.controller.ts
@@ -96,9 +96,16 @@ export class CatsController {
   @ApiParam({
     name: 'type',
     enum: LettersEnum,
-    enumName: 'Letter'
   })
   getWithEnumParam(@Param('type') type: LettersEnum) {}
+
+  @Get('with-enum-named/:type')
+  @ApiParam({
+    name: 'type',
+    enum: LettersEnum,
+    enumName: 'Letter'
+  })
+  getWithEnumNamedParam(@Param('type') type: LettersEnum) {}
 
   @Get('with-random-query')
   @ApiQuery({

--- a/lib/decorators/api-param.decorator.ts
+++ b/lib/decorators/api-param.decorator.ts
@@ -5,7 +5,7 @@ import {
   SchemaObject
 } from '../interfaces/open-api-spec.interface';
 import { SwaggerEnumType } from '../types/swagger-enum.type';
-import { getEnumType, getEnumValues } from '../utils/enum.utils';
+import { addEnumSchema, getEnumType, getEnumValues, isEnumDefined } from '../utils/enum.utils';
 import { createParamDecorator } from './helpers';
 
 type ParameterOptions = Omit<ParameterObject, 'in' | 'schema'>;
@@ -29,24 +29,14 @@ const defaultParamOptions: ApiParamOptions = {
 };
 
 export function ApiParam(options: ApiParamOptions): MethodDecorator {
-  const param: Record<string, any> = {
+  const param: ApiParamMetadata & Record<string, any> = {
     name: isNil(options.name) ? defaultParamOptions.name : options.name,
     in: 'path',
     ...omit(options, 'enum')
   };
 
-  const apiParamMetadata = options as ApiParamMetadata;
-  if (apiParamMetadata.enum) {
-    param.schema = param.schema || ({} as SchemaObject);
-
-    const paramSchema = param.schema as SchemaObject;
-    const enumValues = getEnumValues(apiParamMetadata.enum);
-    paramSchema.type = getEnumType(enumValues);
-    paramSchema.enum = enumValues;
-
-    if (apiParamMetadata.enumName) {
-      param.enumName = apiParamMetadata.enumName;
-    }
+  if (isEnumDefined(options)) {
+    addEnumSchema(param, options);
   }
 
   return createParamDecorator(param, defaultParamOptions);

--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -51,6 +51,9 @@ export class SchemaObjectFactory {
           undefined
         ) as [Type<any>, boolean];
       }
+      if (!isBodyParameter(param) && param.enumName) {
+        return this.createEnumParam(param, schemas);
+      }
       if (this.isPrimitiveType(param.type)) {
         return param;
       }
@@ -89,14 +92,10 @@ export class SchemaObjectFactory {
     return flatten(parameterObjects);
   }
 
-  createQueryOrParamSchema(
+  private createQueryOrParamSchema(
     param: ParamWithTypeMetadata,
     schemas: Record<string, SchemaObject>
   ) {
-    if (param.enumName) {
-      return this.createEnumParam(param, schemas);
-    }
-
     if (isDateCtor(param.type as Function)) {
       return {
         format: 'date-time',

--- a/lib/utils/enum.utils.ts
+++ b/lib/utils/enum.utils.ts
@@ -66,8 +66,8 @@ export function addEnumSchema(
   const enumValues = getEnumValues(decoratorOptions.enum);
 
   paramDefinition.schema = paramSchema;
-  paramSchema.type = getEnumType(enumValues);
   paramSchema.enum = enumValues;
+  paramSchema.type = getEnumType(enumValues);
 
   if (decoratorOptions.enumName) {
     paramDefinition.enumName = decoratorOptions.enumName;

--- a/lib/utils/enum.utils.ts
+++ b/lib/utils/enum.utils.ts
@@ -66,8 +66,8 @@ export function addEnumSchema(
   const enumValues = getEnumValues(decoratorOptions.enum);
 
   paramDefinition.schema = paramSchema;
-  paramSchema.enum = enumValues;
   paramSchema.type = getEnumType(enumValues);
+  paramSchema.enum = enumValues;
 
   if (decoratorOptions.enumName) {
     paramDefinition.enumName = decoratorOptions.enumName;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
 => Documentation is already describing the correct expected behavior: https://docs.nestjs.com/openapi/types-and-parameters#enums-schema:

![image](https://github.com/nestjs/swagger/assets/4543679/83c96460-865f-4208-ae05-e8f0e931cfc2)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Using `enumName` in `@Api[Param|Query|Header]` is not making a reference to the enum model in the Openapi specification.

![image](https://github.com/nestjs/swagger/assets/4543679/9db21d27-f3ec-4768-9fea-876814269a4c) => ![image](https://github.com/nestjs/swagger/assets/4543679/f9d9fb2b-f6c6-484a-91a2-3f360f753b30)

When removing `@Param('type') type: LettersEnum`, the enum is correctly referenced: 

![image](https://github.com/nestjs/swagger/assets/4543679/f2ee9c7a-527e-4b8b-aaf0-4331ba9b6590)

The expected behavior should be like this last screen in both cases (with or without a param in the method).

## What is the new behavior?

In `SchemaObjectFactory.createFromModel`, when we get a primitive type infered from method parameter metadata, it skips the call of `createEnumParam` which handles enums references via `$ref`.

Calling it before `isPrimitiveType` did the job.
BTW, I also improved the implementation of `ApiParam` to make it look like more like `ApiQuery` by using `addEnumSchema`

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
