### PR TITLE
fix(core): support non-ASCII characters in filename paths

### DIFF
--- a/lib/plugin/utils/ast-utils.ts
+++ b/lib/plugin/utils/ast-utils.ts
@@ -103,7 +103,17 @@ export function getText(
     typeFormatFlags = getDefaultTypeFormatFlags(enclosingNode);
   }
   const compilerNode = !enclosingNode ? undefined : enclosingNode;
-  return typeChecker.typeToString(type, compilerNode, typeFormatFlags);
+
+  const text = typeChecker.typeToString(type, compilerNode, typeFormatFlags);
+
+  // Regex to match escaped unicode
+  const unicodeRegex = /\\u([\dA-Fa-f]{4})/g
+
+  // Unescape escaped unicode https://github.com/microsoft/TypeScript/issues/36174
+  return text.replace(unicodeRegex, (match, unicode) => {
+    const charCode = parseInt(unicode, 16);
+    return String.fromCharCode(charCode);
+  });
 }
 
 export function getDefaultTypeFormatFlags(enclosingNode: Node) {

--- a/test/plugin/fixtures/project/cats/dto/create-cat.dto.ts
+++ b/test/plugin/fixtures/project/cats/dto/create-cat.dto.ts
@@ -12,6 +12,7 @@ import { randomUUID } from 'node:crypto';
 import { ApiExtraModels, ApiProperty } from '../../../../lib';
 import { ExtraModel } from './extra-model.dto';
 import { LettersEnum } from './pagination-query.dto';
+import { UnicodeDto } from './privé/unicode.dto';
 import { TagDto } from './tag.dto';
 
 enum NonExportedEnum {
@@ -116,6 +117,9 @@ export class CreateCatDto {
 
   @ApiProperty({ description: 'tag', required: false })
   tag: TagDto;
+
+  @ApiProperty({ description: 'unicode', required: false })
+  unicode: UnicodeDto;
 
   multipleTags: TagDto[];
 

--- a/test/plugin/fixtures/project/cats/dto/privé/unicode.dto.ts
+++ b/test/plugin/fixtures/project/cats/dto/privé/unicode.dto.ts
@@ -1,0 +1,6 @@
+import { ApiProperty } from '../../../../../lib';
+
+export class UnicodeDto {
+  @ApiProperty({ description: 'name' })
+  name: string;
+}

--- a/test/plugin/fixtures/serialized-meta.fixture.ts
+++ b/test/plugin/fixtures/serialized-meta.fixture.ts
@@ -6,6 +6,9 @@ export default async () => {
     ),
     ['./cats/dto/create-cat.dto']: await import('./cats/dto/create-cat.dto'),
     ['./cats/dto/tag.dto']: await import('./cats/dto/tag.dto'),
+    ['./cats/dto/priv\u00E9/unicode.dto']: await import(
+      './cats/dto/privé/unicode.dto'
+    ),
     ['./cats/classes/cat.class']: await import('./cats/classes/cat.class')
   };
   return {
@@ -82,6 +85,10 @@ export default async () => {
           }
         ],
         [
+          import('./cats/dto/priv\u00E9/unicode.dto'),
+          { UnicodeDto: { name: { required: true, type: () => String } } }
+        ],
+        [
           import('./cats/dto/tag.dto'),
           { TagDto: { name: { required: true, type: () => String } } }
         ],
@@ -156,6 +163,10 @@ export default async () => {
               tag: {
                 required: true,
                 type: () => t['./cats/dto/tag.dto'].TagDto
+              },
+              unicode: {
+                required: true,
+                type: () => t['./cats/dto/privé/unicode.dto'].UnicodeDto
               },
               multipleTags: {
                 required: true,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
If there is a non-ASCII character in the path of a dto file this will result in failure to normalize the path.

Example of a non-ASCII character in the project path (actual/expected):
```diff
- ./../../../../../../Priv/u00E9/forks/nestjs-swagger/test/plugin/fixtures/project/cats/dto/pagination-query.dto
+ ./cats/dto/pagination-query.dto
```
Example of a non-ASCII character in the dto folder (actual/expected):
```diff
- /home/user/Documents/projects/nestjs-swagger/test/plugin/fixtures/project/cats/dto/priv\u00E9/unicode.dto
+ ./cats/dto/privé/unicode.dto
```

This results in incorrect imports in the generated JavaScript.

Issue Number: Closes #1868


## What is the new behavior?

The swagger plugin now supports Unicode characters in paths to dto files.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
