### PR TITLE
feat: Add schema support for "example" annotations

### DIFF
--- a/e2e/api-spec.json
+++ b/e2e/api-spec.json
@@ -293,6 +293,7 @@
               "title": "Page",
               "format": "int32",
               "default": 0,
+              "example": 123,
               "type": "number"
             }
           },
@@ -302,6 +303,10 @@
             "in": "query",
             "schema": {
               "nullable": true,
+              "example": [
+                "sort1",
+                "sort2"
+              ],
               "type": "array",
               "items": {
                 "type": "string"
@@ -490,6 +495,7 @@
               "title": "Page",
               "format": "int32",
               "default": 0,
+              "example": 123,
               "type": "number"
             }
           },
@@ -499,6 +505,10 @@
             "required": true,
             "schema": {
               "nullable": true,
+              "example": [
+                "sort1",
+                "sort2"
+              ],
               "type": "array",
               "items": {
                 "type": "string"

--- a/e2e/src/cats/dto/pagination-query.dto.ts
+++ b/e2e/src/cats/dto/pagination-query.dto.ts
@@ -14,13 +14,15 @@ export class PaginationQuery {
     exclusiveMaximum: true,
     exclusiveMinimum: true,
     format: 'int32',
-    default: 0
+    default: 0,
+    example: 123
   })
   page: number;
 
   @ApiProperty({
     name: '_sortBy',
-    nullable: true
+    nullable: true,
+    example: ['sort1', 'sort2']
   })
   sortBy: string[];
 

--- a/lib/services/swagger-types-mapper.ts
+++ b/lib/services/swagger-types-mapper.ts
@@ -157,7 +157,8 @@ export class SwaggerTypesMapper {
       'format',
       'pattern',
       'nullable',
-      'default'
+      'default',
+      'example'
     ];
   }
 }

--- a/test/plugin/fixtures/project/cats/dto/pagination-query.dto.ts
+++ b/test/plugin/fixtures/project/cats/dto/pagination-query.dto.ts
@@ -14,13 +14,15 @@ export class PaginationQuery {
     exclusiveMaximum: true,
     exclusiveMinimum: true,
     format: 'int32',
-    default: 0
+    default: 0,
+    example: 123
   })
   page: number;
 
   @ApiProperty({
     name: '_sortBy',
-    nullable: true
+    nullable: true,
+    example: ['sort1', 'sort2']
   })
   sortBy: string[];
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, the `example` annotation is not correctly copied into the `schema` object.

See https://swagger.io/docs/specification/adding-examples/.

Refer to:
https://github.com/nestjs/swagger/blob/02e03411f7823362247cdf0de0e185657ace2069/lib/services/swagger-types-mapper.ts#L114-L124
and
https://github.com/nestjs/swagger/blob/02e03411f7823362247cdf0de0e185657ace2069/lib/services/swagger-types-mapper.ts#L140-L161

Issue Number: N/A


## What is the new behavior?
Example annotations/properties are now correctly copied.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
