### PR TITLE
feat(core): add decorator for response http status 425 : ApiTooEarlyResponse

### DIFF
--- a/lib/decorators/api-response.decorator.ts
+++ b/lib/decorators/api-response.decorator.ts
@@ -129,6 +129,12 @@ export const ApiUnauthorizedResponse = (options: ApiResponseOptions = {}) =>
     status: HttpStatus.UNAUTHORIZED
   });
 
+export const ApiTooEarlyResponse = (options: ApiResponseOptions = {}) =>
+  ApiResponse({
+    ...options,
+    status: 425
+  });
+
 export const ApiTooManyRequestsResponse = (options: ApiResponseOptions = {}) =>
   ApiResponse({
     ...options,

--- a/lib/extra/swagger-shim.ts
+++ b/lib/extra/swagger-shim.ts
@@ -83,6 +83,9 @@ export function ApiBadRequestResponse() {
 export function ApiUnauthorizedResponse() {
   return () => {};
 }
+export function ApiTooEarlyResponse() {
+  return () => {};
+}
 export function ApiTooManyRequestsResponse() {
   return () => {};
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
No decorator to add documentation about response with HTTP status [425 Too early](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/425)

Issue Number: N/A


## What is the new behavior?
Added the decorator @ApiTooEarlyResponse

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
I could not use the `HttpStatus` enum because it does not contain entry for 425 code.