### PR TITLE
feat: make generated require() ESM compatible

### DIFF
--- a/lib/plugin/utils/plugin-utils.ts
+++ b/lib/plugin/utils/plugin-utils.ts
@@ -137,6 +137,16 @@ export function hasPropertyKey(
     .some((item) => item.name.getText() === key);
 }
 
+function getOutputExtension(fileName: string): string {  
+  if (fileName.endsWith('.mts')) {
+    return '.mjs';
+  } else if (fileName.endsWith('.cts')) {
+    return '.cjs';
+  } else{
+    return ".js";
+  }
+}
+
 export function replaceImportPath(
   typeReference: string,
   fileName: string,
@@ -190,6 +200,10 @@ export function replaceImportPath(
       if (indexPos >= 0) {
         relativePath = relativePath.slice(0, indexPos);
       }
+    } else {
+      // Add appropriate extension for non-node_modules imports
+      const extension = getOutputExtension(fileName);
+      relativePath += extension;
     }
 
     typeReference = typeReference.replace(importPath, relativePath);
@@ -203,6 +217,7 @@ export function replaceImportPath(
         importPath: relativePath
       };
     }
+
     return {
       typeReference: typeReference.replace('import', 'require'),
       importPath: relativePath

--- a/test/plugin/fixtures/parameter-property.dto.ts
+++ b/test/plugin/fixtures/parameter-property.dto.ts
@@ -29,7 +29,7 @@ export class ParameterPropertyDto {
         this.protectedValue = protectedValue;
     }
     static _OPENAPI_METADATA_FACTORY() {
-        return { readonlyValue: { required: false, type: () => String }, privateValue: { required: true, type: () => String, nullable: true }, publicValue: { required: true, type: () => [require("./parameter-property.dto").ItemDto] }, protectedValue: { required: true, type: () => String, default: "1234" } };
+        return { readonlyValue: { required: false, type: () => String }, privateValue: { required: true, type: () => String, nullable: true }, publicValue: { required: true, type: () => [require("./parameter-property.dto.js").ItemDto] }, protectedValue: { required: true, type: () => String, default: "1234" } };
     }
 }
 export var LettersEnum;
@@ -43,7 +43,7 @@ export class ItemDto {
         this.enumValue = enumValue;
     }
     static _OPENAPI_METADATA_FACTORY() {
-        return { enumValue: { required: true, enum: require("./parameter-property.dto").LettersEnum } };
+        return { enumValue: { required: true, enum: require("./parameter-property.dto.js").LettersEnum } };
     }
 }
 `;

--- a/test/plugin/fixtures/serialized-meta.fixture.ts
+++ b/test/plugin/fixtures/serialized-meta.fixture.ts
@@ -1,12 +1,14 @@
 // @ts-nocheck
 export default async () => {
   const t = {
-    ['./cats/dto/pagination-query.dto']: await import(
-      './cats/dto/pagination-query.dto'
+    ['./cats/dto/pagination-query.dto.js']: await import(
+      './cats/dto/pagination-query.dto.js'
     ),
-    ['./cats/dto/create-cat.dto']: await import('./cats/dto/create-cat.dto'),
-    ['./cats/dto/tag.dto']: await import('./cats/dto/tag.dto'),
-    ['./cats/classes/cat.class']: await import('./cats/classes/cat.class')
+    ['./cats/dto/create-cat.dto.js']: await import(
+      './cats/dto/create-cat.dto.js'
+    ),
+    ['./cats/dto/tag.dto.js']: await import('./cats/dto/tag.dto.js'),
+    ['./cats/classes/cat.class.js']: await import('./cats/classes/cat.class.js')
   };
   return {
     '@nestjs/swagger': {
@@ -21,16 +23,16 @@ export default async () => {
               constrainedLimit: { required: false, type: () => Number },
               enum: {
                 required: true,
-                enum: t['./cats/dto/pagination-query.dto'].LettersEnum
+                enum: t['./cats/dto/pagination-query.dto.js'].LettersEnum
               },
               enumArr: {
                 required: true,
-                enum: t['./cats/dto/pagination-query.dto'].LettersEnum,
+                enum: t['./cats/dto/pagination-query.dto.js'].LettersEnum,
                 isArray: true
               },
               letters: {
                 required: true,
-                enum: t['./cats/dto/pagination-query.dto'].LettersEnum,
+                enum: t['./cats/dto/pagination-query.dto.js'].LettersEnum,
                 isArray: true
               },
               beforeDate: { required: true, type: () => Date },
@@ -60,11 +62,11 @@ export default async () => {
               options: { required: false, type: () => [Object] },
               enum: {
                 required: true,
-                enum: t['./cats/dto/pagination-query.dto'].LettersEnum
+                enum: t['./cats/dto/pagination-query.dto.js'].LettersEnum
               },
               enumArr: {
                 required: true,
-                enum: t['./cats/dto/pagination-query.dto'].LettersEnum
+                enum: t['./cats/dto/pagination-query.dto.js'].LettersEnum
               },
               uppercaseString: { required: true, type: () => String },
               lowercaseString: { required: true, type: () => String },
@@ -137,30 +139,30 @@ export default async () => {
               options: { required: false, type: () => [Object] },
               enum: {
                 required: true,
-                enum: t['./cats/dto/pagination-query.dto'].LettersEnum
+                enum: t['./cats/dto/pagination-query.dto.js'].LettersEnum
               },
               state: {
                 required: false,
                 description: 'Available language in the application',
                 example: 'FR',
-                enum: t['./cats/dto/create-cat.dto'].CategoryState
+                enum: t['./cats/dto/create-cat.dto.js'].CategoryState
               },
               enumArr: {
                 required: true,
-                enum: t['./cats/dto/pagination-query.dto'].LettersEnum
+                enum: t['./cats/dto/pagination-query.dto.js'].LettersEnum
               },
               enumArr2: {
                 required: true,
-                enum: t['./cats/dto/pagination-query.dto'].LettersEnum,
+                enum: t['./cats/dto/pagination-query.dto.js'].LettersEnum,
                 isArray: true
               },
               tag: {
                 required: true,
-                type: () => t['./cats/dto/tag.dto'].TagDto
+                type: () => t['./cats/dto/tag.dto.js'].TagDto
               },
               multipleTags: {
                 required: true,
-                type: () => [t['./cats/dto/tag.dto'].TagDto]
+                type: () => [t['./cats/dto/tag.dto.js'].TagDto]
               },
               nested: {
                 required: true,
@@ -197,11 +199,11 @@ export default async () => {
           import('./cats/cats.controller'),
           {
             CatsController: {
-              create: { type: t['./cats/classes/cat.class'].Cat },
-              findOne: { type: t['./cats/classes/cat.class'].Cat },
+              create: { type: t['./cats/classes/cat.class.js'].Cat },
+              findOne: { type: t['./cats/classes/cat.class.js'].Cat },
               findAll: {},
-              createBulk: { type: t['./cats/classes/cat.class'].Cat },
-              createAsFormData: { type: t['./cats/classes/cat.class'].Cat },
+              createBulk: { type: t['./cats/classes/cat.class.js'].Cat },
+              createAsFormData: { type: t['./cats/classes/cat.class.js'].Cat },
               getWithEnumParam: {},
               getWithRandomQuery: {}
             }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: [NestJS Contribution Guide](https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md)
- [x] Tests have been added (for bug fixes and/or features)
- [x] Documentation has been added or updated (for bug fixes and/or features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional or API changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
NestJS does not officially support ESM. I have a project that successfully uses ESM with a custom fork, but in this Swagger plugin, the only incompatibility I found is that the generated code uses `require` without file extensions.

- Prior to Node.js 22, `require` could not import ES modules.
- As of Node.js 22, `require` can import ES modules, but missing file extensions continue to cause issues.

Issue Number: N/A

## What is the new behavior?
This PR adds the appropriate file extension in the generated code based on the input extension (.cts, .mts, or .ts), thereby improving compatibility with ESM.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
I am a new NestJS user who has integrated it into an existing ESM-based project. Currently, I rely on a monkey-patch workaround, but I would prefer to avoid such hacky solutions. This PR addresses that concern by providing a more robust and maintainable approach.