### PR TITLE
feat: support x-enumNames param for client code generations

### DIFF
--- a/lib/decorators/api-property.decorator.ts
+++ b/lib/decorators/api-property.decorator.ts
@@ -8,6 +8,7 @@ export interface ApiPropertyOptions
   name?: string;
   enum?: any[] | Record<string, any> | (() => (any[] | Record<string, any>));
   enumName?: string;
+  'x-enumNames'?: string[]
 }
 
 const isEnumArray = (obj: ApiPropertyOptions): boolean =>

--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -288,7 +288,8 @@ export class SchemaObjectFactory {
           (param.isArray
             ? param.schema?.['items']?.['type']
             : param.schema?.['type']) ?? 'string',
-        enum: _enum
+        enum: _enum,
+        ...(param['x-enumNames'] ? {'x-enumNames': param['x-enumNames']} : {})
       };
     }
 
@@ -297,7 +298,7 @@ export class SchemaObjectFactory {
         ? { type: 'array', items: { $ref } }
         : { $ref };
 
-    return omit(param, ['isArray', 'items', 'enumName', 'enum']);
+    return omit(param, ['isArray', 'items', 'enumName', 'enum', 'x-enumNames']);
   }
 
   createEnumSchemaType(


### PR DESCRIPTION
Supporting numeric enums for client code generators

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
When using a client swagger generator for numeric enums there is a missing feature for setting the enum names, causing a problem when needed to use a numeric enum without success, adding 'x-enumNames' with ts-ignore causing the param to not be copy to the component created when using 'enumName'

Issue Number: N/A


## What is the new behavior?
When copying the params of the enum to the created component add also 'x-enumNames', and then the numeric enum will be generated fine using a codegen

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
