### PR TITLE
fix(plugin): support boolean literal types and boolean enum values

### DIFF
--- a/lib/decorators/api-property.decorator.ts
+++ b/lib/decorators/api-property.decorator.ts
@@ -71,7 +71,9 @@ export function createApiPropertyDecorator(
     const enumValues = getEnumValues(options.enum);
 
     options.enum = enumValues;
-    options.type = getEnumType(enumValues);
+    if (!options.type) {
+      options.type = getEnumType(enumValues);
+    }
   }
 
   if (Array.isArray(options.type)) {

--- a/lib/plugin/utils/ast-utils.ts
+++ b/lib/plugin/utils/ast-utils.ts
@@ -51,7 +51,14 @@ export function getTypeArguments(type: Type) {
 }
 
 export function isBoolean(type: Type) {
-  return hasFlag(type, TypeFlags.Boolean);
+  return (
+    hasFlag(type, TypeFlags.Boolean) ||
+    hasFlag(type, TypeFlags.BooleanLiteral)
+  );
+}
+
+export function isBooleanLiteral(type: Type) {
+  return hasFlag(type, TypeFlags.BooleanLiteral) && !type.isUnion();
 }
 
 export function isString(type: Type) {

--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -606,7 +606,7 @@ export class SchemaObjectFactory {
 
         const enumValues = getEnumValues(propertyCompilerMetadata.enum);
         propertyCompilerMetadata.items = {
-          type: getEnumType(enumValues),
+          type: propertyCompilerMetadata.items?.type ?? getEnumType(enumValues),
           enum: enumValues
         };
         delete propertyCompilerMetadata.enum;
@@ -614,7 +614,9 @@ export class SchemaObjectFactory {
         const enumValues = getEnumValues(propertyCompilerMetadata.enum);
 
         propertyCompilerMetadata.enum = enumValues;
-        propertyCompilerMetadata.type = getEnumType(enumValues);
+        if (!propertyCompilerMetadata.type) {
+          propertyCompilerMetadata.type = getEnumType(enumValues);
+        }
       }
       const propertyMetadata = this.mergePropertyWithMetadata(
         key,

--- a/lib/types/swagger-enum.type.ts
+++ b/lib/types/swagger-enum.type.ts
@@ -1,5 +1,6 @@
 export type SwaggerEnumType =
   | string[]
   | number[]
-  | (string | number)[]
+  | boolean[]
+  | (string | number | boolean)[]
   | Record<number, string>;

--- a/test/plugin/fixtures/boolean-literal.dto.ts
+++ b/test/plugin/fixtures/boolean-literal.dto.ts
@@ -1,0 +1,16 @@
+export const booleanLiteralDtoText = `
+export class BooleanLiteralDto {
+  propTrue: true;
+  propFalse: false;
+  propBoolLitUnion: true | false;
+  propOptionalTrue?: true;
+}
+`;
+
+export const booleanLiteralDtoTextTranspiled = `import * as openapi from "@nestjs/swagger";
+export class BooleanLiteralDto {
+    static _OPENAPI_METADATA_FACTORY() {
+        return { propTrue: { required: true, type: () => Boolean }, propFalse: { required: true, type: () => Boolean }, propBoolLitUnion: { required: true, type: () => Boolean }, propOptionalTrue: { required: false, type: () => Boolean } };
+    }
+}
+`;

--- a/test/plugin/model-class-visitor.spec.ts
+++ b/test/plugin/model-class-visitor.spec.ts
@@ -48,6 +48,10 @@ import {
   stringLiteralDtoText,
   stringLiteralDtoTextTranspiled
 } from './fixtures/string-literal.dto';
+import {
+  booleanLiteralDtoText,
+  booleanLiteralDtoTextTranspiled
+} from './fixtures/boolean-literal.dto';
 
 describe('API model properties', () => {
   it('should add the metadata factory when no decorators exist, and generated propertyKey is title', () => {
@@ -257,6 +261,33 @@ describe('API model properties', () => {
       }
     });
     expect(result.outputText).toEqual(stringLiteralDtoTextTranspiled);
+  });
+
+  it('should support & understand boolean literal types', () => {
+    const options: ts.CompilerOptions = {
+      module: ts.ModuleKind.ES2020,
+      target: ts.ScriptTarget.ES2020,
+      newLine: ts.NewLineKind.LineFeed,
+      noEmitHelpers: true,
+      experimentalDecorators: true,
+      strict: true
+    };
+    const filename = 'boolean-literal.dto.ts';
+    const fakeProgram = ts.createProgram([filename], options);
+
+    const result = ts.transpileModule(booleanLiteralDtoText, {
+      compilerOptions: options,
+      fileName: filename,
+      transformers: {
+        before: [
+          before(
+            { introspectComments: true, classValidatorShim: true },
+            fakeProgram
+          )
+        ]
+      }
+    });
+    expect(result.outputText).toEqual(booleanLiteralDtoTextTranspiled);
   });
 
   it('should support & understand parameter properties', () => {

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -1085,6 +1085,71 @@ describe('SchemaObjectFactory', () => {
     });
   });
 
+  describe('boolean enum and explicit type preservation', () => {
+    it('should produce type "boolean" with enum [true, false]', () => {
+      class BoolEnumDto {
+        @ApiProperty({ enum: [true, false] })
+        active: boolean;
+      }
+
+      const schemas: Record<string, SchemasObject> = {};
+      schemaObjectFactory.exploreModelSchema(BoolEnumDto, schemas);
+
+      expect(schemas.BoolEnumDto).toBeDefined();
+      const props = schemas.BoolEnumDto.properties as any;
+      expect(props.active).toEqual({
+        type: 'boolean',
+        enum: [true, false]
+      });
+    });
+
+    it('should produce type "boolean" with enum [true]', () => {
+      class TrueLiteralDto {
+        @ApiProperty({ enum: [true] })
+        flag: boolean;
+      }
+
+      const schemas: Record<string, SchemasObject> = {};
+      schemaObjectFactory.exploreModelSchema(TrueLiteralDto, schemas);
+
+      const props = schemas.TrueLiteralDto.properties as any;
+      expect(props.flag).toEqual({
+        type: 'boolean',
+        enum: [true]
+      });
+    });
+
+    it('should preserve explicit type when enum is also provided', () => {
+      class ExplicitTypeBoolDto {
+        @ApiProperty({ type: 'boolean', enum: [true] })
+        flag: boolean;
+      }
+
+      const schemas: Record<string, SchemasObject> = {};
+      schemaObjectFactory.exploreModelSchema(ExplicitTypeBoolDto, schemas);
+
+      const props = schemas.ExplicitTypeBoolDto.properties as any;
+      expect(props.flag).toEqual({
+        type: 'boolean',
+        enum: [true]
+      });
+    });
+
+    it('should preserve explicit type "string" even when enum values are numbers', () => {
+      class ExplicitTypeStringDto {
+        @ApiProperty({ type: 'string', enum: [1, 2, 3] })
+        code: string;
+      }
+
+      const schemas: Record<string, SchemasObject> = {};
+      schemaObjectFactory.exploreModelSchema(ExplicitTypeStringDto, schemas);
+
+      const props = schemas.ExplicitTypeStringDto.properties as any;
+      expect(props.code.type).toBe('string');
+      expect(props.code.enum).toEqual([1, 2, 3]);
+    });
+  });
+
   describe('SWC const-enum compatibility (issue #3326)', () => {
     // Simulate the `as const` pattern that SWC resolves as the const object for design:type:
     //   export const MyEnum = { FOO: 'FOO', BAR: 'BAR' } as const;

--- a/test/utils/enum-utils.spec.ts
+++ b/test/utils/enum-utils.spec.ts
@@ -1,0 +1,58 @@
+import { getEnumType, getEnumValues } from '../../lib/utils/enum.utils';
+
+describe('enum.utils', () => {
+  describe('getEnumType', () => {
+    it('should return "string" for string enum values', () => {
+      expect(getEnumType(['a', 'b'])).toBe('string');
+    });
+
+    it('should return "number" for number enum values', () => {
+      expect(getEnumType([1, 2])).toBe('number');
+    });
+
+    it('should return "boolean" for boolean enum values', () => {
+      expect(getEnumType([true, false])).toBe('boolean');
+    });
+
+    it('should return "boolean" for a single true value', () => {
+      expect(getEnumType([true])).toBe('boolean');
+    });
+
+    it('should return "boolean" for a single false value', () => {
+      expect(getEnumType([false])).toBe('boolean');
+    });
+
+    it('should return "string" for mixed string/number values', () => {
+      expect(getEnumType(['a', 1])).toBe('string');
+    });
+  });
+
+  describe('getEnumValues', () => {
+    it('should pass through boolean arrays unchanged', () => {
+      expect(getEnumValues([true, false])).toEqual([true, false]);
+    });
+
+    it('should pass through string arrays unchanged', () => {
+      expect(getEnumValues(['a', 'b'])).toEqual(['a', 'b']);
+    });
+
+    it('should pass through number arrays unchanged', () => {
+      expect(getEnumValues([1, 2])).toEqual([1, 2]);
+    });
+
+    it('should resolve lazy enum types', () => {
+      const lazyEnum = () => ['x', 'y'];
+      expect(getEnumValues(lazyEnum)).toEqual(['x', 'y']);
+    });
+
+    it('should extract values from TypeScript numeric enum objects', () => {
+      const numericEnum = { 0: 'A', 1: 'B', A: 0, B: 1 };
+      expect(getEnumValues(numericEnum)).toEqual([0, 1]);
+    });
+
+    it('should extract values from TypeScript string enum objects', () => {
+      const stringEnum = { A: 'alpha', B: 'beta' };
+      expect(getEnumValues(stringEnum)).toEqual(['alpha', 'beta']);
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

1. **Boolean literal types are not recognized by the CLI plugin.** When a DTO property is typed as literal `true` or `false` (e.g. `hasPaymentMethod: true`), the plugin's `isBoolean()` only checks `TypeFlags.Boolean` and misses `TypeFlags.BooleanLiteral`. This causes `getTypeReferenceAsString` to return `{ typeName: undefined }`, so no `type` is emitted in the plugin metadata for the property.

2. **`getEnumType()` returns `'number'` for boolean enum values.** The function only distinguishes between `'string'` and `'number'`, defaulting to `'number'` for anything that isn't a string. So `@ApiProperty({ enum: [true, false] })` produces `type: "number"` in the OpenAPI schema, which violates the OpenAPI 3.0 specification (Section 5.1 — Schema Object lists `boolean` as a valid primitive type).

3. **Explicit `type` is overwritten by enum type inference.** Both `createFromObjectLiteral()` in `SchemaObjectFactory` and the `@ApiProperty` decorator unconditionally overwrite the `type` property with the result of `getEnumType()` when `enum` is present. This means `@ApiProperty({ type: 'boolean', enum: [true] })` has its `type: 'boolean'` replaced with `type: 'number'`, with no escape hatch for the user.

Issue Number: N/A


## What is the new behavior?

1. `isBoolean()` now also matches `TypeFlags.BooleanLiteral`, so the plugin correctly emits `type: () => Boolean` for literal `true`/`false` properties. A new `isBooleanLiteral()` helper is added, consistent with the existing `isStringLiteral()` and `isEnumLiteral()` functions.

2. `getEnumType()` detects boolean values and returns `'boolean'`, producing spec-compliant OpenAPI schemas. `SwaggerEnumType` and `getEnumValues()` return types are updated to include `boolean[]`.

3. The enum type inference in both `createFromObjectLiteral()` and the `@ApiProperty` decorator now only applies when no explicit `type` is already set on the metadata. This is consistent with every other code path in the library where user-provided decorator metadata takes precedence over inference.

### OpenAPI / JSON Schema specification compliance

These changes bring the generated schemas in line with the [OpenAPI 3.0.3 specification](https://spec.openapis.org/oas/v3.0.3) and the [JSON Schema Validation draft](https://datatracker.ietf.org/doc/html/draft-wright-json-schema-validation-00) it builds on:

- **`type: "boolean"` is a first-class primitive.** OAS 3.0.3 §4.7.24.1 (Schema Object) defines data types via JSON Schema §4.2, which lists `boolean` alongside `string`, `number`, `integer`, `array`, and `object` as valid primitive types. Before this fix, `enum: [true, false]` produced `type: "number"` — an invalid schema that would cause spec validators (e.g. `swagger-cli validate`, Redocly, Spectral) to flag a type mismatch since the enum values are not numbers.

- **`enum` constrains values, not types.** JSON Schema §5.20 defines `enum` as a value-space constraint that is valid for any type. The OpenAPI toolchain (Swagger UI, Swagger Codegen, openapi-generator) resolves `type` independently from `enum` — they are orthogonal. By returning `'boolean'` from `getEnumType()` when the values are booleans, the generated schema now correctly pairs `type: "boolean"` with `enum: [true]` or `enum: [true, false]`, which is valid per §5.20 and renders correctly in Swagger UI as a constrained boolean field.

- **Explicit `type` must not be silently discarded.** OAS 3.0.3 §4.7.24.1 states that the `type` field determines the data type of the schema. When a user explicitly declares `@ApiProperty({ type: 'boolean', enum: [true] })`, the intent is unambiguous — the property is a boolean constrained to a single value. Overwriting this to `type: "number"` produced a schema where the declared type contradicts the enum values, which is a validation error under JSON Schema §5.20 (enum values must be valid against the schema). The guard now preserves user intent and produces schemas where `type` and `enum` are always consistent.

- **Boolean literal discriminators are now representable.** A common OpenAPI pattern for discriminated unions uses a fixed boolean property (e.g. `hasSomething: true` vs `hasSomething: false`) as a discriminator with `oneOf`. This requires `{ type: "boolean", enum: [true] }` and `{ type: "boolean", enum: [false] }` in the respective sub-schemas. Before this fix, both would incorrectly produce `type: "number"`, breaking code generators (openapi-generator, swagger-codegen) that rely on `type` to determine the target language type for the property.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

**Files changed (source):**
- `lib/plugin/utils/ast-utils.ts` — update `isBoolean()`, add `isBooleanLiteral()`
- `lib/utils/enum.utils.ts` — add boolean support to `getEnumType()` and `getEnumValues()`
- `lib/types/swagger-enum.type.ts` — add `boolean[]` to `SwaggerEnumType`
- `lib/services/schema-object-factory.ts` — guard `type` assignment in `createFromObjectLiteral()`
- `lib/decorators/api-property.decorator.ts` — guard `type` assignment in `createApiPropertyDecorator()`

**Files changed (tests):**
- `test/plugin/fixtures/boolean-literal.dto.ts` — new fixture with boolean literal properties
- `test/plugin/model-class-visitor.spec.ts` — test that plugin transpiles boolean literals to `type: () => Boolean`
- `test/utils/enum-utils.spec.ts` — unit tests for `getEnumType()` and `getEnumValues()` with boolean values
- `test/services/schema-object-factory.spec.ts` — tests for boolean enum schemas and explicit type preservation