### PR TITLE
fix: api response overriding when using metadata loader

### DIFF
--- a/lib/explorers/api-response.explorer.ts
+++ b/lib/explorers/api-response.explorer.ts
@@ -110,7 +110,7 @@ function applyMetadataFactory(prototype: Type<unknown>, instance: object) {
       if (meta.status === undefined) {
         meta.status = getStatusCode(instance[key]);
       }
-      ApiResponse(meta, { overrideExisting: false })(
+      ApiResponse(meta, { overrideExisting: true })(
         classPrototype,
         key,
         Object.getOwnPropertyDescriptor(classPrototype, key)

--- a/test/explorer/swagger-explorer.spec.ts
+++ b/test/explorer/swagger-explorer.spec.ts
@@ -173,6 +173,8 @@ describe('SwaggerExplorer', () => {
         return {
           create: {
             summary: 'Create foo',
+            type: Foo,
+            description: 'Newly created Foo object',
             example: {
               id: 'foo',
               name: 'Foo'


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Response metadata was not being applied when using `loadPluginMetadata` if other responses metadata already existed.

Issue Number: #2974 


## What is the new behavior?
Response metadata will be applied when using `loadPluginMetadata` even if other responses metadata already exists.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
