### PR TITLE
fix: enum array when using enumName

### DIFF
--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -262,18 +262,29 @@ export class SchemaObjectFactory {
     const $ref = getSchemaPath(enumName);
 
     if (!(enumName in schemas)) {
-      const _enum = param.enum
-        ? param.enum
-        : param.schema
-        ? param.schema['items']
-          ? param.schema['items']['enum']
-          : param.schema['enum']
-        : param.isArray && param.items
-        ? param.items.enum
-        : undefined;
+      let _enum;
+      let _type;
+      if (param.enum) {
+        _enum = param.enum;
+        _type = param.type;
+      } else if (param.schema) {
+        if (param.schema['items']) {
+          _enum = param.schema['items']['enum'];
+          _type = param.schema['items']['type'];
+        } else {
+          _enum = param.schema['enum'];
+          _type = param.schema['type'];
+        }
+      } else if (param.isArray && param.items) {
+        _enum = param.items.enum;
+        _type = param.items.type;
+      } else {
+        _enum = undefined;
+        _type = 'string';
+      }
 
       schemas[enumName] = {
-        type: param.schema?.['type'] ?? 'string',
+        type: _type ?? 'string',
         enum: _enum
       };
     }

--- a/test/explorer/swagger-explorer.spec.ts
+++ b/test/explorer/swagger-explorer.spec.ts
@@ -1087,6 +1087,7 @@ describe('SwaggerExplorer', () => {
 
     it('should properly define enum as schema with lazy function', () => {
       const explorer = new SwaggerExplorer(schemaObjectFactory);
+      const schema = explorer.getSchemas();
       const routes = explorer.exploreController(
         {
           instance: new BarController(),
@@ -1096,6 +1097,12 @@ describe('SwaggerExplorer', () => {
         'modulePath',
         'globalPrefix'
       );
+
+      expect(schema.QueryEnum).toEqual({ type: 'number', enum: [1, 2, 3] });
+      expect(schema.ParamEnum).toEqual({
+        type: 'string',
+        enum: ['a', 'b', 'c']
+      });
 
       expect(routes[0].root!.parameters).toEqual([
         {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

If you create an ApiQuery parameter, which has an `enum`, `enumName` and `isArray: true`, like this:

```ts
@ApiQuery({
  name: 'page',
  enum: ['a', 'b', 'c'],
  enumName: 'QueryEnum',
  isArray: true
})
```

The type in the schema will be `array` instead of the intended type for the items, e.g. `string`:

```ts
"QueryEnum": {
  "type": "array",
  "enum": ["a", "b", "c"]
}
```
Issue Number: N/A


## What is the new behavior?


It will now generate the correct type for the items schema:

```ts
"QueryEnum": {
  "type": "string",
  "enum": ["a", "b", "c"]
}
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
