### PR TITLE
feat(schema): add duplicate DTO detection in schema exploration

### DIFF
--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -265,6 +265,16 @@ export class SchemaObjectFactory {
     if (this.isLazyTypeFunc(type as Function)) {
       type = (type as Function)();
     }
+
+    const { schemaName, schemaProperties } = this.getSchemaMetadata(type);
+
+    if (schemas[schemaName]) {
+      throw new Error(
+        `Duplicate DTO detected: "${schemaName}" is defined multiple times with different schemas.\n` +
+          `Consider using unique class names or applying @ApiExtraModels() decorator with custom schema names.`
+      );
+    }
+
     const propertiesWithType = this.extractPropertiesFromType(
       type as Type<unknown>,
       schemas,
@@ -276,7 +286,6 @@ export class SchemaObjectFactory {
     const extensionProperties =
       Reflect.getMetadata(DECORATORS.API_EXTENSION, type) || {};
 
-    const { schemaName, schemaProperties } = this.getSchemaMetadata(type);
 
     const typeDefinition: SchemaObject = {
       type: 'object',

--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -266,7 +266,6 @@ export class SchemaObjectFactory {
     if (this.isLazyTypeFunc(type as Function)) {
       type = (type as Function)();
     }
-
     const propertiesWithType = this.extractPropertiesFromType(
       type as Type<unknown>,
       schemas,

--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -267,8 +267,6 @@ export class SchemaObjectFactory {
       type = (type as Function)();
     }
 
-    const { schemaName, schemaProperties } = this.getSchemaMetadata(type);
-
     const propertiesWithType = this.extractPropertiesFromType(
       type as Type<unknown>,
       schemas,
@@ -279,6 +277,8 @@ export class SchemaObjectFactory {
     }
     const extensionProperties =
       Reflect.getMetadata(DECORATORS.API_EXTENSION, type) || {};
+
+    const { schemaName, schemaProperties } = this.getSchemaMetadata(type);
 
     const typeDefinition: SchemaObject = {
       type: 'object',

--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -313,7 +313,7 @@ export class SchemaObjectFactory {
     }
 
     if (schemas[schemaName] && !isEqual(schemas[schemaName], typeDefinition)) {
-      console.error(
+      Logger.error(
         `Duplicate DTO detected: "${schemaName}" is defined multiple times with different schemas.\n` +
           `Consider using unique class names or applying @ApiExtraModels() decorator with custom schema names.\n` +
           `Note: This will throw an error in the next major version.`

--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -313,9 +313,10 @@ export class SchemaObjectFactory {
     }
 
     if (schemas[schemaName] && !isEqual(schemas[schemaName], typeDefinition)) {
-      throw new Error(
+      console.error(
         `Duplicate DTO detected: "${schemaName}" is defined multiple times with different schemas.\n` +
-          `Consider using unique class names or applying @ApiExtraModels() decorator with custom schema names.`
+          `Consider using unique class names or applying @ApiExtraModels() decorator with custom schema names.\n` +
+          `Note: This will throw an error in the next major version.`
       );
     }
 

--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -1,4 +1,4 @@
-import { Type } from '@nestjs/common';
+import { Logger, Type } from '@nestjs/common';
 import { isUndefined } from '@nestjs/common/utils/shared.utils';
 import {
   flatten,

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -176,7 +176,8 @@ describe('SchemaObjectFactory', () => {
       });
     });
 
-    it('should throw an error when detecting duplicate DTOs with different schemas', () => {
+    it('should log an error when detecting duplicate DTOs with different schemas', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
       const schemas: Record<string, SchemasObject> = {};
 
       class DuplicateDTO {
@@ -195,18 +196,22 @@ describe('SchemaObjectFactory', () => {
         value: 'DuplicateDTO'
       });
 
-      expect(() =>
-        schemaObjectFactory.exploreModelSchema(
-          DuplicateDTOWithDifferentSchema,
-          schemas
-        )
-      ).toThrow(
-        'Duplicate DTO detected: "DuplicateDTO" is defined multiple times with different schemas.\n' +
-          'Consider using unique class names or applying @ApiExtraModels() decorator with custom schema names.'
+      schemaObjectFactory.exploreModelSchema(
+        DuplicateDTOWithDifferentSchema,
+        schemas
       );
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        `Duplicate DTO detected: "DuplicateDTO" is defined multiple times with different schemas.\n` +
+          `Consider using unique class names or applying @ApiExtraModels() decorator with custom schema names.\n` +
+          `Note: This will throw an error in the next major version.`
+      );
+
+      consoleErrorSpy.mockRestore();
     });
 
-    it('should not throw an error when detecting duplicate DTOs with the same schemas', () => {
+    it('should not throw an error or log error when detecting duplicate DTOs with the same schemas', () => {
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
       const schemas: Record<string, SchemasObject> = {};
 
       class DuplicateDTO {
@@ -225,12 +230,14 @@ describe('SchemaObjectFactory', () => {
         value: 'DuplicateDTO'
       });
 
-      expect(() =>
-        schemaObjectFactory.exploreModelSchema(
-          DuplicateDTOWithSameSchema,
-          schemas
-        )
-      ).not.toThrow();
+      schemaObjectFactory.exploreModelSchema(
+        DuplicateDTOWithSameSchema,
+        schemas
+      );
+
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
     });
 
     it('should create openapi schema', () => {

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -206,6 +206,33 @@ describe('SchemaObjectFactory', () => {
       );
     });
 
+    it('should not throw an error when detecting duplicate DTOs with the same schemas', () => {
+      const schemas: Record<string, SchemasObject> = {};
+
+      class DuplicateDTO {
+        @ApiProperty()
+        property1: string;
+      }
+
+      schemaObjectFactory.exploreModelSchema(DuplicateDTO, schemas);
+
+      class DuplicateDTOWithSameSchema {
+        @ApiProperty()
+        property1: string;
+      }
+
+      Object.defineProperty(DuplicateDTOWithSameSchema, 'name', {
+        value: 'DuplicateDTO'
+      });
+
+      expect(() =>
+        schemaObjectFactory.exploreModelSchema(
+          DuplicateDTOWithSameSchema,
+          schemas
+        )
+      ).not.toThrow();
+    });
+
     it('should create openapi schema', () => {
       const schemas: Record<string, SchemasObject> = {};
       const schemaKey = schemaObjectFactory.exploreModelSchema(

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -1,4 +1,5 @@
 import { ApiExtension, ApiProperty, ApiSchema } from '../../lib/decorators';
+import { Logger } from '@nestjs/common';
 import {
   BaseParameterObject,
   SchemasObject
@@ -177,7 +178,7 @@ describe('SchemaObjectFactory', () => {
     });
 
     it('should log an error when detecting duplicate DTOs with different schemas', () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const loggerErrorSpy = jest.spyOn(Logger, 'error').mockImplementation();
       const schemas: Record<string, SchemasObject> = {};
 
       class DuplicateDTO {
@@ -201,17 +202,17 @@ describe('SchemaObjectFactory', () => {
         schemas
       );
 
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
         `Duplicate DTO detected: "DuplicateDTO" is defined multiple times with different schemas.\n` +
           `Consider using unique class names or applying @ApiExtraModels() decorator with custom schema names.\n` +
           `Note: This will throw an error in the next major version.`
       );
 
-      consoleErrorSpy.mockRestore();
+      loggerErrorSpy.mockRestore();
     });
 
     it('should not throw an error or log error when detecting duplicate DTOs with the same schemas', () => {
-      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+      const loggerErrorSpy = jest.spyOn(Logger, 'error').mockImplementation();
       const schemas: Record<string, SchemasObject> = {};
 
       class DuplicateDTO {
@@ -235,9 +236,9 @@ describe('SchemaObjectFactory', () => {
         schemas
       );
 
-      expect(consoleErrorSpy).not.toHaveBeenCalled();
+      expect(loggerErrorSpy).not.toHaveBeenCalled();
 
-      consoleErrorSpy.mockRestore();
+      loggerErrorSpy.mockRestore();
     });
 
     it('should create openapi schema', () => {

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -176,6 +176,36 @@ describe('SchemaObjectFactory', () => {
       });
     });
 
+    it('should throw an error when detecting duplicate DTOs with different schemas', () => {
+      const schemas: Record<string, SchemasObject> = {};
+
+      class DuplicateDTO {
+        @ApiProperty()
+        property1: string;
+      }
+
+      schemaObjectFactory.exploreModelSchema(DuplicateDTO, schemas);
+
+      class DuplicateDTOWithDifferentSchema {
+        @ApiProperty()
+        property2: string;
+      }
+
+      Object.defineProperty(DuplicateDTOWithDifferentSchema, 'name', {
+        value: 'DuplicateDTO'
+      });
+
+      expect(() =>
+        schemaObjectFactory.exploreModelSchema(
+          DuplicateDTOWithDifferentSchema,
+          schemas
+        )
+      ).toThrow(
+        'Duplicate DTO detected: "DuplicateDTO" is defined multiple times with different schemas.\n' +
+          'Consider using unique class names or applying @ApiExtraModels() decorator with custom schema names.'
+      );
+    });
+
     it('should create openapi schema', () => {
       const schemas: Record<string, SchemasObject> = {};
       const schemaKey = schemaObjectFactory.exploreModelSchema(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/nestjs/swagger/issues/3398


## What is the new behavior?

Whenever a dto with the same name and different schema is detected, an error would be thrown.


## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Projects with duplicate DTO names with different schemas will have to adjust the duplicate dtos.
