### PR TITLE
feat(exports): Expose more of the OpenAPI types

### DIFF
--- a/lib/interfaces/index.ts
+++ b/lib/interfaces/index.ts
@@ -1,3 +1,3 @@
-export { OpenAPIObject } from './open-api-spec.interface';
+export * from './open-api-spec.interface';
 export * from './swagger-custom-options.interface';
 export * from './swagger-document-options.interface';


### PR DESCRIPTION
I found myself having to make changes to the doc built by the module. It would have been helpful to have these types available.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Currently only the `OpenAPIObject` type is exported. 

Issue Number: N/A


## What is the new behavior?

Now all the types in `open-api-spec.interface` are exported. This would allow others to use them without having to copy them into their own code.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

If possible, I'd love to backport this to 8.x