### PR TITLE
fix(@nest/swagger): Add merge-options condition for dtoFileNameSuffix to CLI-Plugin

### DIFF
--- a/lib/plugin/merge-options.ts
+++ b/lib/plugin/merge-options.ts
@@ -1,4 +1,6 @@
 import { isString } from '@nestjs/common/utils/shared.utils';
+import { pluginDebugLogger } from './plugin-debug-logger';
+import { isArray } from 'lodash';
 
 export interface PluginOptions {
   dtoFileNameSuffix?: string | string[];
@@ -34,6 +36,13 @@ export const mergePluginOptions = (
   }
   if (isString(options.controllerFileNameSuffix)) {
     options.controllerFileNameSuffix = [options.controllerFileNameSuffix];
+  }
+  for (const key of ["dtoFileNameSuffix", "controllerFileNameSuffix"]){
+    if (options[key] && options[key].includes(".ts")){
+      pluginDebugLogger.warn(`Skipping ${key} option ".ts" because it can cause unwanted behaviour.`);
+      options[key] = options[key].filter(e => e !== ".ts");
+      if (options[key].length == 0) delete options[key];
+    }
   }
   return {
     ...defaultOptions,

--- a/test/plugin/fixtures/create-option.ts
+++ b/test/plugin/fixtures/create-option.ts
@@ -1,0 +1,37 @@
+export const createCliPluginMultiOption = 
+{
+  "dtoFileNameSuffix": [ '.ts', '.dto.ts' ],
+  "introspectComments": true
+};
+
+export const createCliPluginSingleOption = 
+{
+  "dtoFileNameSuffix": [ ".ts" ],
+  "introspectComments": true
+};
+
+export const mergedCliPluginMultiOption = 
+{
+  dtoFileNameSuffix: [ '.dto.ts' ],
+  controllerFileNameSuffix: [ '.controller.ts' ],
+  classValidatorShim: true,
+  classTransformerShim: false,
+  dtoKeyOfComment: 'description',
+  controllerKeyOfComment: 'description',
+  introspectComments: true,
+  readonly: false,
+  debug: false
+};
+
+export const mergedCliPluginSingleOption = 
+{
+  dtoFileNameSuffix: [ '.dto.ts', '.entity.ts' ],
+  controllerFileNameSuffix: [ '.controller.ts' ],
+  classValidatorShim: true,
+  classTransformerShim: false,
+  dtoKeyOfComment: 'description',
+  controllerKeyOfComment: 'description',
+  introspectComments: true,
+  readonly: false,
+  debug: false
+};

--- a/test/plugin/merge-option.spec.ts
+++ b/test/plugin/merge-option.spec.ts
@@ -1,0 +1,19 @@
+import { 
+  createCliPluginMultiOption,
+  createCliPluginSingleOption,
+  mergedCliPluginMultiOption,
+  mergedCliPluginSingleOption
+} from "./fixtures/create-option";
+import { mergePluginOptions } from "../../lib/plugin/merge-options";
+
+describe('CLI Plugin options', () => {
+  it('should skip element when dtoFileNameSuffix key has more than one element and include ".ts"', () => {
+    const merged = mergePluginOptions(createCliPluginMultiOption);
+    expect(JSON.stringify(merged)).toEqual(JSON.stringify(mergedCliPluginMultiOption));
+  });
+
+  it('should delete key when dtoFileNameSuffix key has 1 element and element is “.ts”', () => {
+    const merged = mergePluginOptions(createCliPluginSingleOption);
+    expect(JSON.stringify(merged)).toEqual(JSON.stringify(mergedCliPluginSingleOption));
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Issue Number: #2958

When using the cli-plugin, it does not recognize the file for controller when the dtoFileNameSuffix option contains “.ts”.

## What is the new behavior?
When using the cli-plugin, if the dtoFileNameSuffix option contains “.ts”, omit the “.ts”.
It also leaves a warning log.


## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
