### PR TITLE
feat: Add schema support for array items

### DIFF
--- a/e2e/api-spec.json
+++ b/e2e/api-spec.json
@@ -677,7 +677,8 @@
               "title": "Page",
               "format": "int32",
               "default": 0,
-              "example": 123
+              "example": 123,
+              "type": "number"
             }
           },
           {
@@ -689,7 +690,11 @@
               "example": [
                 "sort1",
                 "sort2"
-              ]
+              ],
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
             }
           },
           {
@@ -736,7 +741,10 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "array"
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/LettersEnum"
+              }
             }
           },
           {
@@ -744,7 +752,10 @@
             "in": "query",
             "required": true,
             "schema": {
-              "type": "array"
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/Letter"
+              }
             }
           },
           {
@@ -752,7 +763,8 @@
             "in": "query",
             "required": true,
             "schema": {
-              "format": "date-time"
+              "format": "date-time",
+              "type": "string"
             }
           },
           {
@@ -768,7 +780,8 @@
                   "type": "number"
                 }
               },
-              "additionalProperties": true
+              "additionalProperties": true,
+              "type": "object"
             }
           },
           {

--- a/lib/services/swagger-types-mapper.ts
+++ b/lib/services/swagger-types-mapper.ts
@@ -16,12 +16,10 @@ type KeysToRemove =
 
 export class SwaggerTypesMapper {
   private readonly keysToRemove: Array<KeysToRemove> = [
-    'type',
     'isArray',
     'enum',
     'enumName',
     'enumSchema',
-    'items',
     '$ref',
     ...this.getSchemaOptionsKeys()
   ];
@@ -146,7 +144,9 @@ export class SwaggerTypesMapper {
       'default',
       'example',
       'oneOf',
-      'anyOf'
+      'anyOf',
+      'type',
+      'items'
     ];
   }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A
When a parameter is specified as an array, the `type` and `items` of the parameter are not currently rendered in the schema. E.g.

```
  @ApiProperty({
    name: '_sortBy',
    nullable: true,
  })
  sortBy: string[];
```
produces
```
- name: _sortBy
- in: query
- required: true
- schema:
  - nullable: true
```

This is not valid OpenAPI 3.0. 

## What is the new behavior?

`type` and `items` are specified in the schema.

```
- name: _sortBy
- in: query
- required: true
- schema:
  - nullable: true
  - type: array
  - items:
    - type: string
```

This conforms to the OpenAPI 3.0 spec as described here for how arrays should be serialized in the url: https://swagger.io/docs/specification/v3_0/serialization/#serialization-and-rfc-6570

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

This PR would add additional OpenAPI properties an existing spec without any callsite updates. It's possible some existing SDK-generation pipeline based off the specs might be triggered to validate new things, but a spec without `items` for `type: array` is not actually valid, which makes me think the chance of breaking SDK generation is fairly slim.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
