### PR TITLE
fix: support for multiple api decorators on schema class

### DIFF
--- a/e2e/api-spec.json
+++ b/e2e/api-spec.json
@@ -1677,6 +1677,12 @@
             ]
           }
         },
+        "x-schema-extension-multiple": {
+          "test": "test"
+        },
+        "x-schema-extension": {
+          "test": "test"
+        },
         "required": [
           "name",
           "age",

--- a/e2e/src/cats/classes/cat.class.ts
+++ b/e2e/src/cats/classes/cat.class.ts
@@ -1,6 +1,8 @@
-import { ApiProperty } from '../../../../lib';
+import { ApiExtension, ApiProperty } from '../../../../lib';
 import { LettersEnum } from '../dto/pagination-query.dto';
 
+@ApiExtension('x-schema-extension', { test: 'test' })
+@ApiExtension('x-schema-extension-multiple', { test: 'test' })
 export class Cat {
   @ApiProperty({ example: 'Kitty', description: 'The name of the Cat' })
   name: string;

--- a/e2e/validate-schema.e2e-spec.ts
+++ b/e2e/validate-schema.e2e-spec.ts
@@ -111,13 +111,21 @@ describe('Validate OpenAPI schema', () => {
     writeFileSync(join(__dirname, 'api-spec.json'), doc);
 
     try {
-      const api = await SwaggerParser.validate(document as any);
+      const api = (await SwaggerParser.validate(
+        document as any
+      )) as OpenAPIV3.Document;
       console.log(
         'API name: %s, Version: %s',
         api.info.title,
         api.info.version
       );
       expect(api.info.title).toEqual('Cats example');
+      expect(
+        api.components.schemas['Cat']['x-schema-extension']['test']
+      ).toEqual('test');
+      expect(
+        api.components.schemas['Cat']['x-schema-extension-multiple']['test']
+      ).toEqual('test');
       expect(
         api.paths['/api/cats']['post']['callbacks']['myEvent'][
           '{$request.body#/callbackUrl}'
@@ -204,6 +212,6 @@ describe('Validate OpenAPI schema', () => {
           'image/jpeg': { schema: { type: 'string', format: 'binary' } }
         }
       }
-    })
+    });
   });
 });

--- a/lib/decorators/helpers.ts
+++ b/lib/decorators/helpers.ts
@@ -114,7 +114,16 @@ export function createMixedDecorator<T = any>(
       Reflect.defineMetadata(metakey, metadatas, descriptor.value);
       return descriptor;
     }
-    Reflect.defineMetadata(metakey, metadata, target);
+
+    let metadatas: any;
+    if (Array.isArray(metadata)) {
+      const previousMetadata = Reflect.getMetadata(metakey, target) || [];
+      metadatas = [...previousMetadata, ...metadata];
+    } else {
+      const previousMetadata = Reflect.getMetadata(metakey, target) || {};
+      metadatas = Object.assign(Object.assign({}, previousMetadata), metadata);
+    }
+    Reflect.defineMetadata(metakey, metadatas, target);
     return target;
   };
 }


### PR DESCRIPTION
Support multiple `@ApiExtension` decorators on the schema class. This implementation applies the same fix as #1525 but also for the class, not just for the member functions.

This enables you do use multiple `@ApiExtension` (and other mixed decorators) on an API schema definition like this:
```ts
@ApiExtension('x-foo', { test: 'test' })
@ApiExtension('x-bar', { test: 'test' })
class CatDto {
}
```

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently it is not possible to use the same decorator multiple times on the same class. I.e. using two `@ApiExtension()` decorators will only result in the first one being applied.

Issue Number: N/A


## What is the new behavior?
This PR fixes this behavior and applies all decorators as expected. It implements the same fix as #1525 but on a class level.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
