### PR TITLE
feat(swagger): add OpenAPI 3.2 hierarchical tags support

### DIFF
--- a/e2e/validate-schema.e2e-spec.ts
+++ b/e2e/validate-schema.e2e-spec.ts
@@ -298,4 +298,82 @@ describe('Validate OpenAPI schema', () => {
       'x-another-field': 'another value'
     });
   });
+
+  describe('hierarchical tags (OpenAPI 3.2)', () => {
+    it('should add tag with parent option', async () => {
+      const hierarchicalOptions = new DocumentBuilder()
+        .setTitle('Hierarchical Tags Test')
+        .setVersion('1.0')
+        .addTag('Animals', 'All animal operations')
+        .addTag('Cats', 'Cat operations', undefined, { parent: 'Animals' })
+        .build();
+
+      const document = SwaggerModule.createDocument(app, hierarchicalOptions);
+
+      expect(document.tags).toBeDefined();
+      expect(document.tags).toHaveLength(2);
+      expect(document.tags?.[0]).toEqual({
+        name: 'Animals',
+        description: 'All animal operations'
+      });
+      expect(document.tags?.[1]).toEqual({
+        name: 'Cats',
+        description: 'Cat operations',
+        parent: 'Animals'
+      });
+    });
+
+    it('should add tag with kind option', async () => {
+      const hierarchicalOptions = new DocumentBuilder()
+        .setTitle('Hierarchical Tags Test')
+        .setVersion('1.0')
+        .addTag('Internal', 'Internal APIs', undefined, { kind: 'reference' })
+        .build();
+
+      const document = SwaggerModule.createDocument(app, hierarchicalOptions);
+
+      expect(document.tags).toBeDefined();
+      expect(document.tags).toHaveLength(1);
+      expect(document.tags?.[0]).toEqual({
+        name: 'Internal',
+        description: 'Internal APIs',
+        kind: 'reference'
+      });
+    });
+
+    it('should add tag with both parent and kind options', async () => {
+      const hierarchicalOptions = new DocumentBuilder()
+        .setTitle('Hierarchical Tags Test')
+        .setVersion('1.0')
+        .addTag('Animals', 'All animal operations')
+        .addTag('Cats', 'Cat operations', undefined, {
+          parent: 'Animals',
+          kind: 'navigation'
+        })
+        .build();
+
+      const document = SwaggerModule.createDocument(app, hierarchicalOptions);
+
+      expect(document.tags).toBeDefined();
+      expect(document.tags).toHaveLength(2);
+      expect(document.tags?.[1]).toEqual({
+        name: 'Cats',
+        description: 'Cat operations',
+        parent: 'Animals',
+        kind: 'navigation'
+      });
+    });
+
+    it('should keep operation tags as string arrays', async () => {
+      const document = SwaggerModule.createDocument(app, options);
+
+      // Check that operation-level tags are string arrays (from @ApiTags decorator)
+      const createCatOperation = document.paths['/api/cats']?.post;
+      expect(createCatOperation?.tags).toBeDefined();
+      expect(Array.isArray(createCatOperation?.tags)).toBe(true);
+      expect(createCatOperation?.tags?.every((tag) => typeof tag === 'string')).toBe(
+        true
+      );
+    });
+  });
 });

--- a/lib/decorators/api-use-tags.decorator.ts
+++ b/lib/decorators/api-use-tags.decorator.ts
@@ -1,9 +1,13 @@
 import { DECORATORS } from '../constants';
+import { ApiTagOptions } from '../interfaces/open-api-spec.interface';
 import { createMixedDecorator } from './helpers';
 
 /**
  * @publicApi
  */
-export function ApiTags(...tags: string[]) {
-  return createMixedDecorator(DECORATORS.API_TAGS, tags);
+export function ApiTags(...tags: (string | ApiTagOptions)[]) {
+  const normalizedTags = tags.map((tag) =>
+    typeof tag === 'string' ? tag : tag.name
+  );
+  return createMixedDecorator(DECORATORS.API_TAGS, normalizedTags);
 }

--- a/lib/document-builder.ts
+++ b/lib/document-builder.ts
@@ -113,14 +113,17 @@ export class DocumentBuilder {
   public addTag(
     name: string,
     description = '',
-    externalDocs?: ExternalDocumentationObject
+    externalDocs?: ExternalDocumentationObject,
+    options?: { parent?: string; kind?: 'navigation' | 'reference' }
   ): this {
     this.document.tags = this.document.tags.concat(
       pickBy(
         {
           name,
           description,
-          externalDocs
+          externalDocs,
+          parent: options?.parent,
+          kind: options?.kind
         },
         negate(isUndefined)
       ) as TagObject

--- a/lib/interfaces/index.ts
+++ b/lib/interfaces/index.ts
@@ -1,3 +1,3 @@
-export { OpenAPIObject } from './open-api-spec.interface';
+export { ApiTagOptions, OpenAPIObject } from './open-api-spec.interface';
 export * from './swagger-custom-options.interface';
 export * from './swagger-document-options.interface';

--- a/lib/interfaces/open-api-spec.interface.ts
+++ b/lib/interfaces/open-api-spec.interface.ts
@@ -186,6 +186,14 @@ export interface TagObject {
   name: string;
   description?: string;
   externalDocs?: ExternalDocumentationObject;
+  parent?: string;
+  kind?: 'navigation' | 'reference';
+}
+
+export interface ApiTagOptions {
+  name: string;
+  parent?: string;
+  kind?: 'navigation' | 'reference';
 }
 
 export type ExamplesObject = Record<string, ExampleObject | ReferenceObject>;

--- a/test/decorators/api-use-tags.decorator.spec.ts
+++ b/test/decorators/api-use-tags.decorator.spec.ts
@@ -1,0 +1,137 @@
+import 'reflect-metadata';
+import { DECORATORS } from '../../lib/constants';
+import { ApiTags } from '../../lib/decorators/api-use-tags.decorator';
+
+describe('ApiTags', () => {
+  describe('with string arguments (backward compatibility)', () => {
+    class TestController {
+      @ApiTags('Cats')
+      singleTag() {}
+
+      @ApiTags('Cats', 'Pets')
+      multipleTags() {}
+    }
+
+    it('should store single string tag', () => {
+      const tags = Reflect.getMetadata(
+        DECORATORS.API_TAGS,
+        TestController.prototype.singleTag
+      );
+      expect(tags).toEqual(['Cats']);
+    });
+
+    it('should store multiple string tags', () => {
+      const tags = Reflect.getMetadata(
+        DECORATORS.API_TAGS,
+        TestController.prototype.multipleTags
+      );
+      expect(tags).toEqual(['Cats', 'Pets']);
+    });
+  });
+
+  describe('with object arguments', () => {
+    class TestController {
+      @ApiTags({ name: 'Cats' })
+      objectTag() {}
+
+      @ApiTags({ name: 'Cats', parent: 'Animals' })
+      objectWithParent() {}
+
+      @ApiTags({ name: 'Internal', kind: 'reference' })
+      objectWithKind() {}
+
+      @ApiTags({ name: 'Cats', parent: 'Animals', kind: 'navigation' })
+      objectWithBoth() {}
+    }
+
+    it('should extract name from object tag', () => {
+      const tags = Reflect.getMetadata(
+        DECORATORS.API_TAGS,
+        TestController.prototype.objectTag
+      );
+      expect(tags).toEqual(['Cats']);
+    });
+
+    it('should extract name from object with parent', () => {
+      const tags = Reflect.getMetadata(
+        DECORATORS.API_TAGS,
+        TestController.prototype.objectWithParent
+      );
+      expect(tags).toEqual(['Cats']);
+    });
+
+    it('should extract name from object with kind', () => {
+      const tags = Reflect.getMetadata(
+        DECORATORS.API_TAGS,
+        TestController.prototype.objectWithKind
+      );
+      expect(tags).toEqual(['Internal']);
+    });
+
+    it('should extract name from object with parent and kind', () => {
+      const tags = Reflect.getMetadata(
+        DECORATORS.API_TAGS,
+        TestController.prototype.objectWithBoth
+      );
+      expect(tags).toEqual(['Cats']);
+    });
+  });
+
+  describe('with mixed string and object arguments', () => {
+    class TestController {
+      @ApiTags('Dogs', { name: 'Cats' })
+      mixed() {}
+
+      @ApiTags({ name: 'Cats', parent: 'Animals' }, 'Dogs', { name: 'Birds' })
+      complexMixed() {}
+    }
+
+    it('should handle mixed string and object tags', () => {
+      const tags = Reflect.getMetadata(
+        DECORATORS.API_TAGS,
+        TestController.prototype.mixed
+      );
+      expect(tags).toEqual(['Dogs', 'Cats']);
+    });
+
+    it('should handle complex mixed tags', () => {
+      const tags = Reflect.getMetadata(
+        DECORATORS.API_TAGS,
+        TestController.prototype.complexMixed
+      );
+      expect(tags).toEqual(['Cats', 'Dogs', 'Birds']);
+    });
+  });
+
+  describe('applied on class', () => {
+    @ApiTags('Cats')
+    class StringTagController {}
+
+    @ApiTags({ name: 'Dogs', parent: 'Animals' })
+    class ObjectTagController {}
+
+    @ApiTags('Birds', { name: 'Cats', parent: 'Animals' })
+    class MixedTagController {}
+
+    it('should store string tag on class', () => {
+      const tags = Reflect.getMetadata(
+        DECORATORS.API_TAGS,
+        StringTagController
+      );
+      expect(tags).toEqual(['Cats']);
+    });
+
+    it('should store object tag name on class', () => {
+      const tags = Reflect.getMetadata(
+        DECORATORS.API_TAGS,
+        ObjectTagController
+      );
+      expect(tags).toEqual(['Dogs']);
+    });
+
+    it('should store mixed tags on class', () => {
+      const tags = Reflect.getMetadata(DECORATORS.API_TAGS, MixedTagController);
+      expect(tags).toEqual(['Birds', 'Cats']);
+    });
+  });
+});

--- a/test/document-builder.spec.ts
+++ b/test/document-builder.spec.ts
@@ -1,0 +1,111 @@
+import { DocumentBuilder } from '../lib/document-builder';
+
+describe('DocumentBuilder', () => {
+  describe('addTag', () => {
+    it('should add tag with name and description (backward compatibility)', () => {
+      const builder = new DocumentBuilder();
+      builder.addTag('Cats', 'Cat operations');
+      const doc = builder.build();
+
+      expect(doc.tags).toHaveLength(1);
+      expect(doc.tags[0]).toEqual({
+        name: 'Cats',
+        description: 'Cat operations'
+      });
+      expect(doc.tags[0]).not.toHaveProperty('parent');
+      expect(doc.tags[0]).not.toHaveProperty('kind');
+    });
+
+    it('should add tag with parent option', () => {
+      const builder = new DocumentBuilder();
+      builder.addTag('Cats', 'Cat operations', undefined, {
+        parent: 'Animals'
+      });
+      const doc = builder.build();
+
+      expect(doc.tags).toHaveLength(1);
+      expect(doc.tags[0]).toEqual({
+        name: 'Cats',
+        description: 'Cat operations',
+        parent: 'Animals'
+      });
+    });
+
+    it('should add tag with kind option', () => {
+      const builder = new DocumentBuilder();
+      builder.addTag('Internal', 'Internal APIs', undefined, {
+        kind: 'reference'
+      });
+      const doc = builder.build();
+
+      expect(doc.tags).toHaveLength(1);
+      expect(doc.tags[0]).toEqual({
+        name: 'Internal',
+        description: 'Internal APIs',
+        kind: 'reference'
+      });
+    });
+
+    it('should add tag with both parent and kind options', () => {
+      const builder = new DocumentBuilder();
+      builder.addTag('Cats', 'Cat operations', undefined, {
+        parent: 'Animals',
+        kind: 'navigation'
+      });
+      const doc = builder.build();
+
+      expect(doc.tags).toHaveLength(1);
+      expect(doc.tags[0]).toEqual({
+        name: 'Cats',
+        description: 'Cat operations',
+        parent: 'Animals',
+        kind: 'navigation'
+      });
+    });
+
+    it('should add tag with externalDocs and hierarchy options', () => {
+      const builder = new DocumentBuilder();
+      builder.addTag(
+        'Cats',
+        'Cat operations',
+        { url: 'https://example.com/cats' },
+        { parent: 'Animals', kind: 'navigation' }
+      );
+      const doc = builder.build();
+
+      expect(doc.tags).toHaveLength(1);
+      expect(doc.tags[0]).toEqual({
+        name: 'Cats',
+        description: 'Cat operations',
+        externalDocs: { url: 'https://example.com/cats' },
+        parent: 'Animals',
+        kind: 'navigation'
+      });
+    });
+
+    it('should add multiple tags with hierarchy', () => {
+      const builder = new DocumentBuilder();
+      builder
+        .addTag('Animals', 'All animal operations')
+        .addTag('Cats', 'Cat operations', undefined, { parent: 'Animals' })
+        .addTag('Dogs', 'Dog operations', undefined, { parent: 'Animals' });
+      const doc = builder.build();
+
+      expect(doc.tags).toHaveLength(3);
+      expect(doc.tags[0]).toEqual({
+        name: 'Animals',
+        description: 'All animal operations'
+      });
+      expect(doc.tags[1]).toEqual({
+        name: 'Cats',
+        description: 'Cat operations',
+        parent: 'Animals'
+      });
+      expect(doc.tags[2]).toEqual({
+        name: 'Dogs',
+        description: 'Dog operations',
+        parent: 'Animals'
+      });
+    });
+  });
+});

--- a/test/explorers/api-use-tags.explorer.spec.ts
+++ b/test/explorers/api-use-tags.explorer.spec.ts
@@ -1,0 +1,141 @@
+import 'reflect-metadata';
+import { ApiTags } from '../../lib/decorators/api-use-tags.decorator';
+import {
+  exploreApiTagsMetadata,
+  exploreGlobalApiTagsMetadata
+} from '../../lib/explorers/api-use-tags.explorer';
+
+describe('api-use-tags.explorer', () => {
+  describe('exploreGlobalApiTagsMetadata', () => {
+    describe('with string tags', () => {
+      @ApiTags('Cats')
+      class StringTagController {
+        findAll() {}
+      }
+
+      it('should return tags from string-based @ApiTags', () => {
+        const result = exploreGlobalApiTagsMetadata(false)(StringTagController);
+        expect(result).toEqual({ tags: ['Cats'] });
+      });
+    });
+
+    describe('with object tags (normalized to strings)', () => {
+      @ApiTags({ name: 'Dogs', parent: 'Animals' })
+      class ObjectTagController {
+        findAll() {}
+      }
+
+      it('should return normalized tag names from object-based @ApiTags', () => {
+        const result = exploreGlobalApiTagsMetadata(false)(ObjectTagController);
+        expect(result).toEqual({ tags: ['Dogs'] });
+      });
+    });
+
+    describe('with mixed tags (normalized to strings)', () => {
+      @ApiTags('Birds', { name: 'Cats', parent: 'Animals' })
+      class MixedTagController {
+        findAll() {}
+      }
+
+      it('should return normalized tag names from mixed @ApiTags', () => {
+        const result = exploreGlobalApiTagsMetadata(false)(MixedTagController);
+        expect(result).toEqual({ tags: ['Birds', 'Cats'] });
+      });
+    });
+
+    describe('with autoTagControllers', () => {
+      class UntaggedController {
+        findAll() {}
+      }
+
+      it('should return controller name as default tag when no tags defined', () => {
+        const result = exploreGlobalApiTagsMetadata(true)(UntaggedController);
+        expect(result).toEqual({ tags: ['Untagged'] });
+      });
+    });
+
+    describe('without tags', () => {
+      class NoTagsController {
+        findAll() {}
+      }
+
+      it('should return undefined when no tags and autoTagControllers is false', () => {
+        const result = exploreGlobalApiTagsMetadata(false)(NoTagsController);
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+
+  describe('exploreApiTagsMetadata', () => {
+    describe('with string tags on method', () => {
+      class TestController {
+        @ApiTags('Cats')
+        findAll() {}
+      }
+
+      it('should return tags from method', () => {
+        const instance = new TestController();
+        const result = exploreApiTagsMetadata(
+          instance,
+          TestController,
+          instance.findAll
+        );
+        expect(result).toEqual(['Cats']);
+      });
+    });
+
+    describe('with object tags on method (normalized)', () => {
+      class TestController {
+        @ApiTags({ name: 'Dogs', parent: 'Animals' })
+        findAll() {}
+      }
+
+      it('should return normalized tag names from method', () => {
+        const instance = new TestController();
+        const result = exploreApiTagsMetadata(
+          instance,
+          TestController,
+          instance.findAll
+        );
+        expect(result).toEqual(['Dogs']);
+      });
+    });
+
+    describe('with mixed tags on method (normalized)', () => {
+      class TestController {
+        @ApiTags('Birds', {
+          name: 'Cats',
+          parent: 'Animals',
+          kind: 'navigation'
+        })
+        findAll() {}
+      }
+
+      it('should return normalized tag names from method', () => {
+        const instance = new TestController();
+        const result = exploreApiTagsMetadata(
+          instance,
+          TestController,
+          instance.findAll
+        );
+        expect(result).toEqual(['Birds', 'Cats']);
+      });
+    });
+
+    describe('without tags on method', () => {
+      class TestController {
+        findAll() {}
+      }
+
+      it('should return undefined when no tags on method', () => {
+        const instance = new TestController();
+        const result = exploreApiTagsMetadata(
+          instance,
+          TestController,
+          instance.findAll
+        );
+        expect(result).toBeUndefined();
+      });
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

This PR implements the feature I requested in #3607. I wanted to give it a try myself.

Currently, `TagObject` only supports `name`, `description`, and `externalDocs`. OpenAPI 3.2 introduced hierarchical tags via `parent` and `kind` fields (doc [here](https://spec.openapis.org/oas/v3.2.0.html#fixed-fields-18) ), but there's no way to use them with `@nestjs/swagger`.

## What is the new behavior?

- `TagObject` interface now includes optional `parent` and `kind` fields
- `DocumentBuilder.addTag()` accepts an optional 4th parameter for hierarchy options
- `@ApiTags` decorator accepts object form `{ name, parent?, kind? }` alongside strings
- New `ApiTagOptions` type is exported for TypeScript users

```typescript
// Define tag hierarchy at document level
const config = new DocumentBuilder()
  .addTag('Animals', 'All animal operations')
  .addTag('Cats', 'Cat operations', undefined, { parent: 'Animals' })
  .addTag('Dogs', 'Dog operations', undefined, { parent: 'Animals', kind: 'navigation' })
  .build();

// Use @ApiTags with object form for hierarchy
@ApiTags({ name: 'Cats', parent: 'Animals' })
@Controller('cats')
export class CatsController {}

// Or mix strings and objects
@ApiTags('Dogs', { name: 'Puppies', parent: 'Dogs' })
@Controller('puppies')
export class PuppiesController {}

// Existing string syntax remains fully supported
@ApiTags('Cats')
@Controller('cats')
export class CatsController {}
```

Note: The hierarchy info (`parent`, `kind`) is only meaningful at the document level. When using `@ApiTags` with objects, the `name` is extracted for operation-level tags (which are always `string[]` per OpenAPI spec), while the full hierarchy should be defined via `DocumentBuilder.addTag()`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

**OpenAPI version compatibility:** The `parent` and `kind` fields are part of the OpenAPI 3.2 specification. Tools that only support OpenAPI 3.0/3.1 will simply ignore these fields, so this feature is fully backward compatible.

Related documentation PR: https://github.com/nestjs/docs.nestjs.com/pull/3409

Closes #3607