### PR TITLE
feat: Add recursiveModuleScan option to scanner

### DIFF
--- a/e2e/src/dogs/depth1-dogs/depth1-dogs.controller.ts
+++ b/e2e/src/dogs/depth1-dogs/depth1-dogs.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiTags } from '../../../../lib';
+
+@ApiTags('depth1-dogs')
+@Controller('depth1-dogs')
+export class Depth1DogsController {
+  @Get()
+  findAll() {
+    return 'Depth1 Dogs';
+  }
+}

--- a/e2e/src/dogs/depth1-dogs/depth1-dogs.module.ts
+++ b/e2e/src/dogs/depth1-dogs/depth1-dogs.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { Depth1DogsController } from './depth1-dogs.controller';
+import { Depth2DogsModule } from '../depth2-dogs/depth2-dogs.module';
+
+@Module({
+  imports: [Depth2DogsModule],
+  controllers: [Depth1DogsController]
+})
+export class Depth1DogsModule {}

--- a/e2e/src/dogs/depth2-dogs/depth2-dogs.controller.ts
+++ b/e2e/src/dogs/depth2-dogs/depth2-dogs.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiTags } from '../../../../lib';
+
+@ApiTags('depth2-dogs')
+@Controller('depth2-dogs')
+export class Depth2DogsController {
+  @Get()
+  findAll() {
+    return 'Depth2 Dogs';
+  }
+}

--- a/e2e/src/dogs/depth2-dogs/depth2-dogs.module.ts
+++ b/e2e/src/dogs/depth2-dogs/depth2-dogs.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { Depth2DogsController } from './depth2-dogs.controller';
+import { Depth3DogsModule } from '../depth3-dogs/depth3-dogs.module';
+
+@Module({
+  imports: [Depth3DogsModule],
+  controllers: [Depth2DogsController]
+})
+export class Depth2DogsModule {}

--- a/e2e/src/dogs/depth3-dogs/depth3-dogs.controller.ts
+++ b/e2e/src/dogs/depth3-dogs/depth3-dogs.controller.ts
@@ -1,0 +1,11 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiTags } from '../../../../lib';
+
+@ApiTags('depth3-dogs')
+@Controller('depth3-dogs')
+export class Depth3DogsController {
+  @Get()
+  findAll() {
+    return 'Depth3 Dogs';
+  }
+}

--- a/e2e/src/dogs/depth3-dogs/depth3-dogs.module.ts
+++ b/e2e/src/dogs/depth3-dogs/depth3-dogs.module.ts
@@ -1,0 +1,7 @@
+import { Module } from '@nestjs/common';
+import { Depth3DogsController } from './depth3-dogs.controller';
+
+@Module({
+  controllers: [Depth3DogsController]
+})
+export class Depth3DogsModule {}

--- a/e2e/src/dogs/dogs.controller.ts
+++ b/e2e/src/dogs/dogs.controller.ts
@@ -1,0 +1,16 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiTags } from '../../../lib';
+
+@ApiTags('dogs')
+@Controller('dogs')
+export class DogsController {
+  @Get()
+  findAll() {
+    return 'Dogs';
+  }
+
+  @Get('puppies')
+  findPuppies() {
+    return 'Puppies';
+  }
+}

--- a/e2e/src/dogs/dogs.module.ts
+++ b/e2e/src/dogs/dogs.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { DogsController } from './dogs.controller';
+import { Depth1DogsModule } from './depth1-dogs/depth1-dogs.module';
+
+@Module({
+  imports: [Depth1DogsModule],
+  controllers: [DogsController]
+})
+export class DogsModule {}

--- a/lib/interfaces/swagger-document-options.interface.ts
+++ b/lib/interfaces/swagger-document-options.interface.ts
@@ -53,4 +53,20 @@ export interface SwaggerDocumentOptions {
    * @default true
    */
   autoTagControllers?: boolean;
+
+  /**
+   * If `true`, swagger will recursively scan all nested imported by `include` modules.
+   * When enabled, this overrides the default behavior of `deepScanRoutes` to scan all depths.
+   *
+   * @default false
+   */
+  recursiveModuleScan?: boolean;
+
+  /**
+   * Maximum depth level for recursive module scanning.
+   * Only applies when `recursiveModuleScan` is `true`.
+   *
+   * @default Infinity
+   */
+  maxScanDepth?: number;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The Swagger scanner only scans up to 1-depth for modules included via the `include` option, even when `deepScanRoutes` is set to `true`.

Issue Number: #3102

## What is the new behavior?
<img width="686" alt="스크린샷 2024-11-24 오후 2 01 00" src="https://github.com/user-attachments/assets/6ba92ec3-6e23-4723-ab05-7e7f39ad997a">

When `deepScanRoutes` is set to `true` and the newly added `recursiveModuleScan` flag is also set to `true`, the modules included via `include` will be scanned recursively up to the depth defined by `maxScanDepth`.

- **`deepScanRoutes: false`**: Only scans root modules imported by `include` (current behavior).
- **`deepScanRoutes: true`**: Scans 1-depth modules imported by `include` (current behavior).
- **`deepScanRoutes: true, recursiveModuleScan: true`**: Scans all modules recursively, with no depth limit.
- **`deepScanRoutes: true, recursiveModuleScan: true, maxScanDepth: 5`**: Scans modules recursively up to a depth of 5.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
