### PR TITLE
fix: type import syntax for ApiResponse in esmCompatible

### DIFF
--- a/lib/plugin/utils/plugin-utils.ts
+++ b/lib/plugin/utils/plugin-utils.ts
@@ -233,12 +233,17 @@ export function replaceImportPath(
       };
     }
 
-    if (!options.esmCompatible) {
-      typeReference = typeReference.replace('import', 'require');
+    if (options.esmCompatible) {
+      const { typeName, typeImportStatement } =
+        convertToAsyncImport(typeReference);
+      return {
+        typeReference: `(${typeImportStatement}).${typeName}`,
+        importPath: relativePath
+      };
     }
 
     return {
-      typeReference,
+      typeReference: typeReference.replace('import', 'require'),
       importPath: relativePath
     };
   }

--- a/test/plugin/fixtures/parameter-property.dto.ts
+++ b/test/plugin/fixtures/parameter-property.dto.ts
@@ -25,7 +25,7 @@ export class ItemDto {
 export const parameterPropertyDtoTextTranspiled = (esmCompatible?: boolean) => {
   const fileName = 'parameter-property.dto';
   const fileImport = esmCompatible
-    ? `import("./${fileName}${getOutputExtension(fileName)}")`
+    ? `(await import("./${fileName}${getOutputExtension(fileName)}"))`
     : `require("./${fileName}")`;
 
   return `import * as openapi from "@nestjs/swagger";


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: https://github.com/nestjs/swagger/pull/3399

Fixes an issue where the `esmCompatible` option in the swagger plugin fails to load the `ApiResponse` type when using `tsc`.

<img width="894" alt="image" src="https://github.com/user-attachments/assets/999ac8ab-3615-411e-883a-de7324ef72fa" />

- ✅ esm + swc
- ❌ esm + tsc

## What is the new behavior?

<img width="969" alt="image" src="https://github.com/user-attachments/assets/1fbffc1e-9304-4f82-a67e-9b7b60a18d8f" />

- ✅ esm + tsc

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<img width="432" alt="image" src="https://github.com/user-attachments/assets/33c17bd0-508c-4ac2-a81f-9f83e17583a8" />
