### PR TITLE
fix: Retain $ref when setting name property

### DIFF
--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -365,7 +365,7 @@ export class SchemaObjectFactory {
     if (metadata.isArray) {
       return this.transformToArraySchemaProperty(metadata, key, { $ref });
     }
-    const keysToRemove = ['type', 'isArray', 'required'];
+    const keysToRemove = ['type', 'isArray', 'required', 'name'];
     const validMetadataObject = omit(metadata, keysToRemove);
     const extraMetadataKeys = Object.keys(validMetadataObject);
 

--- a/test/services/fixtures/create-profile.dto.ts
+++ b/test/services/fixtures/create-profile.dto.ts
@@ -10,7 +10,8 @@ export class CreateProfileDto {
   lastname: string;
 
   @ApiProperty({
-    type: () => CreateUserDto
+    type: () => CreateUserDto,
+    name: 'parent'
   })
   parent: CreateUserDto;
 }


### PR DESCRIPTION


## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #2951 


## What is the new behavior?
Setting the `name` property no longer results in a `$ref` being wrapped in `allOf`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
