### PR TITLE
fix: add missing refs declaration in swagger-shim

### DIFF
--- a/lib/extra/swagger-shim.ts
+++ b/lib/extra/swagger-shim.ts
@@ -171,7 +171,7 @@ export function getSchemaPath() {
   return () => '';
 }
 export function refs() {
-  return () => '';
+  return [];
 }
 export function before() {
   return () => '';

--- a/lib/extra/swagger-shim.ts
+++ b/lib/extra/swagger-shim.ts
@@ -170,6 +170,9 @@ export function PickType() {
 export function getSchemaPath() {
   return () => '';
 }
+export function refs() {
+  return () => '';
+}
 export function before() {
   return () => '';
 }


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When using `refs` in the frontend code with shim file used it fails because of missing refs export - of course if that was used.


## What is the new behavior?
No fail

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
