### PR TITLE
chore: Add extensions to API params level

### DIFF
--- a/test/decorators/api-param.decorator.spec.ts
+++ b/test/decorators/api-param.decorator.spec.ts
@@ -53,4 +53,40 @@ describe('ApiParam', () => {
       ).toEqual([{ in: 'path', name: 'testId', required: true }]);
     });
   });
+
+  describe('extensions support', () => {
+    it('should merge extensions into parameter metadata when provided (method level)', () => {
+      @Controller('tests/:testId')
+      class TestAppController {
+        @Get()
+        @ApiParam({ name: 'testId', extensions: { 'x-permissions': ['test.customer.add'] } })
+        public get(@Param('testId') testId: string): string {
+          return testId;
+        }
+      }
+
+      const controller = new TestAppController();
+      expect(Reflect.hasMetadata(DECORATORS.API_PARAMETERS, controller.get)).toBeTruthy();
+      expect(Reflect.getMetadata(DECORATORS.API_PARAMETERS, controller.get)).toEqual([
+        { in: 'path', name: 'testId', required: true, 'x-permissions': ['test.customer.add'] }
+      ]);
+    });
+
+    it('should auto-prefix extension keys without x- (class level)', () => {
+      @ApiParam({ name: 'testId', extensions: { permissions: ['test.customer.add'] } })
+      @Controller('tests/:testId')
+      class TestAppController2 {
+        @Get()
+        public get(@Param('testId') testId: string): string {
+          return testId;
+        }
+      }
+
+      const controller = new TestAppController2();
+      expect(Reflect.hasMetadata(DECORATORS.API_PARAMETERS, controller.get)).toBeTruthy();
+      expect(Reflect.getMetadata(DECORATORS.API_PARAMETERS, controller.get)).toEqual([
+        { in: 'path', name: 'testId', required: true, 'x-permissions': ['test.customer.add'] }
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe:

## What is the current behavior?
Currently API param decorator does not support adding extensions (param level extension). this will be helpful when generating rego rules for params (like user bind to this id or not) 

Issue Number: N/A


## What is the new behavior?
Added optional extension attribute to @ApiParam decorator.

## Does this PR introduce a breaking change?
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
