### PR TITLE
feat(document-builder): add setOpenApiVersion method

### DIFF
--- a/lib/document-builder.ts
+++ b/lib/document-builder.ts
@@ -46,6 +46,15 @@ export class DocumentBuilder {
     return this;
   }
 
+  public setOpenAPIVersion(version: string): this {
+    if (version.match(/^\d\.\d\.\d$/)) {
+      this.document.openapi = version;
+    } else {
+      this.logger.warn('The OpenApi version is invalid. Expecting format "x.x.x"');
+    }
+    return this;
+  }
+
   public addServer(
     url: string,
     description?: string,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Today, the OpenApi Spec version is hard coded at lib/fixtures/document.base.ts and there's no way to change it.

Issue Number: https://github.com/nestjs/swagger/issues/2361

## What is the new behavior?
Creates a new method at the DocumentBuilder called setOpenApiVersion that receives a string, checks if its a valid OpenApi Spec Version and if so override the default versions previously defined.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
The PR reopens https://github.com/nestjs/swagger/pull/2516 as it was closed before being merged.