### PR TITLE
chore: replace lodash with es-toolkit/compat

### DIFF
--- a/lib/decorators/api-body.decorator.ts
+++ b/lib/decorators/api-body.decorator.ts
@@ -1,5 +1,5 @@
 import { Type } from '@nestjs/common';
-import { omit } from 'lodash';
+import { omit } from 'es-toolkit/compat';
 import {
   ExamplesObject,
   ReferenceObject,

--- a/lib/decorators/api-extension.decorator.ts
+++ b/lib/decorators/api-extension.decorator.ts
@@ -1,6 +1,6 @@
 import { DECORATORS } from '../constants';
 import { createMixedDecorator } from './helpers';
-import { clone } from 'lodash';
+import { clone } from 'es-toolkit/compat';
 
 /**
  * @publicApi

--- a/lib/decorators/api-header.decorator.ts
+++ b/lib/decorators/api-header.decorator.ts
@@ -1,4 +1,4 @@
-import { isNil, isUndefined, negate, pickBy } from 'lodash';
+import { isNil, isUndefined, negate, pickBy } from 'es-toolkit/compat';
 import { DECORATORS } from '../constants';
 import {
   ParameterLocation,

--- a/lib/decorators/api-operation.decorator.ts
+++ b/lib/decorators/api-operation.decorator.ts
@@ -1,4 +1,4 @@
-import { isUndefined, negate, pickBy } from 'lodash';
+import { isUndefined, negate, pickBy } from 'es-toolkit/compat';
 import { DECORATORS } from '../constants';
 import { OperationObject } from '../interfaces/open-api-spec.interface';
 import { createMethodDecorator } from './helpers';

--- a/lib/decorators/api-param.decorator.ts
+++ b/lib/decorators/api-param.decorator.ts
@@ -1,5 +1,5 @@
 import { Type } from '@nestjs/common';
-import { isNil, omit } from 'lodash';
+import { isNil, omit } from 'es-toolkit/compat';
 import { EnumSchemaAttributes } from '../interfaces/enum-schema-attributes.interface';
 import {
   ParameterObject,

--- a/lib/decorators/api-query.decorator.ts
+++ b/lib/decorators/api-query.decorator.ts
@@ -1,5 +1,5 @@
 import { Type } from '@nestjs/common';
-import { omit } from 'lodash';
+import { omit } from 'es-toolkit/compat';
 import { EnumSchemaAttributes } from '../interfaces/enum-schema-attributes.interface';
 import {
   ParameterObject,

--- a/lib/decorators/api-response.decorator.ts
+++ b/lib/decorators/api-response.decorator.ts
@@ -1,5 +1,5 @@
 import { HttpStatus, Type } from '@nestjs/common';
-import { omit } from 'lodash';
+import { omit } from 'es-toolkit/compat';
 import { DECORATORS } from '../constants';
 import {
   ReferenceObject,

--- a/lib/decorators/api-security.decorator.ts
+++ b/lib/decorators/api-security.decorator.ts
@@ -1,4 +1,4 @@
-import { isString } from 'lodash';
+import { isString } from 'es-toolkit/compat';
 import { DECORATORS } from '../constants';
 import { SecurityRequirementObject } from '../interfaces/open-api-spec.interface';
 import { extendMetadata } from '../utils/extend-metadata.util';

--- a/lib/decorators/helpers.ts
+++ b/lib/decorators/helpers.ts
@@ -1,4 +1,4 @@
-import { isArray, isUndefined, negate, pickBy } from 'lodash';
+import { isArray, isUndefined, negate, pickBy } from 'es-toolkit/compat';
 import { DECORATORS } from '../constants';
 import { METADATA_FACTORY_NAME } from '../plugin/plugin-constants';
 import { METHOD_METADATA } from '@nestjs/common/constants';

--- a/lib/document-builder.ts
+++ b/lib/document-builder.ts
@@ -1,5 +1,12 @@
 import { Logger } from '@nestjs/common';
-import { clone, isString, isUndefined, negate, omit, pickBy } from 'lodash';
+import {
+  clone,
+  isString,
+  isUndefined,
+  negate,
+  omit,
+  pickBy
+} from 'es-toolkit/compat';
 import { ApiResponseOptions } from './decorators/api-response.decorator';
 import { buildDocumentBase } from './fixtures/document.base';
 import { OpenAPIObject } from './interfaces';

--- a/lib/explorers/api-parameters.explorer.ts
+++ b/lib/explorers/api-parameters.explorer.ts
@@ -1,5 +1,13 @@
 import { Type } from '@nestjs/common';
-import { assign, find, isNil, map, omitBy, some, unionWith } from 'lodash';
+import {
+  assign,
+  find,
+  isNil,
+  map,
+  omitBy,
+  some,
+  unionWith
+} from 'es-toolkit/compat';
 import { DECORATORS } from '../constants';
 import { SchemaObject } from '../interfaces/open-api-spec.interface';
 import { ModelPropertiesAccessor } from '../services/model-properties-accessor';
@@ -54,11 +62,10 @@ export const exploreApiParametersMetadata = (
     const mergeImplicitAndExplicit = (item: ParamWithTypeMetadata) =>
       assign(item, find(explicitParameters, ['name', item.name]));
 
-    properties = removeBodyMetadataIfExplicitExists(
-      properties,
-      explicitParameters
+    properties = map(
+      removeBodyMetadataIfExplicitExists(properties, explicitParameters),
+      mergeImplicitAndExplicit
     );
-    properties = map(properties, mergeImplicitAndExplicit);
     properties = unionWith(
       properties,
       explicitParameters,
@@ -84,10 +91,7 @@ function removeBodyMetadataIfExplicitExists(
   const isBodyReflected = some(properties, (p) => p.in === 'body');
   const isBodyDefinedExplicitly = some(explicitParams, (p) => p.in === 'body');
   if (isBodyReflected && isBodyDefinedExplicitly) {
-    return omitBy(
-      properties,
-      (p) => p.in === 'body'
-    ) as ParamWithTypeMetadata[];
+    return omitBy(properties, (p) => p.in === 'body');
   }
   return properties;
 }

--- a/lib/explorers/api-response.explorer.ts
+++ b/lib/explorers/api-response.explorer.ts
@@ -1,7 +1,7 @@
 import { HttpStatus, RequestMethod, Type } from '@nestjs/common';
 import { HTTP_CODE_METADATA, METHOD_METADATA } from '@nestjs/common/constants';
 import { isEmpty } from '@nestjs/common/utils/shared.utils';
-import { get, mapValues, omit } from 'lodash';
+import { get, mapValues, omit } from 'es-toolkit/compat';
 import { DECORATORS } from '../constants';
 import { ApiResponse, ApiResponseMetadata } from '../decorators';
 import { SchemaObject } from '../interfaces/open-api-spec.interface';

--- a/lib/plugin/utils/plugin-utils.ts
+++ b/lib/plugin/utils/plugin-utils.ts
@@ -1,4 +1,4 @@
-import { head } from 'lodash';
+import { head } from 'es-toolkit/compat';
 import { isAbsolute, posix } from 'path';
 import * as ts from 'typescript';
 import { PluginOptions } from '../merge-options';

--- a/lib/plugin/visitors/controller-class.visitor.ts
+++ b/lib/plugin/visitors/controller-class.visitor.ts
@@ -1,4 +1,4 @@
-import { compact, head } from 'lodash';
+import { compact, head } from 'es-toolkit/compat';
 import { posix } from 'path';
 import * as ts from 'typescript';
 import { ApiOperation, ApiResponse } from '../../decorators';

--- a/lib/plugin/visitors/model-class.visitor.ts
+++ b/lib/plugin/visitors/model-class.visitor.ts
@@ -1,4 +1,4 @@
-import { compact, flatten, head } from 'lodash';
+import { compact, flatten, head } from 'es-toolkit/compat';
 import { posix } from 'path';
 import * as ts from 'typescript';
 import { factory, PropertyAssignment } from 'typescript';

--- a/lib/services/parameter-metadata-accessor.ts
+++ b/lib/services/parameter-metadata-accessor.ts
@@ -4,7 +4,7 @@ import {
   ROUTE_ARGS_METADATA
 } from '@nestjs/common/constants';
 import { RouteParamtypes } from '@nestjs/common/enums/route-paramtypes.enum';
-import { isEmpty, mapValues, omitBy } from 'lodash';
+import { isEmpty, mapValues, omitBy } from 'es-toolkit/compat';
 import { EnumSchemaAttributes } from '../interfaces/enum-schema-attributes.interface';
 import {
   ParameterLocation,

--- a/lib/services/parameters-metadata-mapper.ts
+++ b/lib/services/parameters-metadata-mapper.ts
@@ -1,6 +1,6 @@
 import { Type } from '@nestjs/common';
 import { isFunction } from '@nestjs/common/utils/shared.utils';
-import { flatMap, identity } from 'lodash';
+import { flatMap, identity } from 'es-toolkit/compat';
 import { DECORATORS } from '../constants';
 import { isBodyParameter } from '../utils/is-body-parameter.util';
 import { ModelPropertiesAccessor } from './model-properties-accessor';

--- a/lib/services/response-object-factory.ts
+++ b/lib/services/response-object-factory.ts
@@ -1,4 +1,4 @@
-import { isEmpty, isFunction, omit } from 'lodash';
+import { isEmpty, isFunction, omit } from 'es-toolkit/compat';
 import { DECORATORS } from '../constants';
 import {
   ApiPropertyOptions,

--- a/lib/services/response-object-mapper.ts
+++ b/lib/services/response-object-mapper.ts
@@ -1,4 +1,4 @@
-import { omit, pick } from 'lodash';
+import { omit, pick } from 'es-toolkit/compat';
 import { ApiResponseMetadata, ApiResponseSchemaHost } from '../decorators';
 import { getSchemaPath } from '../utils';
 import { MimetypeContentWrapper } from './mimetype-content-wrapper';

--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -10,7 +10,7 @@ import {
   omit,
   omitBy,
   pick
-} from 'lodash';
+} from 'es-toolkit/compat';
 import { DECORATORS } from '../constants';
 import { ApiSchemaOptions } from '../decorators';
 import { getTypeIsArrayTuple } from '../decorators/helpers';

--- a/lib/services/swagger-types-mapper.ts
+++ b/lib/services/swagger-types-mapper.ts
@@ -1,4 +1,10 @@
-import { isFunction, isString, isUndefined, omit, omitBy, pick } from 'lodash';
+import {
+  isFunction,
+  isString,
+  isUndefined,
+  omit,
+  pick
+} from 'es-toolkit/compat';
 import { ApiPropertyOptions } from '../decorators';
 import {
   BaseParameterObject,
@@ -6,6 +12,7 @@ import {
   SchemaObject
 } from '../interfaces/open-api-spec.interface';
 import { ParamWithTypeMetadata } from './parameter-metadata-accessor';
+import { omitBy } from 'es-toolkit/compat';
 
 type KeysToRemove =
   | keyof ApiPropertyOptions

--- a/lib/swagger-explorer.ts
+++ b/lib/swagger-explorer.ts
@@ -30,7 +30,7 @@ import {
   omit,
   omitBy,
   pick
-} from 'lodash';
+} from 'es-toolkit/compat';
 import { parse, Wildcard } from 'path-to-regexp';
 import { DECORATORS } from './constants';
 import { exploreApiCallbacksMetadata } from './explorers/api-callbacks.explorer';

--- a/lib/swagger-scanner.ts
+++ b/lib/swagger-scanner.ts
@@ -3,7 +3,7 @@ import { MODULE_PATH } from '@nestjs/common/constants';
 import { ApplicationConfig, NestContainer } from '@nestjs/core';
 import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 import { Module } from '@nestjs/core/injector/module';
-import { flatten, isEmpty } from 'lodash';
+import { flatten, isEmpty } from 'es-toolkit/compat';
 import {
   OpenAPIObject,
   OperationIdFactory,

--- a/lib/swagger-transformer.ts
+++ b/lib/swagger-transformer.ts
@@ -1,4 +1,4 @@
-import { filter, groupBy, keyBy, mapValues, omit } from 'lodash';
+import { filter, groupBy, keyBy, mapValues, omit } from 'es-toolkit/compat';
 import { OpenAPIObject } from './interfaces';
 import { sortObjectLexicographically } from './utils/sort-object-lexicographically';
 

--- a/lib/type-helpers/mapped-types.utils.ts
+++ b/lib/type-helpers/mapped-types.utils.ts
@@ -1,5 +1,5 @@
 import { Type } from '@nestjs/common';
-import { identity } from 'lodash';
+import { identity } from 'es-toolkit/compat';
 import { METADATA_FACTORY_NAME } from '../plugin/plugin-constants';
 
 export function clonePluginMetadataFactory(

--- a/lib/type-helpers/omit-type.helper.ts
+++ b/lib/type-helpers/omit-type.helper.ts
@@ -4,7 +4,7 @@ import {
   inheritTransformationMetadata,
   inheritValidationMetadata
 } from '@nestjs/mapped-types';
-import { omit } from 'lodash';
+import { omit } from 'es-toolkit/compat';
 import { DECORATORS } from '../constants';
 import { ApiProperty } from '../decorators';
 import { MetadataLoader } from '../plugin/metadata-loader';

--- a/lib/type-helpers/partial-type.helper.ts
+++ b/lib/type-helpers/partial-type.helper.ts
@@ -6,7 +6,7 @@ import {
   inheritTransformationMetadata,
   inheritValidationMetadata
 } from '@nestjs/mapped-types';
-import { mapValues } from 'lodash';
+import { mapValues } from 'es-toolkit/compat';
 import { DECORATORS } from '../constants';
 import { ApiProperty } from '../decorators';
 import { MetadataLoader } from '../plugin/metadata-loader';

--- a/lib/type-helpers/pick-type.helper.ts
+++ b/lib/type-helpers/pick-type.helper.ts
@@ -4,7 +4,7 @@ import {
   inheritTransformationMetadata,
   inheritValidationMetadata
 } from '@nestjs/mapped-types';
-import { pick } from 'lodash';
+import { pick } from 'es-toolkit/compat';
 import { DECORATORS } from '../constants';
 import { ApiProperty } from '../decorators';
 import { MetadataLoader } from '../plugin/metadata-loader';

--- a/lib/utils/enum.utils.ts
+++ b/lib/utils/enum.utils.ts
@@ -1,4 +1,4 @@
-import { isString } from 'lodash';
+import { isString } from 'es-toolkit/compat';
 import { SchemaObject } from '../interfaces/open-api-spec.interface';
 import { SchemaObjectMetadata } from '../interfaces/schema-object-metadata.interface';
 import { SwaggerEnumType } from '../types/swagger-enum.type';

--- a/lib/utils/is-built-in-type.util.ts
+++ b/lib/utils/is-built-in-type.util.ts
@@ -1,5 +1,5 @@
 import { Type } from '@nestjs/common';
-import { isFunction } from 'lodash';
+import { isFunction } from 'es-toolkit/compat';
 import { BUILT_IN_TYPES } from '../services/constants';
 
 export function isBuiltInType(

--- a/lib/utils/merge-and-uniq.util.ts
+++ b/lib/utils/merge-and-uniq.util.ts
@@ -1,4 +1,4 @@
-import { merge, uniq } from 'lodash';
+import { merge, uniq } from 'es-toolkit/compat';
 
 export function mergeAndUniq<T = any>(a: unknown = [], b: unknown = []): T {
   return uniq(merge(a, b) as any) as unknown as T;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,8 +11,8 @@
       "dependencies": {
         "@microsoft/tsdoc": "0.15.1",
         "@nestjs/mapped-types": "2.1.0",
+        "es-toolkit": "1.39.5",
         "js-yaml": "4.1.0",
-        "lodash": "4.17.21",
         "path-to-regexp": "8.2.0",
         "swagger-ui-dist": "5.21.0"
       },
@@ -28,7 +28,6 @@
         "@nestjs/platform-fastify": "11.1.3",
         "@types/jest": "30.0.0",
         "@types/js-yaml": "4.0.9",
-        "@types/lodash": "4.17.19",
         "@types/node": "22.15.34",
         "class-transformer": "0.5.1",
         "class-validator": "0.14.2",
@@ -3526,13 +3525,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/lodash": {
-      "version": "4.17.19",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.19.tgz",
-      "integrity": "sha512-NYqRyg/hIQrYPT9lbOeYc3kIRabJDn/k4qQHIXUpx88CBDww2fD15Sg5kbXlW86zm2XEW4g0QxkTI3/Kfkc7xQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/node": {
       "version": "22.15.34",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.34.tgz",
@@ -6067,6 +6059,15 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.39.5",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.5.tgz",
+      "integrity": "sha512-z9V0qU4lx1TBXDNFWfAASWk6RNU6c6+TJBKE+FLIg8u0XJ6Yw58Hi0yX8ftEouj6p1QARRlXLFfHbIli93BdQQ==",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -9887,6 +9888,7 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.camelcase": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "@microsoft/tsdoc": "0.15.1",
     "@nestjs/mapped-types": "2.1.0",
     "js-yaml": "4.1.0",
-    "lodash": "4.17.21",
+    "es-toolkit": "1.39.5",
     "path-to-regexp": "8.2.0",
     "swagger-ui-dist": "5.21.0"
   },
@@ -46,7 +46,6 @@
     "@nestjs/platform-fastify": "11.1.3",
     "@types/jest": "30.0.0",
     "@types/js-yaml": "4.0.9",
-    "@types/lodash": "4.17.19",
     "@types/node": "22.15.34",
     "class-transformer": "0.5.1",
     "class-validator": "0.14.2",

--- a/test/explorer/swagger-explorer.spec.ts
+++ b/test/explorer/swagger-explorer.spec.ts
@@ -12,7 +12,7 @@ import {
 import { VERSION_NEUTRAL, VersionValue } from '@nestjs/common/interfaces';
 import { ApplicationConfig } from '@nestjs/core';
 import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
-import { upperFirst } from 'lodash';
+import { upperFirst } from 'es-toolkit/compat';
 import {
   ApiBadRequestResponse,
   ApiBody,


### PR DESCRIPTION
## PR Checklist
This pull request replaces all `lodash` imports with `es-toolkit/compat` across multiple files in the codebase. The change aims to standardize utility imports and potentially improve performance.

https://es-toolkit.dev/compatibility.html#compatibility-with-lodash

[Recharts](https://github.com/recharts/recharts/blob/main/package.json#L77) and [Storybook](https://github.com/search?q=repo%3Astorybookjs%2Fstorybook+es-toolkit+language%3AJSON&type=code&l=JSON) already use it with same reason. so I wanted to suggest this changes

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
