### PR TITLE
feat: allow to disable Swagger UI

### DIFF
--- a/lib/interfaces/swagger-custom-options.interface.ts
+++ b/lib/interfaces/swagger-custom-options.interface.ts
@@ -14,8 +14,11 @@ export interface SwaggerCustomOptions {
   customSwaggerUiPath?: string;
   swaggerUrl?: string;
   customSiteTitle?: string;
+  /** @deprecated This property has no effect. */
   validatorUrl?: string;
+  /** @deprecated This property has no effect. */
   url?: string;
+  /** @deprecated This property has no effect. */
   urls?: Record<'url' | 'name', string>[];
   jsonDocumentUrl?: string;
   yamlDocumentUrl?: string;

--- a/lib/interfaces/swagger-custom-options.interface.ts
+++ b/lib/interfaces/swagger-custom-options.interface.ts
@@ -2,29 +2,106 @@ import { SwaggerUiOptions } from './swagger-ui-options.interface';
 import { OpenAPIObject } from './open-api-spec.interface';
 
 export interface SwaggerCustomOptions {
+  /**
+   * If `true`, Swagger resources paths will be prefixed by the global prefix set through `setGlobalPrefix()`.
+   * Default: `false`.
+   * @see https://docs.nestjs.com/faq/global-prefix
+   */
   useGlobalPrefix?: boolean;
+
+  /**
+   * If `false`, only API definitions (JSON and YAML) will be served (on `/{path}-json` and `/{path}-yaml`).
+   * This is particularly useful if you are already hosting a Swagger UI somewhere else and just want to serve API definitions.
+   * Default: `true`.
+   */
   swaggerUiEnabled?: boolean;
-  explorer?: boolean;
-  swaggerOptions?: SwaggerUiOptions;
-  customCss?: string;
-  customCssUrl?: string | string[];
-  customJs?: string | string[];
-  customJsStr?: string | string[];
-  customfavIcon?: string;
-  customSwaggerUiPath?: string;
+
+  /**
+   * Url point the API definition to load in Swagger UI.
+   */
   swaggerUrl?: string;
-  customSiteTitle?: string;
-  /** @deprecated This property has no effect. */
-  validatorUrl?: string;
-  /** @deprecated This property has no effect. */
-  url?: string;
-  /** @deprecated This property has no effect. */
-  urls?: Record<'url' | 'name', string>[];
+
+  /**
+   * Path of the JSON API definition to serve.
+   * Default: `{{path}}-json`.
+   */
   jsonDocumentUrl?: string;
+
+  /**
+   * Path of the YAML API definition to serve.
+   * Default: `{{path}}-json`.
+   */
   yamlDocumentUrl?: string;
+
+  /**
+   * Hook allowing to alter the OpenAPI document before being served.
+   * It's called after the document is generated and before it is served as JSON & YAML.
+   */
   patchDocumentOnRequest?: <TRequest = any, TResponse = any>(
     req: TRequest,
     res: TResponse,
     document: OpenAPIObject
   ) => OpenAPIObject;
+
+  /**
+   * If `true`, the selector of OpenAPI definitions is displayed in the Swagger UI interface.
+   * Default: `false`.
+   */
+  explorer?: boolean;
+
+  /**
+   * Additional Swagger UI options
+   */
+  swaggerOptions?: SwaggerUiOptions;
+
+  /**
+   * Custom CSS styles to inject in Swagger UI page.
+   */
+  customCss?: string;
+
+  /**
+   * URL(s) of a custom CSS stylesheet to load in Swagger UI page.
+   */
+  customCssUrl?: string | string[];
+
+  /**
+   * URL(s) of custom JavaScript files to load in Swagger UI page.
+   */
+  customJs?: string | string[];
+
+  /**
+   * Custom JavaScript scripts to load in Swagger UI page.
+   */
+  customJsStr?: string | string[];
+
+  /**
+   * Custom favicon for Swagger UI page.
+   */
+  customfavIcon?: string;
+
+  /**
+   * Custom title for Swagger UI page.
+   */
+  customSiteTitle?: string;
+
+  /**
+   * File system path (ex: ./node_modules/swagger-ui-dist) containing static Swagger UI assets.
+   */
+  customSwaggerUiPath?: string;
+
+  /**
+   * @deprecated This property has no effect.
+   */
+  validatorUrl?: string;
+
+  /**
+   * @deprecated This property has no effect.
+   */
+  url?: string;
+
+  /**
+   * @deprecated This property has no effect.
+   */
+  urls?: Record<'url' | 'name', string>[];
+
 }

--- a/lib/interfaces/swagger-custom-options.interface.ts
+++ b/lib/interfaces/swagger-custom-options.interface.ts
@@ -1,9 +1,9 @@
 import { SwaggerUiOptions } from './swagger-ui-options.interface';
-import { SwaggerDocumentOptions } from './swagger-document-options.interface';
 import { OpenAPIObject } from './open-api-spec.interface';
 
 export interface SwaggerCustomOptions {
   useGlobalPrefix?: boolean;
+  swaggerUiEnabled?: boolean;
   explorer?: boolean;
   swaggerOptions?: SwaggerUiOptions;
   customCss?: string;
@@ -22,5 +22,9 @@ export interface SwaggerCustomOptions {
   urls?: Record<'url' | 'name', string>[];
   jsonDocumentUrl?: string;
   yamlDocumentUrl?: string;
-  patchDocumentOnRequest?: <TRequest = any, TResponse = any> (req: TRequest, res: TResponse, document: OpenAPIObject) => OpenAPIObject;
+  patchDocumentOnRequest?: <TRequest = any, TResponse = any>(
+    req: TRequest,
+    res: TResponse,
+    document: OpenAPIObject
+  ) => OpenAPIObject;
 }

--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -180,21 +180,9 @@ export class SwaggerModule {
         document = lazyBuildDocument();
       }
 
-      if (options.swaggerOptions.patchDocumentOnRequest) {
-        const documentToSerialize =
-          options.swaggerOptions.patchDocumentOnRequest(req, res, document);
-        const htmlPerRequest = buildSwaggerHTML(
-          baseUrlForSwaggerUI,
-          documentToSerialize,
-          options.swaggerOptions
-        );
-        return res.send(htmlPerRequest);
-      }
-
       if (!html) {
         html = buildSwaggerHTML(
           baseUrlForSwaggerUI,
-          document,
           options.swaggerOptions
         );
       }
@@ -211,24 +199,13 @@ export class SwaggerModule {
           document = lazyBuildDocument();
         }
 
-        if (options.swaggerOptions.patchDocumentOnRequest) {
-          const documentToSerialize =
-            options.swaggerOptions.patchDocumentOnRequest(req, res, document);
-          const htmlPerRequest = buildSwaggerHTML(
-            baseUrlForSwaggerUI,
-            documentToSerialize,
-            options.swaggerOptions
-          );
-          return res.send(htmlPerRequest);
-        }
-
         if (!html) {
           html = buildSwaggerHTML(
             baseUrlForSwaggerUI,
-            document,
             options.swaggerOptions
           );
         }
+
         res.send(html);
       });
     } catch (err) {

--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -85,6 +85,7 @@ export class SwaggerModule {
     httpAdapter: HttpServer,
     documentOrFactory: OpenAPIObject | (() => OpenAPIObject),
     options: {
+      swaggerUiEnabled: boolean;
       jsonDocumentUrl: string;
       yamlDocumentUrl: string;
       swaggerOptions: SwaggerCustomOptions;
@@ -92,41 +93,64 @@ export class SwaggerModule {
   ) {
     let document: OpenAPIObject;
 
-    const lazyBuildDocument = () => {
-      return typeof documentOrFactory === 'function'
-        ? documentOrFactory()
-        : documentOrFactory;
+    const getBuiltDocument = () => {
+      if (!document) {
+        document =
+          typeof documentOrFactory === 'function'
+            ? documentOrFactory()
+            : documentOrFactory;
+      }
+      return document;
     };
 
+    if (options.swaggerUiEnabled) {
+      this.serveSwaggerUi(
+        finalPath,
+        urlLastSubdirectory,
+        httpAdapter,
+        getBuiltDocument,
+        options.swaggerOptions
+      );
+    }
+    this.serveDefinitions(httpAdapter, getBuiltDocument, options);
+  }
+
+  private static serveSwaggerUi(
+    finalPath: string,
+    urlLastSubdirectory: string,
+    httpAdapter: HttpServer,
+    getBuiltDocument: () => OpenAPIObject,
+    swaggerOptions: SwaggerCustomOptions
+  ) {
     const baseUrlForSwaggerUI = normalizeRelPath(`./${urlLastSubdirectory}/`);
 
-    let html: string;
-    let swaggerInitJS: string;
+    let swaggerUiHtml: string;
+    let swaggerUiInitJS: string;
 
     httpAdapter.get(
       normalizeRelPath(`${finalPath}/swagger-ui-init.js`),
       (req, res) => {
         res.type('application/javascript');
+        const document = getBuiltDocument();
 
-        if (!document) {
-          document = lazyBuildDocument();
-        }
-
-        if (options.swaggerOptions.patchDocumentOnRequest) {
-          const documentToSerialize =
-            options.swaggerOptions.patchDocumentOnRequest(req, res, document);
+        if (swaggerOptions.patchDocumentOnRequest) {
+          const documentToSerialize = swaggerOptions.patchDocumentOnRequest(
+            req,
+            res,
+            document
+          );
           const swaggerInitJsPerRequest = buildSwaggerInitJS(
             documentToSerialize,
-            options.swaggerOptions
+            swaggerOptions
           );
           return res.send(swaggerInitJsPerRequest);
         }
 
-        if (!swaggerInitJS) {
-          swaggerInitJS = buildSwaggerInitJS(document, options.swaggerOptions);
+        if (!swaggerUiInitJS) {
+          swaggerUiInitJS = buildSwaggerInitJS(document, swaggerOptions);
         }
 
-        res.send(swaggerInitJS);
+        res.send(swaggerUiInitJS);
       }
     );
 
@@ -141,29 +165,26 @@ export class SwaggerModule {
         ),
         (req, res) => {
           res.type('application/javascript');
+          const document = getBuiltDocument();
 
-          if (!document) {
-            document = lazyBuildDocument();
-          }
-
-          if (options.swaggerOptions.patchDocumentOnRequest) {
-            const documentToSerialize =
-              options.swaggerOptions.patchDocumentOnRequest(req, res, document);
+          if (swaggerOptions.patchDocumentOnRequest) {
+            const documentToSerialize = swaggerOptions.patchDocumentOnRequest(
+              req,
+              res,
+              document
+            );
             const swaggerInitJsPerRequest = buildSwaggerInitJS(
               documentToSerialize,
-              options.swaggerOptions
+              swaggerOptions
             );
             return res.send(swaggerInitJsPerRequest);
           }
 
-          if (!swaggerInitJS) {
-            swaggerInitJS = buildSwaggerInitJS(
-              document,
-              options.swaggerOptions
-            );
+          if (!swaggerUiInitJS) {
+            swaggerUiInitJS = buildSwaggerInitJS(document, swaggerOptions);
           }
 
-          res.send(swaggerInitJS);
+          res.send(swaggerUiInitJS);
         }
       );
     } catch (err) {
@@ -173,40 +194,26 @@ export class SwaggerModule {
        */
     }
 
-    httpAdapter.get(finalPath, (req, res) => {
+    httpAdapter.get(finalPath, (_, res) => {
       res.type('text/html');
 
-      if (!document) {
-        document = lazyBuildDocument();
+      if (!swaggerUiHtml) {
+        swaggerUiHtml = buildSwaggerHTML(baseUrlForSwaggerUI, swaggerOptions);
       }
 
-      if (!html) {
-        html = buildSwaggerHTML(
-          baseUrlForSwaggerUI,
-          options.swaggerOptions
-        );
-      }
-
-      res.send(html);
+      res.send(swaggerUiHtml);
     });
 
     // fastify doesn't resolve 'routePath/' -> 'routePath', that's why we handle it manually
     try {
-      httpAdapter.get(normalizeRelPath(`${finalPath}/`), (req, res) => {
+      httpAdapter.get(normalizeRelPath(`${finalPath}/`), (_, res) => {
         res.type('text/html');
 
-        if (!document) {
-          document = lazyBuildDocument();
+        if (!swaggerUiHtml) {
+          swaggerUiHtml = buildSwaggerHTML(baseUrlForSwaggerUI, swaggerOptions);
         }
 
-        if (!html) {
-          html = buildSwaggerHTML(
-            baseUrlForSwaggerUI,
-            options.swaggerOptions
-          );
-        }
-
-        res.send(html);
+        res.send(swaggerUiHtml);
       });
     } catch (err) {
       /**
@@ -216,13 +223,20 @@ export class SwaggerModule {
        * We can simply ignore that error here.
        */
     }
+  }
 
+  private static serveDefinitions(
+    httpAdapter: HttpServer,
+    getBuiltDocument: () => OpenAPIObject,
+    options: {
+      jsonDocumentUrl: string;
+      yamlDocumentUrl: string;
+      swaggerOptions: SwaggerCustomOptions;
+    }
+  ) {
     httpAdapter.get(normalizeRelPath(options.jsonDocumentUrl), (req, res) => {
       res.type('application/json');
-
-      if (!document) {
-        document = lazyBuildDocument();
-      }
+      const document = getBuiltDocument();
 
       const documentToSerialize = options.swaggerOptions.patchDocumentOnRequest
         ? options.swaggerOptions.patchDocumentOnRequest(req, res, document)
@@ -233,10 +247,7 @@ export class SwaggerModule {
 
     httpAdapter.get(normalizeRelPath(options.yamlDocumentUrl), (req, res) => {
       res.type('text/yaml');
-
-      if (!document) {
-        document = lazyBuildDocument();
-      }
+      const document = getBuiltDocument();
 
       const documentToSerialize = options.swaggerOptions.patchDocumentOnRequest
         ? options.swaggerOptions.patchDocumentOnRequest(req, res, document)
@@ -276,6 +287,8 @@ export class SwaggerModule {
       ? `${validatedGlobalPrefix}${validatePath(options.yamlDocumentUrl)}`
       : `${finalPath}-yaml`;
 
+    const swaggerUiEnabled = options?.swaggerUiEnabled ?? true;
+
     const httpAdapter = app.getHttpAdapter();
 
     SwaggerModule.serveDocuments(
@@ -284,24 +297,27 @@ export class SwaggerModule {
       httpAdapter,
       documentOrFactory,
       {
+        swaggerUiEnabled,
         jsonDocumentUrl: finalJSONDocumentPath,
         yamlDocumentUrl: finalYAMLDocumentPath,
         swaggerOptions: options || {}
       }
     );
 
-    SwaggerModule.serveStatic(finalPath, app, options?.customSwaggerUiPath);
-    /**
-     * Covers assets fetched through a relative path when Swagger url ends with a slash '/'.
-     * @see https://github.com/nestjs/swagger/issues/1976
-     */
-    const serveStaticSlashEndingPath = `${finalPath}/${urlLastSubdirectory}`;
-    /**
-     *  serveStaticSlashEndingPath === finalPath when path === '' || path === '/'
-     *  in that case we don't need to serve swagger assets on extra sub path
-     */
-    if (serveStaticSlashEndingPath !== finalPath) {
-      SwaggerModule.serveStatic(serveStaticSlashEndingPath, app);
+    if (swaggerUiEnabled) {
+      SwaggerModule.serveStatic(finalPath, app, options?.customSwaggerUiPath);
+      /**
+       * Covers assets fetched through a relative path when Swagger url ends with a slash '/'.
+       * @see https://github.com/nestjs/swagger/issues/1976
+       */
+      const serveStaticSlashEndingPath = `${finalPath}/${urlLastSubdirectory}`;
+      /**
+       *  serveStaticSlashEndingPath === finalPath when path === '' || path === '/'
+       *  in that case we don't need to serve swagger assets on extra sub path
+       */
+      if (serveStaticSlashEndingPath !== finalPath) {
+        SwaggerModule.serveStatic(serveStaticSlashEndingPath, app);
+      }
     }
   }
 }

--- a/lib/swagger-ui/swagger-ui.ts
+++ b/lib/swagger-ui/swagger-ui.ts
@@ -66,7 +66,6 @@ function toTags(
  */
 export function buildSwaggerHTML(
   baseUrl: string,
-  swaggerDoc: OpenAPIObject,
   customOptions: SwaggerCustomOptions = {}
 ) {
   const {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features) => https://github.com/nestjs/docs.nestjs.com/pull/2972


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: none

Currently when using `SwaggerModule.setup` it serves all files of Swagger UI and API definitions generated on the fly (JSON and YAML). It isn't possible for now to only serve API definitions.

I see two uses-cases for this feature:
- You want to serve multiple API definitions in your Nest application, so you might want to enable the UI only for the "default" API and disable it for other ones.
- You already have a Swagger UI served somewhere else in your infrastructure and just want to make it point the API definition of your Nest app. So the UI might be disabled to reduce noise.

## What is the new behavior?

This PR introduces a way to disable the Swagger UI to only generate API definitions.
A new flag `swaggerUiEnabled` is available in `SwaggerModule.setup` options.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

In this PR, I also improved some documentation and removed dead code 