### PR TITLE
fix(swagger): added options in createEnumSchemaType

### DIFF
--- a/lib/interfaces/open-api-spec.interface.ts
+++ b/lib/interfaces/open-api-spec.interface.ts
@@ -232,6 +232,7 @@ export interface SchemaObject {
   minProperties?: number;
   required?: string[];
   enum?: any[];
+  'x-enumNames'?: string[];
 }
 
 export type SchemasObject = Record<string, SchemaObject>;

--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -34,7 +34,6 @@ import { isDateCtor } from '../utils/is-date-ctor.util';
 import { ModelPropertiesAccessor } from './model-properties-accessor';
 import { ParamWithTypeMetadata } from './parameter-metadata-accessor';
 import { SwaggerTypesMapper } from './swagger-types-mapper';
-import e = require('express');
 
 export class SchemaObjectFactory {
   constructor(
@@ -409,11 +408,11 @@ export class SchemaObjectFactory {
       schemas[enumName] = {
         type: enumType,
         ...metadata.enumSchema,
-        description: metadata.description ?? undefined,
         enum:
           metadata.isArray && metadata.items
             ? metadata.items['enum']
             : metadata.enum,
+        description: metadata.description ?? undefined,
         'x-enumNames': metadata['x-enumNames'] ?? undefined
       };
     } else {
@@ -632,11 +631,10 @@ export class SchemaObjectFactory {
       };
     }
 
-    if (isEnumMetadata(metadata)) {
-      return this.createEnumSchemaType(key, metadata, schemas);
-    }
-
     if (isString(typeRef)) {
+      if (isEnumMetadata(metadata)) {
+        return this.createEnumSchemaType(key, metadata, schemas);
+      }
       if (metadata.isArray) {
         return this.transformToArraySchemaProperty(metadata, key, typeRef);
       }

--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -409,12 +409,12 @@ export class SchemaObjectFactory {
       schemas[enumName] = {
         type: enumType,
         ...metadata.enumSchema,
-        description: metadata.description,
+        description: metadata.description ?? undefined,
         enum:
           metadata.isArray && metadata.items
             ? metadata.items['enum']
             : metadata.enum,
-        'x-enumNames': metadata['x-enumNames'] ?? []
+        'x-enumNames': metadata['x-enumNames'] ?? undefined
       };
     } else {
       if (metadata.enumSchema) {
@@ -435,7 +435,9 @@ export class SchemaObjectFactory {
       type: metadata.isArray ? 'array' : 'string'
     };
 
-    const refHost = metadata.isArray ? { items: { $ref } } : { $ref };
+    const refHost = metadata.isArray
+      ? { items: { $ref } }
+      : { allOf: [{ $ref }] };
 
     const paramObject = { ..._schemaObject, ...refHost };
     const pathsToOmit = ['enum', 'enumName', 'enumSchema'];


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
```
export enum StatusEnum {
  APPROVED = 1,
  PENDING,
  REJECTED,
}

export class Meeting {
  name: string;

  @ApiProperty({
    description: 'The status of the meeting',
    enum: StatusEnum,
    enumName: 'StatusEnum',
    'x-enumNames': ['APPROVED', 'PENDING', 'REJECTED'],
  })
  status: StatusEnum;
}
```

```
# current schemas
"components": {
    "schemas": {
      "StatusEnum": {
        "type": "number",
        "enum": [
          1,
          2,
          3
        ]
      },
      "Meeting": {
        "type": "object",
        "properties": {
          "status": {
            "description": "The status of the meeting",
            "x-enumNames": [
              "APPROVED",
              "PENDING",
              "REJECTED"
            ],
            "allOf": [
              {
                "$ref": "#/components/schemas/StatusEnum"
              }
            ]
          },
          "name": {
            "type": "string"
          }
        },
        "required": [
          "status",
          "name"
        ]
      }
    }
```

x-enumNames no longer works from v8.0.0 

Previously, `x-enumNames` allowed customization of enum names in, but after the refactor in PR #3123, it was unintentionally removed. This breaks compatibility with certain API client generators that rely on `x-enumNames` for correct enum name mapping.

Issue Number: #3294 





## What is the new behavior?
Restores support for x-enumNames
```
"components": {
    "schemas": {
      "StatusEnum": {
        "type": "number",
        "description": "The status of the meeting",
        "enum": [
          1,
          2,
          3
        ],
        "x-enumNames": [
          "APPROVED",
          "PENDING",
          "REJECTED"
        ]
      },
      "Meeting": {
        "type": "object",
        "properties": {
          "status": {
            "$ref": "#/components/schemas/StatusEnum"
          },
          "name": {
            "type": "string"
          }
        },
        "required": [
          "status",
          "name"
        ]
      }
    }
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
