### PR TITLE
feat(decorator): add type definition for format option

### DIFF
--- a/lib/interfaces/open-api-spec.interface.ts
+++ b/lib/interfaces/open-api-spec.interface.ts
@@ -105,6 +105,33 @@ export type ParameterStyle =
   | 'pipeDelimited'
   | 'deepObject';
 
+/**
+ * OpenAPI-defined standard format values and commonly used formats.
+ *
+ * The `format` property in OpenAPI is an "open value", allowing custom formats.
+ * This type provides IDE autocomplete for standard formats while still permitting custom values.
+ *
+ * @issue https://github.com/nestjs/swagger/issues/3508
+ * @see https://swagger.io/docs/specification/data-models/data-types/
+ */
+export type SchemaObjectFormat =
+  | 'int32'
+  | 'int64'
+  | 'float'
+  | 'double'
+  | 'byte'
+  | 'binary'
+  | 'date'
+  | 'date-time'
+  | 'password'
+  | 'email'
+  | 'uuid'
+  | 'uri'
+  | 'hostname'
+  | 'ipv4'
+  | 'ipv6'
+  | (string & {});
+
 export interface BaseParameterObject {
   description?: string;
   required?: boolean;
@@ -214,7 +241,7 @@ export interface SchemaObject {
   additionalProperties?: SchemaObject | ReferenceObject | boolean;
   patternProperties?: SchemaObject | ReferenceObject | any;
   description?: string;
-  format?: string;
+  format?: SchemaObjectFormat;
   default?: any;
   title?: string;
   multipleOf?: number;

--- a/test/services/fixtures/create-user.dto.ts
+++ b/test/services/fixtures/create-user.dto.ts
@@ -99,6 +99,9 @@ export class CreateUserDto {
   @ApiProperty({ type: [String], format: 'uuid' })
   formatArray: string[];
 
+  @ApiProperty({ type: String, format: 'custom-format' })
+  customFormat: string;
+
   static _OPENAPI_METADATA_FACTORY() {
     return {
       tags: { type: () => [String] },

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -359,6 +359,10 @@ describe('SchemaObjectFactory', () => {
               type: 'string',
               format: 'uuid'
             }
+          },
+          customFormat: {
+            type: 'string',
+            format: 'custom-format'
           }
         },
         required: [
@@ -375,7 +379,8 @@ describe('SchemaObjectFactory', () => {
           'houses',
           'createdAt',
           'amount',
-          'formatArray'
+          'formatArray',
+          'customFormat'
         ]
       });
       expect(schemas['CreateProfileDto']).toEqual({


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The `format` field in `@ApiProperty()` accepts any `string` value, which allows for invalid or misspelled values without any feedback from the TypeScript compiler.

Issue Number: #3508 


## What is the new behavior?
Added `SchemaObjectFormat` type that
- Provides IDE autocomplete for OpenAPI-defined standard formats (`int32`, `int64`, `float`, `double`, `byte`, `binary`, `date`, `date-time`, `password`)
- Includes commonly used formats (`email`, `uuid`, `uri`, `hostname`, `ipv4`, `ipv6`)
- Maintains full backward compatibility by allowing custom format values via `(string & {})` pattern
    

```typescript
@ApiProperty({ format: 'date-time' })  // Autocomplete + type checking
createdAt: Date;

@ApiProperty({ format: 'custom-format' })  // Still works (backward compatible)
customField: string;
```

The (string & {}) pattern ensures all existing custom format values continue to work while providing autocomplete for standard formats.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No