### PR TITLE
feat(enum): add support for enum varnames and descriptions

### DIFF
--- a/e2e/api-spec.json
+++ b/e2e/api-spec.json
@@ -1420,6 +1420,25 @@
           "REJECTED"
         ]
       },
+      "XEnumVarnamesTest": {
+        "type": "number",
+        "enum": [
+          1,
+          2,
+          3
+        ],
+        "description": "The x-enum-varnames and x-enum-descriptions test",
+        "x-enum-varnames": [
+          "APPROVED",
+          "PENDING",
+          "REJECTED"
+        ],
+        "x-enum-descriptions": [
+          "Approved State",
+          "Pending State",
+          "Rejected State"
+        ]
+      },
       "CreateCatDto": {
         "type": "object",
         "properties": {
@@ -1511,6 +1530,14 @@
                 "$ref": "#/components/schemas/XEnumTest"
               }
             ]
+          },
+          "xEnumVarnamesTest": {
+            "description": "The x-enum-varnames and x-enum-descriptions test",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/XEnumVarnamesTest"
+              }
+            ]
           }
         },
         "x-tags": [
@@ -1529,7 +1556,8 @@
           "enum",
           "enumArr",
           "enumWithRef",
-          "xEnumTest"
+          "xEnumTest",
+          "xEnumVarnamesTest"
         ]
       },
       "Cat": {

--- a/e2e/src/cats/dto/create-cat.dto.ts
+++ b/e2e/src/cats/dto/create-cat.dto.ts
@@ -88,7 +88,16 @@ export class CreateCatDto {
     description: 'The x-enumNames test',
     enum: XEnumTest,
     enumName: 'XEnumTest',
-    'x-enumNames': ['APPROVED', 'PENDING', 'REJECTED']
+    'x-enumNames': ['APPROVED', 'PENDING', 'REJECTED'],
   })
   xEnumTest: XEnumTest;
+
+  @ApiProperty({
+    description: 'The x-enum-varnames and x-enum-descriptions test',
+    enum: XEnumTest,
+    enumName: 'XEnumVarnamesTest',
+    'x-enum-varnames': ['APPROVED', 'PENDING', 'REJECTED'],
+    'x-enum-descriptions': ['Approved State', 'Pending State', 'Rejected State']
+  })
+  xEnumVarnamesTest: XEnumTest;
 }

--- a/lib/decorators/api-property.decorator.ts
+++ b/lib/decorators/api-property.decorator.ts
@@ -9,8 +9,7 @@ import { getEnumType, getEnumValues } from '../utils/enum.utils';
 import { createPropertyDecorator, getTypeIsArrayTuple } from './helpers';
 
 export type ApiPropertyCommonOptions = SchemaObjectMetadata & {
-  'x-enumNames'?: string[];
-  /**
+    /**
    * Lazy function returning the type for which the decorated property
    * can be used as an id
    *

--- a/lib/interfaces/open-api-spec.interface.ts
+++ b/lib/interfaces/open-api-spec.interface.ts
@@ -233,6 +233,8 @@ export interface SchemaObject {
   required?: string[];
   enum?: any[];
   'x-enumNames'?: string[];
+  'x-enum-varnames'?: string[];
+  'x-enum-descriptions'?: string[];
 }
 
 export type SchemasObject = Record<string, SchemaObject>;

--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -335,6 +335,11 @@ export class SchemaObjectFactory {
   ) {
     const enumName = param.enumName;
     const $ref = getSchemaPath(enumName);
+    const enumSchemaExtensions = [
+      'x-enumNames',
+      'x-enum-varnames',
+      'x-enum-descriptions'
+    ];
 
     if (!(enumName in schemas)) {
       const _enum = param.enum
@@ -354,7 +359,10 @@ export class SchemaObjectFactory {
             : param.schema?.['type']) ?? 'string',
         enum: _enum,
         ...param.enumSchema,
-        ...(param['x-enumNames'] ? { 'x-enumNames': param['x-enumNames'] } : {})
+        ...enumSchemaExtensions.reduce(
+          (acc, c) => ({ ...acc, ...(param[c] ? { [c]: param[c] } : {}) }),
+          {}
+        )
       };
     } else {
       // Enum type is already defined so grab it and
@@ -377,8 +385,8 @@ export class SchemaObjectFactory {
       'items',
       'enumName',
       'enum',
-      'x-enumNames',
-      'enumSchema'
+      'enumSchema',
+      ...enumSchemaExtensions
     ]);
   }
 
@@ -396,6 +404,11 @@ export class SchemaObjectFactory {
 
     const enumName = metadata.enumName;
     const $ref = getSchemaPath(enumName);
+    const enumSchemaExtensions = [
+      'x-enumNames',
+      'x-enum-varnames',
+      'x-enum-descriptions'
+    ];
 
     const enumType: string =
       (metadata.isArray ? metadata.items['type'] : metadata.type) ?? 'string';
@@ -409,7 +422,10 @@ export class SchemaObjectFactory {
             ? metadata.items['enum']
             : metadata.enum,
         description: metadata.description ?? undefined,
-        'x-enumNames': metadata['x-enumNames'] ?? undefined
+        ...enumSchemaExtensions.reduce(
+          (acc, c) => ({ ...acc, ...{ [c]: metadata[c] ?? undefined } }),
+          {}
+        )
       };
     } else {
       if (metadata.enumSchema) {
@@ -419,8 +435,10 @@ export class SchemaObjectFactory {
         };
       }
 
-      if (metadata['x-enumNames']) {
-        schemas[enumName]['x-enumNames'] = metadata['x-enumNames'];
+      for (const extension of enumSchemaExtensions) {
+        if (metadata[extension]) {
+          schemas[enumName][extension] = metadata[extension];
+        }
       }
     }
 
@@ -435,7 +453,12 @@ export class SchemaObjectFactory {
       : { allOf: [{ $ref }] };
 
     const paramObject = { ..._schemaObject, ...refHost };
-    const pathsToOmit = ['enum', 'enumName', 'enumSchema', 'x-enumNames'];
+    const pathsToOmit = [
+      'enum',
+      'enumName',
+      'enumSchema',
+      ...enumSchemaExtensions
+    ];
 
     if (!metadata.isArray) {
       pathsToOmit.push('type');

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -589,6 +589,25 @@ describe('SchemaObjectFactory', () => {
 
       expect(schemas).toEqual({ MyEnum: { enum: [1, 2, 3], type: 'number' } });
     });
+
+    it('should create an enum schema definition with extended attributes', () => {
+
+      const extendedAttributes = {
+        'x-enum-varnames': ['APPROVED', 'PENDING', 'REJECTED'],
+        'x-enum-descriptions': ['Approved State', 'Pending State', 'Rejected State'],
+      }
+      const metadata = {
+        type: 'number',
+        enum: [1, 2, 3],
+        enumName: 'MyEnum',
+        isArray: false,
+        ...extendedAttributes
+      } as const;
+      const schemas = {};
+      schemaObjectFactory.createEnumSchemaType('field', metadata, schemas);
+
+      expect(schemas).toEqual({ MyEnum: { enum: [1, 2, 3], type: 'number', ...extendedAttributes } });
+    });
   });
 
   describe('createEnumParam', () => {
@@ -627,6 +646,29 @@ describe('SchemaObjectFactory', () => {
       expect(schemas['MyEnum']).toEqual({
         enum: ['a', 'b', 'c'],
         type: 'string'
+      });
+    });
+
+    it('should create an enum schema definition with extended attributes', () => {
+
+      const extendedAttributes = {
+        'x-enum-varnames': ['APPROVED', 'PENDING', 'REJECTED'],
+        'x-enum-descriptions': ['Approved State', 'Pending State', 'Rejected State'],
+      }
+      const params: ParamWithTypeMetadata & BaseParameterObject & { 'x-enum-varnames': string[], 'x-enum-descriptions': string[] } = {
+        required: true,
+        isArray: true,
+        enumName: 'MyEnum',
+        enum: [1, 2, 3],
+        ...extendedAttributes,
+      };
+      const schemas = {};
+      schemaObjectFactory.createEnumParam(params, schemas);
+
+      expect(schemas['MyEnum']).toEqual({
+        enum: [1, 2, 3],
+        type: 'string',
+        ...extendedAttributes
       });
     });
   });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently only the `x-enumNames` extension is supported for specifying names for enums, however the popular [openapi generator](https://openapi-generator.tech/docs/templating/#all-generators-core) only supports the `x-enum-varnames` extension.

Issue Number: N/A


## What is the new behavior?
Add support for the  `x-enum-varnames`  and `x-enum-descriptions` extensions to be added to the schema.

Example:
```typescript
enum StatusEnum {
  APPROVED = 1,
  PENDING,
  REJECTED
 }

  @ApiProperty({
    description: 'The status enum example',
    enum: StatusEnum,
    enumName: 'StatusEnum',
    'x-enum-varnames': ['APPROVED', 'PENDING', 'REJECTED'],
    'x-enum-descriptions': ['Approved State', 'Pending State', 'Rejected State']
  })
  statusEnum: StatusEnum;
```

Would generate:
```json
   {
      "StatusEnum ": {
        "type": "number",
        "enum": [
          1,
          2,
          3
        ],
        "description": "The status enum example",
        "x-enum-varnames": [
          "APPROVED",
          "PENDING",
          "REJECTED"
        ],
        "x-enum-descriptions": [
          "Approved State",
          "Pending State",
          "Rejected State"
        ]
      }
   }
```
## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
