### PR TITLE
Add 'file' type to schema object metadata interface

### DIFF
--- a/lib/interfaces/schema-object-metadata.interface.ts
+++ b/lib/interfaces/schema-object-metadata.interface.ts
@@ -25,6 +25,7 @@ export type SchemaObjectMetadata =
         | 'number'
         | 'boolean'
         | 'integer'
+        | 'file'
         | 'null';
       required?: boolean;
     })


### PR DESCRIPTION
we need to define file type for file upload

meanwhile I am doing this :
```

      ApiProperty({
        type: 'file' as any,
        additionalProperties: {
          [propertyKey]: {
            type: 'string',
            format: 'binary',
          },
        },
      })(target, propertyKey);


```

which works file, but with this PR, it won't be necessary