### PR TITLE
chore(swagger): include model name in circular dependency warning

### DIFF
--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -453,7 +453,7 @@ export class SchemaObjectFactory {
   ): SchemaObjectMetadata {
     if (isUndefined(trueMetadataType)) {
       throw new Error(
-        `A circular dependency has been detected (property key: "${key}"). Please, make sure that each side of a bidirectional relationships are using lazy resolvers ("type: () => ClassType").`
+        `A circular dependency has been detected (property key: "${key}"${pendingSchemaRefs[0] ? ` on model ${pendingSchemaRefs[0]}` : ''}). Please, make sure that each side of a bidirectional relationships are using lazy resolvers ("type: () => ClassType").`
       );
     }
     let schemaObjectName = (trueMetadataType as Function).name;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md

## PR Type
What kind of change does this PR introduce?

- [x] Other - Improved Error Message

## What is the current behavior?
Right now nest shows something like this:
`Error: A circular dependency has been detected (property key: "id"). Please, make sure that each side of a bidirectional relationships are using lazy resolvers ("type: () => ClassType").`. If you've changed / refactored few files in your repo you probably don't easily know with Model had the error (and since the error occurred in the `id` field for me, it could've been basically any)

## What is the new behavior?
We're now checking if there is a `pendingSchemaRef`. As far as I understood the code this is a list of models to work on. In my testing the first item always equaled the model that the error was thrown so I thought it might be a good idea to include the model name in the error message.
If I was just "lucky" and the order of the `pendingSchemaRefs` isn't actually sorted in any way making the error message invalid, I guess we can close this (if there is no other easy way to infer the models name)

## Does this PR introduce a breaking change?
- [x] No
