### PR TITLE
feat: add skip null properties option to partial type

### DIFF
--- a/test/type-helpers/partial-type.helper.spec.ts
+++ b/test/type-helpers/partial-type.helper.spec.ts
@@ -21,8 +21,43 @@ describe('PartialType', () => {
   describe('Validation metadata', () => {
     it('should apply @IsOptional to properties reflected by the plugin', async () => {
       const updateDto = new UpdateUserDto();
+      updateDto.firstName = null;
       const validationErrors = await validate(updateDto);
       expect(validationErrors).toHaveLength(0);
+    });
+
+    it('should apply @IsOptional to properties reflected by the plugin if option `skipNullProperties` is true', async () => {
+      class UpdateUserWithNullableDto extends PartialType(CreateUserDto, {
+        skipNullProperties: true
+      }) {}
+      const updateDto = new UpdateUserWithNullableDto();
+      updateDto.firstName = null;
+      const validationErrors = await validate(updateDto);
+      expect(validationErrors).toHaveLength(0);
+    });
+
+    it('should apply @IsOptional to properties reflected by the plugin if option `skipNullProperties` is undefined', async () => {
+      class UpdateUserWithoutNullableDto extends PartialType(
+        CreateUserDto,
+        {}
+      ) {}
+      const updateDto = new UpdateUserWithoutNullableDto();
+      updateDto.firstName = null;
+      const validationErrors = await validate(updateDto);
+      expect(validationErrors).toHaveLength(0);
+    });
+
+    it('should apply @ValidateIf to properties reflected by the plugin if option `skipNullProperties` is false', async () => {
+      class UpdateUserWithoutNullableDto extends PartialType(CreateUserDto, {
+        skipNullProperties: false
+      }) {}
+      const updateDto = new UpdateUserWithoutNullableDto();
+      updateDto.firstName = null;
+      const validationErrors = await validate(updateDto);
+      expect(validationErrors).toHaveLength(1);
+      expect(validationErrors[0].constraints).toEqual({
+        isString: 'firstName must be a string'
+      });
     });
   });
   describe('OpenAPI metadata', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

`PartialType` will return a class for which validations are ignored `null` properties (in addition to `undefined` properties).

Issue Number: [2843](https://github.com/nestjs/swagger/issues/2843), [2623](https://github.com/nestjs/swagger/issues/2623)

## What is the new behaviour?
`PartialType` can optionally return a class for which validations are ignored only for `undefined` properties, not `null` properties. This can be useful if you are creating a DTO for a PATCH endpoint: there may be a certain field, say `name`, that should not be `null`, but which doesn't need to be included in PATCH updates.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
This is actually just a copy-paste of the same PR to mapped-types repo: https://github.com/nestjs/mapped-types/pull/1274
Thanks to @tf3 