### PR TITLE
feat(api-header): add example property to ApiHeader decorator

### DIFF
--- a/e2e/api-spec.json
+++ b/e2e/api-spec.json
@@ -336,6 +336,7 @@
             "required": false,
             "schema": {
               "type": "string",
+              "example": "test",
               "default": "test"
             }
           },
@@ -416,6 +417,7 @@
             "required": false,
             "schema": {
               "type": "string",
+              "example": "test",
               "default": "test"
             }
           },
@@ -662,6 +664,7 @@
             "required": false,
             "schema": {
               "type": "string",
+              "example": "test",
               "default": "test"
             }
           },
@@ -739,6 +742,7 @@
             "required": false,
             "schema": {
               "type": "string",
+              "example": "test",
               "default": "test"
             }
           },
@@ -820,6 +824,7 @@
             "required": false,
             "schema": {
               "type": "string",
+              "example": "test",
               "default": "test"
             }
           },
@@ -1039,6 +1044,7 @@
             "required": false,
             "schema": {
               "type": "string",
+              "example": "test",
               "default": "test"
             }
           },
@@ -1113,6 +1119,7 @@
             "required": false,
             "schema": {
               "type": "string",
+              "example": "test",
               "default": "test"
             }
           },
@@ -1183,6 +1190,7 @@
             "required": false,
             "schema": {
               "type": "string",
+              "example": "test",
               "default": "test"
             }
           },
@@ -1269,6 +1277,7 @@
             "required": false,
             "schema": {
               "type": "string",
+              "example": "test",
               "default": "test"
             }
           },
@@ -1326,6 +1335,7 @@
             "required": false,
             "schema": {
               "type": "string",
+              "example": "test",
               "default": "test"
             }
           },
@@ -1396,6 +1406,7 @@
             "required": false,
             "schema": {
               "type": "string",
+              "example": "test",
               "default": "test"
             }
           },
@@ -1463,6 +1474,7 @@
             "required": false,
             "schema": {
               "type": "string",
+              "example": "test",
               "default": "test"
             }
           },
@@ -1542,6 +1554,7 @@
             "required": false,
             "schema": {
               "type": "string",
+              "example": "test",
               "default": "test"
             }
           },
@@ -1601,6 +1614,7 @@
             "required": false,
             "schema": {
               "type": "string",
+              "example": "test",
               "default": "test"
             }
           },

--- a/e2e/src/cats/cats.controller.ts
+++ b/e2e/src/cats/cats.controller.ts
@@ -37,7 +37,8 @@ import { CatBreed } from './enums/cat-breed.enum';
   name: 'header',
   required: false,
   description: 'Test',
-  schema: { default: 'test' }
+  schema: { default: 'test' },
+  example: 'test'
 })
 @Controller('cats')
 export class CatsController {

--- a/e2e/validate-schema.e2e-spec.ts
+++ b/e2e/validate-schema.e2e-spec.ts
@@ -169,6 +169,17 @@ describe('Validate OpenAPI schema', () => {
       );
       expect(api.paths['/api/cats']['get']['tags']).toContain('tag1');
       expect(api.paths['/api/cats']['get']['tags']).toContain('tag2');
+      expect(api.paths['/api/cats']['get']['parameters'][0]).toEqual({
+        name: 'header',
+        in: 'header',
+        description: 'Test',
+        required: false,
+        schema: {
+          type: 'string',
+          example: 'test',
+          default: 'test'
+        }
+      });
     } catch (err) {
       console.log(doc);
       expect(err).toBeUndefined();

--- a/e2e/validate-schema.e2e-spec.ts
+++ b/e2e/validate-schema.e2e-spec.ts
@@ -169,17 +169,6 @@ describe('Validate OpenAPI schema', () => {
       );
       expect(api.paths['/api/cats']['get']['tags']).toContain('tag1');
       expect(api.paths['/api/cats']['get']['tags']).toContain('tag2');
-      expect(api.paths['/api/cats']['get']['parameters'][0]).toEqual({
-        name: 'header',
-        in: 'header',
-        description: 'Test',
-        required: false,
-        schema: {
-          type: 'string',
-          example: 'test',
-          default: 'test'
-        }
-      });
     } catch (err) {
       console.log(doc);
       expect(err).toBeUndefined();

--- a/lib/decorators/api-header.decorator.ts
+++ b/lib/decorators/api-header.decorator.ts
@@ -31,6 +31,7 @@ export function ApiHeader(
       examples: options.examples,
       schema: {
         type: 'string',
+        ...(options.example ? { example: options.example } : {}),
         ...(options.schema || {})
       }
     },

--- a/test/explorer/swagger-explorer.spec.ts
+++ b/test/explorer/swagger-explorer.spec.ts
@@ -1382,6 +1382,16 @@ describe('SwaggerExplorer', () => {
       create(): Promise<any> {
         return Promise.resolve();
       }
+
+      @ApiHeader({
+        name: 'X-API-Version',
+        description: 'API version',
+        example: '2025-05-16'
+      })
+      @Get('foos')
+      find2(): Promise<Foo[]> {
+        return Promise.resolve([]);
+      }
     }
 
     it('should properly define headers', () => {
@@ -1425,6 +1435,26 @@ describe('SwaggerExplorer', () => {
           schema: {
             default: 'default token',
             type: 'string'
+          }
+        }
+      ]);
+      expect(routes[2].root.parameters).toEqual([
+        {
+          description: 'auth token',
+          name: 'Authorization',
+          in: 'header',
+          schema: {
+            default: 'default token',
+            type: 'string'
+          }
+        },
+        {
+          description: 'API version',
+          name: 'X-API-Version',
+          in: 'header',
+          schema: {
+            type: 'string',
+            example: '2025-05-16'
           }
         }
       ]);


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When using the `@ApiHeader` decorator with the `example` field (not `examples`) on methods or controllers:

```typescript
@Controller()
export class AppController {
  constructor(private readonly appService: AppService) {}

  @ApiHeader({
    name: 'test',
    example: 'example-data',
  })
  @Get()
  getHello() {
    console.log('Hello World');
  }
}

```

then

![image](https://github.com/user-attachments/assets/876c92a9-1c89-45be-8ea1-da475eb37370)

it is not applied


Issue Number: N/A


## What is the new behavior?

![image](https://github.com/user-attachments/assets/ae88a3ab-8d7c-4794-a9be-0afb13f5350b)

`example` field are applied

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
According to [OpenAPI 3.0 Parameter Object](https://swagger.io/specification/#parameter-object), `example` should be placed inside schema.