### PR TITLE
fix: correct ApiParam type as in: path

### DIFF
--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -122,7 +122,7 @@ export class SchemaObjectFactory {
         (property: ParameterObject & ParamWithTypeMetadata) => {
           const parameterObject = {
             ...(omit(property, 'enumName') as ParameterObject),
-            in: 'query',
+            in: param.in ?? 'query',
             required: property.required ?? true
           };
           return parameterObject;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #3061


## What is the new behavior?
Class ApiProperties must be mapped as in: "path" when used in type of ApiParam

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
