### PR TITLE
fix: import handling for ESM compatibility

### DIFF
--- a/lib/plugin/utils/plugin-utils.ts
+++ b/lib/plugin/utils/plugin-utils.ts
@@ -177,8 +177,12 @@ export function replaceImportPath(
     if (isAbsolute(importPath)) {
       throw {};
     }
+
     require.resolve(importPath);
-    typeReference = typeReference.replace('import', 'require');
+    if (!options.esmCompatible) {
+      typeReference = typeReference.replace('import', 'require');
+    }
+
     return {
       typeReference,
       importPath: null
@@ -229,8 +233,12 @@ export function replaceImportPath(
       };
     }
 
+    if (!options.esmCompatible) {
+      typeReference = typeReference.replace('import', 'require');
+    }
+
     return {
-      typeReference: typeReference.replace('import', 'require'),
+      typeReference,
       importPath: relativePath
     };
   }

--- a/test/plugin/fixtures/parameter-property.dto.ts
+++ b/test/plugin/fixtures/parameter-property.dto.ts
@@ -23,10 +23,10 @@ export class ItemDto {
 `;
 
 export const parameterPropertyDtoTextTranspiled = (esmCompatible?: boolean) => {
-  let fileName = 'parameter-property.dto';
-  if (esmCompatible) {
-    fileName += getOutputExtension(fileName);
-  }
+  const fileName = 'parameter-property.dto';
+  const fileImport = esmCompatible
+    ? `import("./${fileName}${getOutputExtension(fileName)}")`
+    : `require("./${fileName}")`;
 
   return `import * as openapi from "@nestjs/swagger";
 export class ParameterPropertyDto {
@@ -37,7 +37,7 @@ export class ParameterPropertyDto {
         this.protectedValue = protectedValue;
     }
     static _OPENAPI_METADATA_FACTORY() {
-        return { readonlyValue: { required: false, type: () => String }, privateValue: { required: true, type: () => String, nullable: true }, publicValue: { required: true, type: () => [require("./${fileName}").ItemDto] }, protectedValue: { required: true, type: () => String, default: "1234" } };
+        return { readonlyValue: { required: false, type: () => String }, privateValue: { required: true, type: () => String, nullable: true }, publicValue: { required: true, type: () => [${fileImport}.ItemDto] }, protectedValue: { required: true, type: () => String, default: "1234" } };
     }
 }
 export var LettersEnum;
@@ -51,7 +51,7 @@ export class ItemDto {
         this.enumValue = enumValue;
     }
     static _OPENAPI_METADATA_FACTORY() {
-        return { enumValue: { required: true, enum: require("./${fileName}").LettersEnum } };
+        return { enumValue: { required: true, enum: ${fileImport}.LettersEnum } };
     }
 }
 `;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/nestjs/swagger/pull/3362
Fixing errors in the environment that were not tested in the previous PR.

- ✅ commonjs
- ✅ esm + swc
- ❌ esm + tsc

## What is the new behavior?

- ✅ esm + tsc

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The format of the output when building in `swc` and `tsc` is different.
`swc` converts `require` to `import` in the metadata, but `tsc` does not.

**tsc**
```js
__decorate([
    Get('memo/:id'),
    openapi.ApiResponse({ status: 200, type: require("../entities/test/memo.entity.js").Memo }),
    __param(0, Param('id', ParseIntPipe)),
    __metadata("design:type", Function),
    __metadata("design:paramtypes", [Number]),
    __metadata("design:returntype", Promise)
], SampleController.prototype, "read", null);
```

**swc**
```js
_ts_decorate([
    Get('memo/:id'),
    _ts_param(0, Param('id', ParseIntPipe)),
    _ts_metadata("design:type", Function),
    _ts_metadata("design:paramtypes", [
        Number
    ]),
    _ts_metadata("design:returntype", Promise)
], SampleController.prototype, "read", null);
```