### PR TITLE
feat(core): add decorator for reponse http status 402 : ApiPaymentRequiredResponse

### DIFF
--- a/lib/decorators/api-response.decorator.ts
+++ b/lib/decorators/api-response.decorator.ts
@@ -211,6 +211,12 @@ export const ApiPayloadTooLargeResponse = (options: ApiResponseOptions = {}) =>
     status: HttpStatus.PAYLOAD_TOO_LARGE
   });
 
+export const ApiPaymentRequiredResponse = (options: ApiResponseOptions = {}) =>
+  ApiResponse({
+    ...options,
+    status: HttpStatus.PAYMENT_REQUIRED
+  });
+
 export const ApiRequestTimeoutResponse = (options: ApiResponseOptions = {}) =>
   ApiResponse({
     ...options,

--- a/lib/extra/swagger-shim.ts
+++ b/lib/extra/swagger-shim.ts
@@ -122,6 +122,9 @@ export function ApiPreconditionFailedResponse() {
 export function ApiPayloadTooLargeResponse() {
   return () => {};
 }
+export function ApiPaymentRequiredResponse() {
+  return () => {};
+}
 export function ApiRequestTimeoutResponse() {
   return () => {};
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
No decorator to add documentation about response with HTTP status [402 Payment required](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/402)

Issue Number: N/A


## What is the new behavior?
Added the decorator `@ApiPaymentRequiredResponse`


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
