### PR TITLE
feat(schema): include class name in circular dependency error messages

### DIFF
--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -221,33 +221,41 @@ export class SchemaObjectFactory {
     const modelProperties =
       this.modelPropertiesAccessor.getModelProperties(prototype);
     const propertiesWithType = modelProperties.map((key) => {
-      const property = this.mergePropertyWithMetadata(
-        key,
-        prototype,
-        schemas,
-        pendingSchemasRefs
-      );
+      try {
+        const property = this.mergePropertyWithMetadata(
+          key,
+          prototype,
+          schemas,
+          pendingSchemasRefs
+        );
 
-      const schemaCombinators = ['oneOf', 'anyOf', 'allOf'];
-      const declaredSchemaCombinator = schemaCombinators.find(
-        (combinator) => combinator in property
-      );
-      if (declaredSchemaCombinator) {
-        const schemaObjectMetadata = property as SchemaObjectMetadata;
+        const schemaCombinators = ['oneOf', 'anyOf', 'allOf'];
+        const declaredSchemaCombinator = schemaCombinators.find(
+          (combinator) => combinator in property
+        );
+        if (declaredSchemaCombinator) {
+          const schemaObjectMetadata = property as SchemaObjectMetadata;
 
-        if (
-          schemaObjectMetadata?.type === 'array' ||
-          schemaObjectMetadata.isArray
-        ) {
-          schemaObjectMetadata.items = {};
-          schemaObjectMetadata.items[declaredSchemaCombinator] =
-            property[declaredSchemaCombinator];
-          delete property[declaredSchemaCombinator];
-        } else {
-          delete schemaObjectMetadata.type;
+          if (
+            schemaObjectMetadata?.type === 'array' ||
+            schemaObjectMetadata.isArray
+          ) {
+            schemaObjectMetadata.items = {};
+            schemaObjectMetadata.items[declaredSchemaCombinator] =
+              property[declaredSchemaCombinator];
+            delete property[declaredSchemaCombinator];
+          } else {
+            delete schemaObjectMetadata.type;
+          }
         }
+        return property as ParameterObject;
+      } catch (error) {
+        const className = type.name || 'Unknown';
+        if (error instanceof Error) {
+          error.message = `[${className}] ${error.message}`;
+        }
+        throw error;
       }
-      return property as ParameterObject;
     });
     return propertiesWithType;
   }

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -818,5 +818,21 @@ describe('SchemaObjectFactory', () => {
       expect(result.type).toBe('array');
     });
   });
+
+  describe('circular dependency error message', () => {
+    it('should include class name in circular dependency error message', () => {
+      class CircularDto {
+        @ApiProperty()
+        name: string;
+
+        @ApiProperty({ type: () => undefined as any })
+        circular: any;
+      }
+
+      expect(() => {
+        schemaObjectFactory.exploreModelSchema(CircularDto, {});
+      }).toThrow(/\[CircularDto\].*circular dependency/i);
+    });
+  });
 });
 


### PR DESCRIPTION
## Summary

Improves the error message for circular dependencies by including the class name where the issue occurred. This makes debugging significantly easier in large projects with many DTOs.

## Problem

When a circular dependency is detected, the current error message only shows the property key:

```
Error: A circular dependency has been detected (property key: "user")
```

In large projects with hundreds of DTOs, knowing only the property name is insufficient to locate the problematic class.

## Solution

The error message now includes the class name(s) as errors bubble up:

```
Error: [UserResponseDto] [ParentEntity] A circular dependency has been detected (property key: "user")
```

## Implementation

- Added try-catch in `extractPropertiesFromType` to catch errors during property metadata extraction
- Prepends the class name to the error message before re-throwing
- Creates a path showing the full chain of classes involved in nested DTOs

## Benefits

1. **Faster Debugging**: Immediately identify which class has the circular dependency
2. **Non-Breaking**: Only changes error message format, no API changes
3. **Nested Path**: Shows full chain when DTOs reference each other

## Test Plan

- [x] Added test case for circular dependency error including class name

Closes #3655

🤖 Generated with [Claude Code](https://claude.ai/code)