### PR TITLE
fix(plugin): add async modifier when a reference is await import statement

### DIFF
--- a/lib/plugin/visitors/model-class.visitor.ts
+++ b/lib/plugin/visitors/model-class.visitor.ts
@@ -527,6 +527,10 @@ export class ModelClassVisitor extends AbstractFileVisitor {
       return [];
     }
 
+    const modifiers = typeReferenceDescriptor.typeName.includes('import(')
+      ? [factory.createModifier(ts.SyntaxKind.AsyncKeyword)]
+      : undefined;
+
     const identifier = typeReferenceToIdentifier(
       typeReferenceDescriptor,
       hostFilename,
@@ -537,7 +541,7 @@ export class ModelClassVisitor extends AbstractFileVisitor {
     );
 
     const initializer = factory.createArrowFunction(
-      undefined,
+      modifiers,
       undefined,
       [],
       undefined,

--- a/test/plugin/fixtures/parameter-property.dto.ts
+++ b/test/plugin/fixtures/parameter-property.dto.ts
@@ -37,7 +37,7 @@ export class ParameterPropertyDto {
         this.protectedValue = protectedValue;
     }
     static _OPENAPI_METADATA_FACTORY() {
-        return { readonlyValue: { required: false, type: () => String }, privateValue: { required: true, type: () => String, nullable: true }, publicValue: { required: true, type: () => [${fileImport}.ItemDto] }, protectedValue: { required: true, type: () => String, default: "1234" } };
+        return { readonlyValue: { required: false, type: () => String }, privateValue: { required: true, type: () => String, nullable: true }, publicValue: { required: true, type: async () => [${fileImport}.ItemDto] }, protectedValue: { required: true, type: () => String, default: "1234" } };
     }
 }
 export var LettersEnum;

--- a/test/plugin/fixtures/serialized-meta-esm.fixture.ts
+++ b/test/plugin/fixtures/serialized-meta-esm.fixture.ts
@@ -158,11 +158,11 @@ export default async () => {
               },
               tag: {
                 required: true,
-                type: () => t['./cats/dto/tag.dto.js'].TagDto
+                type: async () => t['./cats/dto/tag.dto.js'].TagDto
               },
               multipleTags: {
                 required: true,
-                type: () => [t['./cats/dto/tag.dto.js'].TagDto]
+                type: async () => [t['./cats/dto/tag.dto.js'].TagDto]
               },
               nested: {
                 required: true,

--- a/test/plugin/fixtures/serialized-meta.fixture.ts
+++ b/test/plugin/fixtures/serialized-meta.fixture.ts
@@ -156,11 +156,11 @@ export default async () => {
               },
               tag: {
                 required: true,
-                type: () => t['./cats/dto/tag.dto'].TagDto
+                type: async () => t['./cats/dto/tag.dto'].TagDto
               },
               multipleTags: {
                 required: true,
-                type: () => [t['./cats/dto/tag.dto'].TagDto]
+                type: async () => [t['./cats/dto/tag.dto'].TagDto]
               },
               nested: {
                 required: true,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

When the CLI compiles comments and types into Swagger decorators, it omits the async keyword in arrow functions that reference another DTO, even though those functions use the await keyword.
This change ensures that any arrow function using await within a DTO reference property is correctly prefixed with the async keyword.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

```json5
{
  // ...
  "compilerOptions": {
    "plugins": [{ "name": "@nestjs/swagger", "options": { "introspectComments": true, "esmCompatible": true } }]
  },
  // ...
}

```

```typescript
import { Exclude, Expose } from 'class-transformer';

@Exclude()
export class Foo {
  /**
   * Foo
   */
  @Expose()
  bar!: Bar;
}

@Exclude()
export class Bar {
  /**
   * Property
   */
  @Expose()
  property!: string;
}
```

```javascript
let Foo = class Foo {
    static _OPENAPI_METADATA_FACTORY() {
        return { bar: { required: true, type: () => (await import("./foo-bar.dto.js")).Bar, description: "Foo" } }; // There is no 'async' keyword at the arrow function.
    }
};
```