### PR TITLE
fix(schema): preserve items schema when metadata.items is already defined

### DIFF
--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -547,9 +547,11 @@ export class SchemaObjectFactory {
       ...omit(metadata, [...keysToRemove, ...keysToMove]),
       name: metadata.name || key,
       type: 'array',
-      items: isString(type)
-        ? { type, ...movedProperties }
-        : { ...type, ...movedProperties }
+      items: metadata.items
+        ? { ...(metadata.items as Record<string, any>), ...movedProperties }
+        : isString(type)
+          ? { type, ...movedProperties }
+          : { ...type, ...movedProperties }
     };
     schemaHost.items = omitBy(schemaHost.items, isUndefined);
 

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -747,4 +747,76 @@ describe('SchemaObjectFactory', () => {
       });
     });
   });
+
+  describe('transformToArraySchemaProperty', () => {
+    it('should preserve items schema when metadata.items is already defined and type is string', () => {
+      const metadata = {
+        type: 'array',
+        isArray: true,
+        items: {
+          type: 'object',
+          additionalProperties: {
+            type: 'string',
+            enum: ['asc', 'desc']
+          }
+        },
+        example: [{ created_on: 'desc' }],
+        required: false
+      };
+
+      const result = schemaObjectFactory.transformToArraySchemaProperty(
+        metadata as any,
+        'sort',
+        'array'
+      );
+
+      expect(result.items).toEqual({
+        type: 'object',
+        additionalProperties: {
+          type: 'string',
+          enum: ['asc', 'desc']
+        }
+      });
+      expect(result.type).toBe('array');
+      expect(result.example).toEqual([{ created_on: 'desc' }]);
+    });
+
+    it('should use type parameter when metadata.items is not defined', () => {
+      const metadata = {
+        type: 'array',
+        isArray: true,
+        required: false
+      };
+
+      const result = schemaObjectFactory.transformToArraySchemaProperty(
+        metadata as any,
+        'items',
+        'string'
+      );
+
+      expect(result.items).toEqual({ type: 'string' });
+      expect(result.type).toBe('array');
+    });
+
+    it('should use type object when provided', () => {
+      const metadata = {
+        type: 'array',
+        isArray: true,
+        required: false
+      };
+
+      const result = schemaObjectFactory.transformToArraySchemaProperty(
+        metadata as any,
+        'items',
+        { type: 'object', properties: { name: { type: 'string' } } }
+      );
+
+      expect(result.items).toEqual({
+        type: 'object',
+        properties: { name: { type: 'string' } }
+      });
+      expect(result.type).toBe('array');
+    });
+  });
 });
+


### PR DESCRIPTION
fix(schema): preserve items schema when metadata.items is already defined

Fixes transformToArraySchemaProperty overwriting existing items schema from zod-openapi generated classes, ensuring correct OpenAPI schemas.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When using `@ApiQuery({ type: SomeClass })` where `SomeClass` is generated by libraries like `@anatine/zod-openapi` that pre-define `items` schema in metadata, `transformToArraySchemaProperty` was overwriting the existing `items` schema with `{ type: 'array' }` instead of preserving it.

This occurred because when `type` parameter is the string `'array'`, the function would create new items from the type parameter, ignoring the existing `metadata.items` that contained the correct schema definition.

**Example of incorrect output:**
```json
{
  "schema": {
    "type": "array",
    "items": { "type": "array" } 
  }
}
```

Issue Number: #3624



The `transformToArraySchemaProperty` method now checks if `metadata.items` exists first. If it does, it preserves the existing items schema and merges it with moved properties (format, min/max, etc.). This ensures that pre-defined items schemas from zod-openapi and similar libraries are correctly preserved in the OpenAPI output.

**Example of correct output:**
```json
{
  "schema": {
    "type": "array",
    "items": {
      "type": "object",
      "additionalProperties": {
        "type": "string",
        "enum": ["asc", "desc"]
      }
    } 
  }
}
```

The fix is backward compatible - when `metadata.items` is not defined, it falls back to the original behavior of creating items from the `type` parameter.



## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

**Test coverage:**
- Added 3 test cases in `test/services/schema-object-factory.spec.ts`:
  1. Preserves items schema when metadata.items is already defined and type is string
  2. Uses type parameter when metadata.items is not defined (backward compatibility)
  3. Uses type object when provided