### PR TITLE
fix(swagger): improve rendering of array items

### DIFF
--- a/lib/services/swagger-types-mapper.ts
+++ b/lib/services/swagger-types-mapper.ts
@@ -115,8 +115,8 @@ export class SwaggerTypesMapper {
         ...omit(this.getSchemaOptions(param), [...itemsModifierKeys]),
         type: 'array',
         items: isString((items as any).type)
-          ? { type: (items as any).type, ...modifierProperties }
-          : { ...(items as any).type, ...modifierProperties }
+          ? { type: (items as any).type, ...modifierProperties, ...items }
+          : { ...(items as any).type, ...modifierProperties, ...items }
       }
     };
   }

--- a/test/explorer/swagger-explorer.spec.ts
+++ b/test/explorer/swagger-explorer.spec.ts
@@ -2509,4 +2509,56 @@ describe('SwaggerExplorer', () => {
       ]);
     });
   });
+
+  it('should explore array query parameters with minLenght and maxLength', () => {
+    class FooDto {
+      @ApiProperty({
+        type: 'array',
+        isArray: true,
+        items: {
+          type: 'string',
+          minLength: 1,
+          maxLength: 10
+        },
+        example: ['a', 'b', 'c'],
+        minItems: 5,
+        maxItems: 50
+      })
+      field: string[];
+    }
+
+    class FooController {
+      @Get('/route1')
+      route1(@Query() fooDto: FooDto) {}
+    }
+
+    const explorer = new SwaggerExplorer(schemaObjectFactory);
+    const routes = explorer.exploreController(
+      {
+        instance: new FooController(),
+        metatype: FooController
+      } as InstanceWrapper<FooController>,
+      new ApplicationConfig(),
+      'path'
+    );
+
+    expect(routes[0].root.parameters).toEqual([
+      {
+        name: 'field',
+        required: true,
+        in: 'query',
+        schema: {
+          example: ['a', 'b', 'c'],
+          type: 'array',
+          items: {
+            type: 'string',
+            minLength: 1,
+            maxLength: 10
+          },
+          minItems: 5,
+          maxItems: 50
+        }
+      }
+    ]);
+  });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When documenting items in arrays, `minLength` and `maxLength` will not be rendered. 

Issue Number: #3207 

## What is the new behavior?

`minLength` and `maxLength` can now be used to document items in arrays.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
