### PR TITLE
fix(@nestjs/swagger): api property should be required by default

### DIFF
--- a/lib/decorators/api-property.decorator.ts
+++ b/lib/decorators/api-property.decorator.ts
@@ -6,16 +6,18 @@ import { createPropertyDecorator, getTypeIsArrayTuple } from './helpers';
 export interface ApiPropertyOptions
   extends Omit<SchemaObjectMetadata, 'name' | 'enum'> {
   name?: string;
-  enum?: any[] | Record<string, any> | (() => (any[] | Record<string, any>));
+  enum?: any[] | Record<string, any> | (() => any[] | Record<string, any>);
   enumName?: string;
-  'x-enumNames'?: string[]
+  'x-enumNames'?: string[];
 }
 
 const isEnumArray = (obj: ApiPropertyOptions): boolean =>
   obj.isArray && !!obj.enum;
 
 export function ApiProperty(
-  options: ApiPropertyOptions = {}
+  options: ApiPropertyOptions = {
+    required: true
+  }
 ): PropertyDecorator {
   return createApiPropertyDecorator(options);
 }

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -221,9 +221,10 @@ describe('SchemaObjectFactory', () => {
               type: 'array',
               items: {
                 type: 'string'
-              }
+              },
+              required: true
             },
-            type: 'array'
+            type: 'array',
           },
           twoDimensionModels: {
             items: {


### PR DESCRIPTION
The ApiProperty decorator was not required by default which rendered the ApiPropertyOptional decorator redundant.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

The `@ApiProperty()` decorator will now be set as `required` by default,
as previously the `required` flag was `false` if given no options and that
would mean the `@ApiPropertyOptional()` decorator is the same duplicated
code as the other decorator.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
