### PR TITLE
fix(swagger-options): add persistAuthorization to SwaggerUiOptions

### DIFF
--- a/lib/interfaces/swagger-ui-options.interface.ts
+++ b/lib/interfaces/swagger-ui-options.interface.ts
@@ -18,5 +18,6 @@ export interface SwaggerUiOptions {
     useBasicAuthenticationWithAccessCodeGrant?: boolean;
     usePkceWithAuthorizationCodeGrant?: boolean;
   };
+  persistAuthorization?: boolean;
   [key: string]: any;
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: Type definition improvement (developer experience)

## What is the current behavior?
Currently, `SwaggerUiOptions` does not include the `persistAuthorization` property, which is a valid option in Swagger UI.
This causes TypeScript users to not receive autocomplete and type safety for this option.

Issue Number: N/A


## What is the new behavior?
This PR adds `persistAuthorization` to the `SwaggerUiOptions` interface, allowing TypeScript users to use this option with proper type inference.



## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Swagger UI documentation confirms that `persistAuthorization` is a valid option.
Reference: https://swagger.io/docs/open-source-tools/swagger-ui/usage/configuration/
