### PR TITLE
Move typescript from dev to peer dependencies.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,8 +44,7 @@
         "release-it": "17.0.1",
         "supertest": "6.3.3",
         "swagger-parser": "10.0.3",
-        "ts-jest": "29.1.1",
-        "typescript": "5.1.6"
+        "ts-jest": "29.1.1"
       },
       "peerDependencies": {
         "@fastify/static": "^6.0.0",
@@ -53,7 +52,8 @@
         "@nestjs/core": "^9.0.0 || ^10.0.0",
         "class-transformer": "*",
         "class-validator": "*",
-        "reflect-metadata": "^0.1.12"
+        "reflect-metadata": "^0.1.12",
+        "typescript": "5.1.6"
       },
       "peerDependenciesMeta": {
         "@fastify/static": {
@@ -12590,7 +12590,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
-      "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -22413,7 +22413,7 @@
       "version": "5.1.6",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
       "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
-      "dev": true
+      "peer": true
     },
     "uid": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -59,8 +59,7 @@
     "release-it": "17.0.1",
     "supertest": "6.3.3",
     "swagger-parser": "10.0.3",
-    "ts-jest": "29.1.1",
-    "typescript": "5.1.6"
+    "ts-jest": "29.1.1"
   },
   "peerDependencies": {
     "@fastify/static": "^6.0.0",
@@ -68,7 +67,8 @@
     "@nestjs/core": "^9.0.0 || ^10.0.0",
     "class-transformer": "*",
     "class-validator": "*",
-    "reflect-metadata": "^0.1.12"
+    "reflect-metadata": "^0.1.12",
+    "typescript": "5.1.6"
   },
   "peerDependenciesMeta": {
     "@fastify/static": {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The current version lists `typescript` as a dev dependency, which means it wouldn't be installed with the package in production. However, this package directly depends on importing the typescript library like

https://github.com/nestjs/swagger/blob/18f088e39ef586c8af6d4efbdaf4bf3bdaffc556/lib/plugin/visitors/abstract.visitor.ts#L1

Since all nestjs projects are already in typescript, and `@nestjs/swagger` is only used in development, it is usually not an issue. However, if people are using newer package managers like pnpm or yarn+pnp, packages not declared under `dependencies` or `peerDependencies` will be strictly forbidden to import. It will cause problems like https://github.com/nestjs/nest-cli/issues/1836


## What is the new behavior?

`typescript` is now listed as a peer dependency, which solves the problem mentioned above.a


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

It shouldn't introduce a breaking change since it's only moving a dependency from dev to peer.

## Other information

I didn't write any tests in this PR. I don't know if they are necessary for this small change.