### PR TITLE
fix: @ApiSchema inheritance

### DIFF
--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -292,7 +292,7 @@ export class SchemaObjectFactory {
       return type.name;
     }
 
-    const schemaName = customSchema[0].name;
+    const schemaName = customSchema[customSchema.length - 1].name;
     return schemaName ?? type.name;
   }
 

--- a/lib/utils/get-schema-path.util.ts
+++ b/lib/utils/get-schema-path.util.ts
@@ -21,7 +21,7 @@ function getSchemaNameByClass(target: Function): string {
     return target.name;
   }
 
-  return customSchema[0].name ?? target.name;
+  return customSchema[customSchema.length - 1].name ?? target.name;
 }
 
 export function refs(...models: Function[]) {

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -412,6 +412,24 @@ describe('SchemaObjectFactory', () => {
       expect(Object.keys(schemas)).toContain('UpdateUserDto');
     });
 
+    it('should override the schema name of base class', () => {
+      @ApiSchema({
+        name: 'CreateUser'
+      })
+      class CreateUserDto {}
+
+      @ApiSchema({
+        name: 'UpdateUser'
+      })
+      class UpdateUserDto extends CreateUserDto {}
+
+      const schemas: Record<string, SchemasObject> = {};
+
+      schemaObjectFactory.exploreModelSchema(UpdateUserDto, schemas);
+
+      expect(Object.keys(schemas)).toContain('UpdateUser');
+    });
+
     it('should include extension properties', () => {
       @ApiExtension('x-test', 'value')
       class CreatUserDto {


### PR DESCRIPTION
Ensure the correct @ApiSchema name is used when inheriting from a base class.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #3160


## What is the new behavior?

The correct schema name will be used


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

There's also a fix necessary for `getSchemaPath` (get-schema-ath.util.ts). However I have not found a single test for these utils, so I didn't add one but applied the exact same fix.