### PR TITLE
fix: incorrect IsUuid class-validator decorator

### DIFF
--- a/lib/services/decorators-properties.ts
+++ b/lib/services/decorators-properties.ts
@@ -90,7 +90,7 @@ export const decoratorsProperties = [
   },
   {
     mappingType: decoratorsPropertiesMappingType.INDIRECT_VALUE,
-    decorator: 'IsUuid',
+    decorator: 'IsUUID',
     property: 'format',
     value: 'uuid'
   },

--- a/test/plugin/fixtures/create-cat.dto.ts
+++ b/test/plugin/fixtures/create-cat.dto.ts
@@ -56,7 +56,7 @@ export class CreateCatDto {
   response: Record<string, any>;
   @IsUrl()
   githubAccount: string;
-  @IsUuid()
+  @IsUUID()
   transactionId: string;
   @IsMobilePhone()
   phoneNumber: string;
@@ -177,7 +177,7 @@ __decorate([
     IsUrl()
 ], CreateCatDto.prototype, "githubAccount", void 0);
 __decorate([
-    IsUuid()
+    IsUUID()
 ], CreateCatDto.prototype, "transactionId", void 0);
 __decorate([
     IsMobilePhone()


### PR DESCRIPTION

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
This PR corrects class-validator property decorator name IsUuid to IsUUID. ([Reference](https://www.npmjs.com/package/class-validator#validation-decorators) class-validator decorators)

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently IsUUID decorator from class-validator is not adding {pattern: uuid} in the generated swagger property.

Issue Number: N/A


## What is the new behavior?
Using IsUUID decorator from class-validator now adds {pattern: uuid} in the generated swagger property.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
