### PR TITLE
fix(plugin): resolve compiler option paths relative to base

### DIFF
--- a/lib/plugin/utils/plugin-utils.ts
+++ b/lib/plugin/utils/plugin-utils.ts
@@ -171,15 +171,13 @@ export function replaceImportPath(
       ? convertPath(options.pathToSource)
       : posix.dirname(convertPath(fileName));
 
-    for (const [key, value] of Object.entries(compilerOptionsPaths)) {
-      const keyToMatch = key.replace('*', '');
-      if (importPath.includes(keyToMatch)) {
-        const newImportPath = posix.join(
-          from,
-          importPath.replace(keyToMatch, value[0].replace('*', ''))
-        );
-        typeReference = typeReference.replace(importPath, newImportPath);
-        importPath = newImportPath;
+    for (const [optionName, optionPaths] of Object.entries(
+      compilerOptionsPaths
+    )) {
+      if (importPath.includes(optionName)) {
+        const optionPath = optionPaths[0];
+        typeReference = typeReference.replace(optionName, optionPath);
+        importPath = importPath.replace(optionName, optionPath);
         break;
       }
     }
@@ -210,7 +208,6 @@ export function replaceImportPath(
     }
 
     typeReference = typeReference.replace(importPath, relativePath);
-
     if (options.readonly) {
       const { typeName, typeImportStatement } =
         convertToAsyncImport(typeReference);
@@ -396,4 +393,37 @@ export function canReferenceNode(node: ts.Node, options: PluginOptions) {
     return true;
   }
   return false;
+}
+
+/**
+ * Get modifies compiler options paths where
+ *
+ * - all `*` are removed from the aliases and paths
+ * - all paths are resolved to absolute paths
+ *
+ * If both `baseUrl` and `pathsBasePath` are not set, the current
+ * compilation directory is used as the base path for resolution.
+ */
+export function getAbsoluteCompilerOptionsPaths(
+  program: ts.Program
+): ts.MapLike<string[]> {
+  const compilerOptions = program.getCompilerOptions();
+  const { paths } = compilerOptions;
+  if (!paths) {
+    return {};
+  }
+
+  const base =
+    (compilerOptions.pathsBasePath as string | undefined) ||
+    compilerOptions.baseUrl ||
+    program.getCurrentDirectory();
+
+  const result: ts.MapLike<string[]> = {};
+  for (const [key, list] of Object.entries(paths)) {
+    result[key.replace('/*', '')] = list.map((item) => {
+      const path = item.replace('/*', '');
+      return isAbsolute(path) ? path : posix.join(base, path);
+    });
+  }
+  return result;
 }

--- a/lib/plugin/visitors/controller-class.visitor.ts
+++ b/lib/plugin/visitors/controller-class.visitor.ts
@@ -14,6 +14,7 @@ import {
 } from '../utils/ast-utils';
 import {
   convertPath,
+  getAbsoluteCompilerOptionsPaths,
   getDecoratorOrUndefinedByNames,
   getTypeReferenceAsString,
   hasPropertyKey
@@ -58,7 +59,7 @@ export class ControllerClassVisitor extends AbstractFileVisitor {
     options: PluginOptions
   ) {
     const typeChecker = program.getTypeChecker();
-    const compilerOptionsPaths = program.getCompilerOptions().paths ?? {};
+    const compilerOptionsPaths = getAbsoluteCompilerOptionsPaths(program);
     if (!options.readonly) {
       sourceFile = this.updateImports(sourceFile, ctx.factory, program);
     }

--- a/lib/plugin/visitors/model-class.visitor.ts
+++ b/lib/plugin/visitors/model-class.visitor.ts
@@ -28,6 +28,7 @@ import {
   canReferenceNode,
   convertPath,
   extractTypeArgumentIfArray,
+  getAbsoluteCompilerOptionsPaths,
   getDecoratorOrUndefinedByNames,
   getTypeReferenceAsString,
   hasPropertyKey,
@@ -72,7 +73,7 @@ export class ModelClassVisitor extends AbstractFileVisitor {
   ) {
     const externalImports = getExternalImports(sourceFile);
     const typeChecker = program.getTypeChecker();
-    const compilerOptionsPaths = program.getCompilerOptions().paths ?? {};
+    const compilerOptionsPaths = getAbsoluteCompilerOptionsPaths(program);
     sourceFile = this.updateImports(sourceFile, ctx.factory, program);
 
     const propertyNodeVisitorFactory =


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently compiler option paths never take the base path into the account when resolving dependencies (as introduced in #3134). In certain configurations this can lead to errors as we always join the resolved path with the source file path.
This is likely causing issues in #3154.

## What is the new behavior?
Compiler option paths are resolved to base path if declared as relative.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
