### PR TITLE
feat(spec): allow additional fields on enum refs

### DIFF
--- a/e2e/api-spec.json
+++ b/e2e/api-spec.json
@@ -205,8 +205,8 @@
             "description": "Test",
             "required": false,
             "schema": {
-              "default": "test",
-              "type": "string"
+              "type": "string",
+              "default": "test"
             }
           },
           {
@@ -277,8 +277,8 @@
             "description": "Test",
             "required": false,
             "schema": {
-              "default": "test",
-              "type": "string"
+              "type": "string",
+              "default": "test"
             }
           },
           {
@@ -415,8 +415,8 @@
             "description": "Test",
             "required": false,
             "schema": {
-              "default": "test",
-              "type": "string"
+              "type": "string",
+              "default": "test"
             }
           },
           {
@@ -474,8 +474,8 @@
             "description": "Test",
             "required": false,
             "schema": {
-              "default": "test",
-              "type": "string"
+              "type": "string",
+              "default": "test"
             }
           },
           {
@@ -610,8 +610,8 @@
             "description": "Test",
             "required": false,
             "schema": {
-              "default": "test",
-              "type": "string"
+              "type": "string",
+              "default": "test"
             }
           },
           {
@@ -662,8 +662,8 @@
             "description": "Test",
             "required": false,
             "schema": {
-              "default": "test",
-              "type": "string"
+              "type": "string",
+              "default": "test"
             }
           },
           {
@@ -720,8 +720,8 @@
             "description": "Test",
             "required": false,
             "schema": {
-              "default": "test",
-              "type": "string"
+              "type": "string",
+              "default": "test"
             }
           },
           {
@@ -784,8 +784,8 @@
             "description": "Test",
             "required": false,
             "schema": {
-              "default": "test",
-              "type": "string"
+              "type": "string",
+              "default": "test"
             }
           },
           {
@@ -828,8 +828,8 @@
             "description": "Test",
             "required": false,
             "schema": {
-              "default": "test",
-              "type": "string"
+              "type": "string",
+              "default": "test"
             }
           },
           {
@@ -885,8 +885,8 @@
             "description": "Test",
             "required": false,
             "schema": {
-              "default": "test",
-              "type": "string"
+              "type": "string",
+              "default": "test"
             }
           },
           {
@@ -937,8 +937,8 @@
             "description": "Test",
             "required": false,
             "schema": {
-              "default": "test",
-              "type": "string"
+              "type": "string",
+              "default": "test"
             }
           },
           {
@@ -1049,6 +1049,9 @@
       },
       "LettersEnum": {
         "type": "string",
+        "description": "A small assortment of letters?",
+        "deprecated": true,
+        "default": "A",
         "enum": [
           "A",
           "B",
@@ -1128,6 +1131,9 @@
               "$ref": "#/components/schemas/LettersEnum"
             }
           },
+          "enumWithRef": {
+            "$ref": "#/components/schemas/LettersEnum"
+          },
           "tag": {
             "description": "tag",
             "allOf": [
@@ -1151,7 +1157,8 @@
           "options",
           "enumWithDescription",
           "enum",
-          "enumArr"
+          "enumArr",
+          "enumWithRef"
         ]
       },
       "Cat": {
@@ -1223,6 +1230,9 @@
                 "C"
               ]
             }
+          },
+          "enumWithRef": {
+            "$ref": "#/components/schemas/LettersEnum"
           }
         },
         "required": [
@@ -1234,7 +1244,8 @@
           "urls",
           "_options",
           "enum",
-          "enumArr"
+          "enumArr",
+          "enumWithRef"
         ]
       },
       "Letter": {

--- a/e2e/express.e2e-spec.ts
+++ b/e2e/express.e2e-spec.ts
@@ -46,7 +46,7 @@ describe('Express Swagger', () => {
     const doc = JSON.stringify(document, null, 2);
 
     try {
-      let api = await SwaggerParser.validate(document as any);
+      const api = await SwaggerParser.validate(document as any);
       console.log(
         'API name: %s, Version: %s',
         api.info.title,

--- a/e2e/fastify.e2e-spec.ts
+++ b/e2e/fastify.e2e-spec.ts
@@ -46,7 +46,7 @@ describe('Fastify Swagger', () => {
     const doc = JSON.stringify(document, null, 2);
 
     try {
-      let api = await SwaggerParser.validate(document as any);
+      const api = await SwaggerParser.validate(document as any);
       console.log(
         'API name: %s, Version: %s',
         api.info.title,

--- a/e2e/src/cats/classes/cat.class.ts
+++ b/e2e/src/cats/classes/cat.class.ts
@@ -53,4 +53,13 @@ export class Cat {
     isArray: true
   })
   enumArr: LettersEnum;
+
+  @ApiProperty({
+    enum: LettersEnum,
+    enumName: 'LettersEnum',
+    description: 'A small assortment of letters?',
+    default: 'A',
+    deprecated: true,
+  })
+  enumWithRef: LettersEnum
 }

--- a/e2e/src/cats/dto/create-cat.dto.ts
+++ b/e2e/src/cats/dto/create-cat.dto.ts
@@ -61,6 +61,15 @@ export class CreateCatDto {
   })
   readonly enumArr: LettersEnum;
 
+  @ApiProperty({
+    enum: LettersEnum,
+    enumName: 'LettersEnum',
+    description: 'A small assortment of letters?',
+    default: 'A',
+    deprecated: true,
+  })
+  readonly enumWithRef: LettersEnum
+
   @ApiProperty({ description: 'tag', required: false })
   readonly tag: TagDto;
 

--- a/e2e/validate-schema.e2e-spec.ts
+++ b/e2e/validate-schema.e2e-spec.ts
@@ -104,7 +104,7 @@ describe('Validate OpenAPI schema', () => {
     writeFileSync(join(__dirname, 'api-spec.json'), doc);
 
     try {
-      let api = await SwaggerParser.validate(document as any);
+      const api = await SwaggerParser.validate(document as any);
       console.log(
         'API name: %s, Version: %s',
         api.info.title,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?
If there is an `enumName` supplied, all the additionalFields are currently just added as a ref-sibling. This is not swagger-spec compliant and therefore gets ignored.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
See this issue for more information: https://github.com/nestjs/swagger/issues/2806