### PR TITLE
fix(plugin): call assignment function to add `enum` property by `@IsEnum` decorator

### DIFF
--- a/lib/plugin/visitors/model-class.visitor.ts
+++ b/lib/plugin/visitors/model-class.visitor.ts
@@ -640,6 +640,14 @@ export class ModelClassVisitor extends AbstractFileVisitor {
         assignments,
         options
       );
+      this.addPropertyByValidationDecorator(
+        factory,
+        'IsEnum',
+        'enum',
+        decorators,
+        assignments,
+        options
+      );
     }
     this.addPropertyByValidationDecorator(
       factory,

--- a/lib/plugin/visitors/model-class.visitor.ts
+++ b/lib/plugin/visitors/model-class.visitor.ts
@@ -631,7 +631,7 @@ export class ModelClassVisitor extends AbstractFileVisitor {
     const decorators = ts.canHaveDecorators(node) && ts.getDecorators(node);
 
     if (!options.readonly) {
-      // @IsIn() and @IsEnum() decorator is not supported in readonly mode
+      // @IsIn() and @IsEnum() decorators are not supported in readonly mode
       this.addPropertyByValidationDecorator(
         factory,
         'IsIn',

--- a/lib/plugin/visitors/model-class.visitor.ts
+++ b/lib/plugin/visitors/model-class.visitor.ts
@@ -631,7 +631,7 @@ export class ModelClassVisitor extends AbstractFileVisitor {
     const decorators = ts.canHaveDecorators(node) && ts.getDecorators(node);
 
     if (!options.readonly) {
-      // @IsIn() annotation is not supported in readonly mode
+      // @IsIn() and @IsEnum() annotation is not supported in readonly mode
       this.addPropertyByValidationDecorator(
         factory,
         'IsIn',

--- a/lib/plugin/visitors/model-class.visitor.ts
+++ b/lib/plugin/visitors/model-class.visitor.ts
@@ -631,7 +631,7 @@ export class ModelClassVisitor extends AbstractFileVisitor {
     const decorators = ts.canHaveDecorators(node) && ts.getDecorators(node);
 
     if (!options.readonly) {
-      // @IsIn() and @IsEnum() annotation is not supported in readonly mode
+      // @IsIn() and @IsEnum() decorator is not supported in readonly mode
       this.addPropertyByValidationDecorator(
         factory,
         'IsIn',


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When the option `classValidatorShim` is enabled, I expected the CLI to add an `enum` property into Swagger documentation automatically about a `@IsEnum` decorator used property, but it doesn't run expectation.
Then I tried using a `@IsIn` decorator instead of `@IsEnum`, and the behavior ran as expected.

Issue Number: N/A


## What is the new behavior?

When the option `classValidatorShim` is enabled and using the `@IsEnum` decorator at a property, the CLI plugin adds the `enum` property automatically.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

If I need then I will create an issue with the information, I don't know why exists the `readonly` option, and why can't run adding `enum` options by the `@IsIn` decorator when enabled the option `readonly`.