### PR TITLE
refactor: Replace express/fastify specific methods with adapter methods

### DIFF
--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -149,7 +149,7 @@ export class SwaggerModule {
     httpAdapter.get(
       normalizeRelPath(`${finalPath}/swagger-ui-init.js`),
       (req, res) => {
-        res.type('application/javascript');
+        httpAdapter.type(res, 'application/javascript');
         const document = getBuiltDocument();
 
         if (swaggerOptions.patchDocumentOnRequest) {
@@ -162,14 +162,14 @@ export class SwaggerModule {
             documentToSerialize,
             swaggerOptions
           );
-          return res.send(swaggerInitJsPerRequest);
+          return httpAdapter.send(res, swaggerInitJsPerRequest);
         }
 
         if (!swaggerUiInitJS) {
           swaggerUiInitJS = buildSwaggerInitJS(document, swaggerOptions);
         }
 
-        res.send(swaggerUiInitJS);
+        httpAdapter.send(res, swaggerUiInitJS);
       }
     );
 
@@ -183,7 +183,7 @@ export class SwaggerModule {
           `${finalPath}/${urlLastSubdirectory}/swagger-ui-init.js`
         ),
         (req, res) => {
-          res.type('application/javascript');
+          httpAdapter.type(res, 'application/javascript');
           const document = getBuiltDocument();
 
           if (swaggerOptions.patchDocumentOnRequest) {
@@ -196,14 +196,14 @@ export class SwaggerModule {
               documentToSerialize,
               swaggerOptions
             );
-            return res.send(swaggerInitJsPerRequest);
+            return httpAdapter.send(res, swaggerInitJsPerRequest);
           }
 
           if (!swaggerUiInitJS) {
             swaggerUiInitJS = buildSwaggerInitJS(document, swaggerOptions);
           }
 
-          res.send(swaggerUiInitJS);
+          httpAdapter.send(res, swaggerUiInitJS);
         }
       );
     } catch (err) {
@@ -214,13 +214,13 @@ export class SwaggerModule {
     }
 
     function serveSwaggerHtml(_: any, res: any) {
-      res.type('text/html');
+      httpAdapter.type(res, 'text/html');
 
       if (!swaggerUiHtml) {
         swaggerUiHtml = buildSwaggerHTML(baseUrlForSwaggerUI, swaggerOptions);
       }
 
-      res.send(swaggerUiHtml);
+      httpAdapter.send(res, swaggerUiHtml);
     }
 
     httpAdapter.get(finalPath, serveSwaggerHtml);
@@ -251,7 +251,7 @@ export class SwaggerModule {
   ) {
     if (serveOptions.serveJson) {
       httpAdapter.get(normalizeRelPath(options.jsonDocumentUrl), (req, res) => {
-        res.type('application/json');
+        httpAdapter.type(res, 'application/json');
         const document = getBuiltDocument();
 
         const documentToSerialize = options.swaggerOptions
@@ -259,13 +259,13 @@ export class SwaggerModule {
           ? options.swaggerOptions.patchDocumentOnRequest(req, res, document)
           : document;
 
-        res.send(JSON.stringify(documentToSerialize));
+        httpAdapter.send(res, JSON.stringify(documentToSerialize));
       });
     }
 
     if (serveOptions.serveYaml) {
       httpAdapter.get(normalizeRelPath(options.yamlDocumentUrl), (req, res) => {
-        res.type('text/yaml');
+        httpAdapter.type(res, 'text/yaml');
         const document = getBuiltDocument();
 
         const documentToSerialize = options.swaggerOptions
@@ -277,7 +277,7 @@ export class SwaggerModule {
           skipInvalid: true,
           noRefs: true
         });
-        res.send(yamlDocument);
+        httpAdapter.send(res, yamlDocument);
       });
     }
   }


### PR DESCRIPTION
Replace express/fastify specific methods with adapter methods

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
req.send and erq.type is express/fastify specific code https://nodejs.org/api/http.html#requestenddata-encoding-callback

Issue Number: N/A


## What is the new behavior?
To work with any adapters.

## Does this PR introduce a breaking change?
- [ x] Yes
- [ ] No

Need to add that methods (send and type) to all adapters if not (official and custom).

## Other information
