### PR TITLE
fix(plugin): respect debug option for all debug log messages

### DIFF
--- a/lib/plugin/visitors/model-class.visitor.ts
+++ b/lib/plugin/visitors/model-class.visitor.ts
@@ -198,9 +198,11 @@ export class ModelClassVisitor extends AbstractFileVisitor {
     ) {
       return node;
     } else if (annotatePropertyDecoratorExists && hidePropertyDecoratorExists) {
-      pluginDebugLogger.debug(
-        `"${node.parent.name.getText()}->${node.name.getText()}" has conflicting decorators, excluding as @ApiHideProperty() takes priority.`
-      );
+      if (options.debug) {
+        pluginDebugLogger.debug(
+          `"${node.parent.name.getText()}->${node.name.getText()}" has conflicting decorators, excluding as @ApiHideProperty() takes priority.`
+        );
+      }
       return node;
     }
 
@@ -769,11 +771,13 @@ export class ModelClassVisitor extends AbstractFileVisitor {
       this.clonePrimitiveLiteral(factory, initializer) ?? initializer;
 
     if (!canReferenceNode(initializer, options)) {
-      const parentFilePath = node.getSourceFile().fileName;
-      const propertyName = node.name.getText();
-      pluginDebugLogger.debug(
-        `Skipping registering default value for "${propertyName}" property in "${parentFilePath}" file because it is not a referenceable value ("${initializer.getText()}").`
-      );
+      if (options.debug) {
+        const parentFilePath = node.getSourceFile().fileName;
+        const propertyName = node.name.getText();
+        pluginDebugLogger.debug(
+          `Skipping registering default value for "${propertyName}" property in "${parentFilePath}" file because it is not a referenceable value ("${initializer.getText()}").`
+        );
+      }
       return undefined;
     }
     return factory.createPropertyAssignment(key, initializer);


### PR DESCRIPTION
## Description

Two `pluginDebugLogger.debug()` calls in `model-class.visitor.ts` were outputting messages unconditionally without checking `options.debug`:

1. **Line ~201**: Conflicting decorators message
2. **Line ~774**: Skipping default value message

This caused noisy DEBUG logs to appear during development even when `debug: false` was set in `nest-cli.json` plugin options:

```
[Nest] DEBUG [CLI Plugin] Skipping registering default value for "progressions" property in "..." file because it is not a referenceable value ("new Collection<...>(this)").
```

## Changes

This PR wraps both debug calls with `if (options.debug)` checks, consistent with the existing pattern used elsewhere in the same file (e.g., line 118 for skipping unexported classes).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manual testing by setting `debug: false` in `nest-cli.json` and confirming that the debug messages no longer appear.