### PR TITLE
refactor!: fix options type of specific response decorators

### DIFF
--- a/lib/decorators/api-response.decorator.ts
+++ b/lib/decorators/api-response.decorator.ts
@@ -81,150 +81,150 @@ export function ApiResponse(
   };
 }
 
-export const ApiOkResponse = (options: ApiResponseOptions = {}) =>
+export const ApiOkResponse = (options: Omit<ApiResponseOptions, 'status'> = {}) =>
   ApiResponse({
     ...options,
     status: HttpStatus.OK
   });
 
-export const ApiCreatedResponse = (options: ApiResponseOptions = {}) =>
+export const ApiCreatedResponse = (options: Omit<ApiResponseOptions, 'status'> = {}) =>
   ApiResponse({
     ...options,
     status: HttpStatus.CREATED
   });
 
-export const ApiAcceptedResponse = (options: ApiResponseOptions = {}) =>
+export const ApiAcceptedResponse = (options: Omit<ApiResponseOptions, 'status'> = {}) =>
   ApiResponse({
     ...options,
     status: HttpStatus.ACCEPTED
   });
 
-export const ApiNoContentResponse = (options: ApiResponseOptions = {}) =>
+export const ApiNoContentResponse = (options: Omit<ApiResponseOptions, 'status'> = {}) =>
   ApiResponse({
     ...options,
     status: HttpStatus.NO_CONTENT
   });
 
-export const ApiMovedPermanentlyResponse = (options: ApiResponseOptions = {}) =>
+export const ApiMovedPermanentlyResponse = (options: Omit<ApiResponseOptions, 'status'> = {}) =>
   ApiResponse({
     ...options,
     status: HttpStatus.MOVED_PERMANENTLY
   });
 
-export const ApiFoundResponse = (options: ApiResponseOptions = {}) =>
+export const ApiFoundResponse = (options: Omit<ApiResponseOptions, 'status'> = {}) =>
   ApiResponse({
     ...options,
     status: HttpStatus.FOUND
   });
 
-export const ApiBadRequestResponse = (options: ApiResponseOptions = {}) =>
+export const ApiBadRequestResponse = (options: Omit<ApiResponseOptions, 'status'> = {}) =>
   ApiResponse({
     ...options,
     status: HttpStatus.BAD_REQUEST
   });
 
-export const ApiUnauthorizedResponse = (options: ApiResponseOptions = {}) =>
+export const ApiUnauthorizedResponse = (options: Omit<ApiResponseOptions, 'status'> = {}) =>
   ApiResponse({
     ...options,
     status: HttpStatus.UNAUTHORIZED
   });
 
-export const ApiTooManyRequestsResponse = (options: ApiResponseOptions = {}) =>
+export const ApiTooManyRequestsResponse = (options: Omit<ApiResponseOptions, 'status'> = {}) =>
   ApiResponse({
     ...options,
     status: HttpStatus.TOO_MANY_REQUESTS
   });
 
-export const ApiNotFoundResponse = (options: ApiResponseOptions = {}) =>
+export const ApiNotFoundResponse = (options: Omit<ApiResponseOptions, 'status'> = {}) =>
   ApiResponse({
     ...options,
     status: HttpStatus.NOT_FOUND
   });
 
 export const ApiInternalServerErrorResponse = (
-  options: ApiResponseOptions = {}
+  options: Omit<ApiResponseOptions, 'status'> = {}
 ) =>
   ApiResponse({
     ...options,
     status: HttpStatus.INTERNAL_SERVER_ERROR
   });
 
-export const ApiBadGatewayResponse = (options: ApiResponseOptions = {}) =>
+export const ApiBadGatewayResponse = (options: Omit<ApiResponseOptions, 'status'> = {}) =>
   ApiResponse({
     ...options,
     status: HttpStatus.BAD_GATEWAY
   });
 
-export const ApiConflictResponse = (options: ApiResponseOptions = {}) =>
+export const ApiConflictResponse = (options: Omit<ApiResponseOptions, 'status'> = {}) =>
   ApiResponse({
     ...options,
     status: HttpStatus.CONFLICT
   });
 
-export const ApiForbiddenResponse = (options: ApiResponseOptions = {}) =>
+export const ApiForbiddenResponse = (options: Omit<ApiResponseOptions, 'status'> = {}) =>
   ApiResponse({
     ...options,
     status: HttpStatus.FORBIDDEN
   });
 
-export const ApiGatewayTimeoutResponse = (options: ApiResponseOptions = {}) =>
+export const ApiGatewayTimeoutResponse = (options: Omit<ApiResponseOptions, 'status'> = {}) =>
   ApiResponse({
     ...options,
     status: HttpStatus.GATEWAY_TIMEOUT
   });
 
-export const ApiGoneResponse = (options: ApiResponseOptions = {}) =>
+export const ApiGoneResponse = (options: Omit<ApiResponseOptions, 'status'> = {}) =>
   ApiResponse({
     ...options,
     status: HttpStatus.GONE
   });
 
-export const ApiMethodNotAllowedResponse = (options: ApiResponseOptions = {}) =>
+export const ApiMethodNotAllowedResponse = (options: Omit<ApiResponseOptions, 'status'> = {}) =>
   ApiResponse({
     ...options,
     status: HttpStatus.METHOD_NOT_ALLOWED
   });
 
-export const ApiNotAcceptableResponse = (options: ApiResponseOptions = {}) =>
+export const ApiNotAcceptableResponse = (options: Omit<ApiResponseOptions, 'status'> = {}) =>
   ApiResponse({
     ...options,
     status: HttpStatus.NOT_ACCEPTABLE
   });
 
-export const ApiNotImplementedResponse = (options: ApiResponseOptions = {}) =>
+export const ApiNotImplementedResponse = (options: Omit<ApiResponseOptions, 'status'> = {}) =>
   ApiResponse({
     ...options,
     status: HttpStatus.NOT_IMPLEMENTED
   });
 
 export const ApiPreconditionFailedResponse = (
-  options: ApiResponseOptions = {}
+  options: Omit<ApiResponseOptions, 'status'> = {}
 ) =>
   ApiResponse({
     ...options,
     status: HttpStatus.PRECONDITION_FAILED
   });
 
-export const ApiPayloadTooLargeResponse = (options: ApiResponseOptions = {}) =>
+export const ApiPayloadTooLargeResponse = (options: Omit<ApiResponseOptions, 'status'> = {}) =>
   ApiResponse({
     ...options,
     status: HttpStatus.PAYLOAD_TOO_LARGE
   });
 
-export const ApiPaymentRequiredResponse = (options: ApiResponseOptions = {}) =>
+export const ApiPaymentRequiredResponse = (options: Omit<ApiResponseOptions, 'status'> = {}) =>
   ApiResponse({
     ...options,
     status: HttpStatus.PAYMENT_REQUIRED
   });
 
-export const ApiRequestTimeoutResponse = (options: ApiResponseOptions = {}) =>
+export const ApiRequestTimeoutResponse = (options: Omit<ApiResponseOptions, 'status'> = {}) =>
   ApiResponse({
     ...options,
     status: HttpStatus.REQUEST_TIMEOUT
   });
 
 export const ApiServiceUnavailableResponse = (
-  options: ApiResponseOptions = {}
+  options: Omit<ApiResponseOptions, 'status'> = {}
 ) =>
   ApiResponse({
     ...options,
@@ -232,7 +232,7 @@ export const ApiServiceUnavailableResponse = (
   });
 
 export const ApiUnprocessableEntityResponse = (
-  options: ApiResponseOptions = {}
+  options: Omit<ApiResponseOptions, 'status'> = {}
 ) =>
   ApiResponse({
     ...options,
@@ -240,14 +240,14 @@ export const ApiUnprocessableEntityResponse = (
   });
 
 export const ApiUnsupportedMediaTypeResponse = (
-  options: ApiResponseOptions = {}
+  options: Omit<ApiResponseOptions, 'status'> = {}
 ) =>
   ApiResponse({
     ...options,
     status: HttpStatus.UNSUPPORTED_MEDIA_TYPE
   });
 
-export const ApiDefaultResponse = (options: ApiResponseOptions = {}) =>
+export const ApiDefaultResponse = (options: Omit<ApiResponseOptions, 'status'> = {}) =>
   ApiResponse({
     ...options,
     status: 'default'


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
It's not obvious from .d.ts file that `status` field in `options` is overridden in every `Api*Response` decorator.

Issue Number: N/A


## What is the new behavior?
`status` field is omited from `ApiResponseOptions` type for each `Api*Response` decorator.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
It can cause TypeScript errors I guess? Fix: remove `status` field from `options` when using `Api*Response` decorator.

## Other information
