### PR TITLE
fix(schema): preserve example metadata for non-body params with named types

### DIFF
--- a/e2e/api-spec.json
+++ b/e2e/api-spec.json
@@ -1482,6 +1482,79 @@
         }
       }
     },
+    "/api/cats/with-named-type-example": {
+      "get": {
+        "operationId": "CatsController_getWithNamedTypeExample",
+        "parameters": [
+          {
+            "name": "header",
+            "in": "header",
+            "description": "Test",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "default": "test"
+            }
+          },
+          {
+            "name": "filter",
+            "required": true,
+            "in": "query",
+            "schema": {
+              "example": "example-tag",
+              "allOf": [
+                {
+                  "$ref": "#/components/schemas/TagDto"
+                }
+              ]
+            }
+          },
+          {
+            "name": "x-tenant-id",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": ""
+          },
+          "400": {
+            "description": "Bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ValidationErrorDto"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error"
+          }
+        },
+        "security": [
+          {
+            "key2": [],
+            "key1": []
+          },
+          {
+            "bearer": []
+          },
+          {
+            "basic": []
+          }
+        ],
+        "tags": [
+          "cats"
+        ],
+        "x-foo": {
+          "from-controller": true
+        }
+      }
+    },
     "/api/cats/with-random-query": {
       "get": {
         "operationId": "CatsController_getWithRandomQuery",

--- a/e2e/src/cats/cats.controller.ts
+++ b/e2e/src/cats/cats.controller.ts
@@ -27,6 +27,7 @@ import { CatsService } from './cats.service';
 import { Cat } from './classes/cat.class';
 import { CreateCatDto } from './dto/create-cat.dto';
 import { LettersEnum, PaginationQuery } from './dto/pagination-query.dto';
+import { TagDto } from './dto/tag.dto';
 import { CatBreed } from './enums/cat-breed.enum';
 
 @ApiSecurity('basic')
@@ -172,6 +173,14 @@ export class CatsController {
     deprecated: false
   })
   getWithEnumNamedParam(@Param('type') type: LettersEnum) {}
+
+  @Get('with-named-type-example')
+  @ApiQuery({
+    name: 'filter',
+    type: TagDto,
+    example: 'example-tag'
+  })
+  getWithNamedTypeExample(@Query('filter') filter: TagDto) {}
 
   @Get('with-random-query')
   @ApiQuery({

--- a/e2e/validate-schema.e2e-spec.ts
+++ b/e2e/validate-schema.e2e-spec.ts
@@ -10,7 +10,7 @@ import {
   OpenAPIObject,
   SwaggerModule
 } from '../lib';
-import { SchemaObject } from '../lib/interfaces/open-api-spec.interface';
+import { ParameterObject, SchemaObject } from '../lib/interfaces/open-api-spec.interface';
 import { ApplicationModule } from './src/app.module';
 import { Cat } from './src/cats/classes/cat.class';
 import { TagDto } from './src/cats/dto/tag.dto';
@@ -189,6 +189,20 @@ describe('Validate OpenAPI schema', () => {
       console.log(doc);
       expect(err).toBeUndefined();
     }
+  });
+
+  it('should preserve example metadata for named type query params (issue #3335)', () => {
+    const document = SwaggerModule.createDocument(app, options);
+    const params =
+      document.paths['/api/cats/with-named-type-example']['get']['parameters'];
+    const filterParam = params.find(
+      (p: any) => p.name === 'filter' && p.in === 'query'
+    );
+    expect(filterParam).toBeDefined();
+    expect((filterParam as ParameterObject).schema).toEqual({
+      example: 'example-tag',
+      allOf: [{ $ref: '#/components/schemas/TagDto' }]
+    });
   });
 
   it('should fix colons in url', async () => {

--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -125,10 +125,15 @@ export class SchemaObjectFactory {
         // Just generate the schema for the type instead and link it with ref if needed
         const customType = this.getCustomType(param, schemas);
 
-        // Move schema-level options (e.g., example) from the top level into the schema
-        // object so they are not lost when mapParamTypes strips top-level keys.
-        const schemaOptionsKeys =
-          this.swaggerTypesMapper.getSchemaOptionsKeys();
+        // Move schema-level options (e.g., example, allOf) from the top level into
+        // the schema object so they are not lost when mapParamTypes strips top-level
+        // keys. SwaggerTypesMapper#omitParamKeys() does not remove 'allOf', so an
+        // unhandled top-level allOf would otherwise leak into the resulting
+        // ParameterObject as an invalid field.
+        const schemaOptionsKeys = [
+          ...this.swaggerTypesMapper.getSchemaOptionsKeys(),
+          'allOf'
+        ];
         const schemaOptionsFromParam: Record<string, any> = {};
         for (const key of schemaOptionsKeys) {
           // Skip 'type' and 'items' as they are handled by getCustomType
@@ -145,19 +150,36 @@ export class SchemaObjectFactory {
             string,
             any
           >;
-          // When we have extra metadata alongside a $ref, use allOf pattern
+          // When we have extra metadata alongside a $ref, wrap the $ref using
+          // allOf so the metadata sits beside it (OpenAPI does not allow sibling
+          // keys next to $ref). Merge with any pre-existing allOf entries from
+          // either the schema itself or the parameter rather than overwriting.
           if ('$ref' in existingSchema) {
-            const { $ref, ...restSchema } = existingSchema;
+            const { $ref, allOf: existingAllOf, ...restSchema } = existingSchema;
+            const { allOf: paramAllOf, ...restParamOptions } =
+              schemaOptionsFromParam;
+            const mergedAllOf = [
+              ...(Array.isArray(existingAllOf) ? existingAllOf : []),
+              ...(Array.isArray(paramAllOf) ? paramAllOf : []),
+              { $ref: $ref as string }
+            ];
             (customType as any).schema = {
               ...restSchema,
-              ...schemaOptionsFromParam,
-              allOf: [{ $ref: $ref as string }]
+              ...restParamOptions,
+              allOf: mergedAllOf
             };
           } else {
-            (customType as any).schema = {
+            const mergedSchema: Record<string, any> = {
               ...existingSchema,
               ...schemaOptionsFromParam
             };
+            // Merge allOf from both sides instead of letting one overwrite the other.
+            const existingAllOf = (existingSchema as any).allOf;
+            const paramAllOf = schemaOptionsFromParam.allOf;
+            if (Array.isArray(existingAllOf) && Array.isArray(paramAllOf)) {
+              mergedSchema.allOf = [...existingAllOf, ...paramAllOf];
+            }
+            (customType as any).schema = mergedSchema;
           }
         }
         return customType;

--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -123,7 +123,44 @@ export class SchemaObjectFactory {
       if (param.name) {
         // We should not spread parameters that have a name
         // Just generate the schema for the type instead and link it with ref if needed
-        return this.getCustomType(param, schemas);
+        const customType = this.getCustomType(param, schemas);
+
+        // Move schema-level options (e.g., example) from the top level into the schema
+        // object so they are not lost when mapParamTypes strips top-level keys.
+        const schemaOptionsKeys =
+          this.swaggerTypesMapper.getSchemaOptionsKeys();
+        const schemaOptionsFromParam: Record<string, any> = {};
+        for (const key of schemaOptionsKeys) {
+          // Skip 'type' and 'items' as they are handled by getCustomType
+          if (key === 'type' || key === 'items') {
+            continue;
+          }
+          if (key in customType && !(key in (customType.schema || {}))) {
+            schemaOptionsFromParam[key] = (customType as any)[key];
+            delete (customType as any)[key];
+          }
+        }
+        if (Object.keys(schemaOptionsFromParam).length > 0) {
+          const existingSchema = (customType.schema || {}) as Record<
+            string,
+            any
+          >;
+          // When we have extra metadata alongside a $ref, use allOf pattern
+          if ('$ref' in existingSchema) {
+            const { $ref, ...restSchema } = existingSchema;
+            (customType as any).schema = {
+              ...restSchema,
+              ...schemaOptionsFromParam,
+              allOf: [{ $ref: $ref as string }]
+            };
+          } else {
+            (customType as any).schema = {
+              ...existingSchema,
+              ...schemaOptionsFromParam
+            };
+          }
+        }
+        return customType;
       }
 
       const propertiesWithType = this.extractPropertiesFromType(

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -825,6 +825,52 @@ describe('SchemaObjectFactory', () => {
       expect(paramResult.schema.$ref).toContain('SimpleChild');
       expect(paramResult.schema.allOf).toBeUndefined();
     });
+
+    it('should merge param-level allOf with $ref wrapping and not lose example', () => {
+      class TagDto {
+        @ApiProperty()
+        name: string;
+      }
+
+      class FilterDto {
+        @ApiProperty()
+        value: string;
+      }
+
+      const schemas: Record<string, SchemasObject> = {};
+
+      // Simulate @ApiQuery({ name: 'filter', type: FilterDto, example: 'foo',
+      //   allOf: [{ $ref: '#/components/schemas/TagDto' }] }) on a @Query() param.
+      const queryParams: ParamWithTypeMetadata[] = [
+        {
+          in: 'query',
+          type: FilterDto,
+          name: 'filter',
+          required: true,
+          example: 'foo',
+          allOf: [{ $ref: '#/components/schemas/TagDto' }]
+        } as any
+      ];
+
+      const result = schemaObjectFactory.createFromModel(queryParams, schemas);
+
+      expect(result).toHaveLength(1);
+      const paramResult = result[0] as any;
+      // Top-level allOf and example must be moved into schema, not leaked.
+      expect(paramResult.allOf).toBeUndefined();
+      expect(paramResult.example).toBeUndefined();
+      expect(paramResult.schema).toBeDefined();
+      expect(paramResult.schema.example).toBe('foo');
+      // Both the parameter's allOf entry and the wrapped $ref should be present.
+      expect(Array.isArray(paramResult.schema.allOf)).toBe(true);
+      expect(paramResult.schema.allOf).toEqual(
+        expect.arrayContaining([
+          { $ref: '#/components/schemas/TagDto' },
+          expect.objectContaining({ $ref: expect.stringContaining('FilterDto') })
+        ])
+      );
+      expect(paramResult.schema.$ref).toBeUndefined();
+    });
   });
 
   describe('transformToArraySchemaProperty', () => {

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -748,6 +748,85 @@ describe('SchemaObjectFactory', () => {
     });
   });
 
+  describe('createFromModel', () => {
+    it('should preserve parent example when a non-body param property has a DTO type', () => {
+      class ChildDto {
+        @ApiProperty({ example: 'child DTO example 1' })
+        childKey1: string;
+        @ApiProperty({ example: 'child DTO example 2' })
+        childKey2: string;
+      }
+
+      class ParentDto {
+        @ApiProperty({ example: 'parent DTO example' })
+        parentKey: ChildDto;
+      }
+
+      const schemas: Record<string, SchemasObject> = {};
+
+      // Simulate what ParametersMetadataMapper produces for @Query() ParentDto:
+      // it expands the DTO into individual properties with their metadata
+      const queryParams: ParamWithTypeMetadata[] = [
+        {
+          in: 'query',
+          type: ChildDto,
+          name: 'parentKey',
+          required: true,
+          example: 'parent DTO example'
+        } as any
+      ];
+
+      const result = schemaObjectFactory.createFromModel(
+        queryParams,
+        schemas
+      );
+
+      expect(result).toHaveLength(1);
+      const paramResult = result[0] as any;
+      expect(paramResult.name).toBe('parentKey');
+      // The parent's example should be preserved in the schema
+      expect(paramResult.schema).toBeDefined();
+      expect(paramResult.schema.example).toBe('parent DTO example');
+      // Should use allOf pattern when extra metadata exists alongside $ref
+      expect(paramResult.schema.allOf).toBeDefined();
+      expect(paramResult.schema.allOf[0].$ref).toContain('ChildDto');
+    });
+
+    it('should not alter schema when no extra schema options exist on param', () => {
+      class SimpleChild {
+        @ApiProperty()
+        value: string;
+      }
+
+      class SimpleParent {
+        @ApiProperty()
+        child: SimpleChild;
+      }
+
+      const schemas: Record<string, SchemasObject> = {};
+
+      const queryParams: ParamWithTypeMetadata[] = [
+        {
+          in: 'query',
+          type: SimpleChild,
+          name: 'child',
+          required: true
+        } as any
+      ];
+
+      const result = schemaObjectFactory.createFromModel(
+        queryParams,
+        schemas
+      );
+
+      expect(result).toHaveLength(1);
+      const paramResult = result[0] as any;
+      // Without extra schema options, should use plain $ref
+      expect(paramResult.schema.$ref).toContain('SimpleChild');
+      expect(paramResult.schema.allOf).toBeUndefined();
+    });
+  });
+
   describe('transformToArraySchemaProperty', () => {
     it('should preserve items schema when metadata.items is already defined and type is string', () => {
       const metadata = {


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
- [x] Bugfix

## What is the current behavior?
When a ParentDto has a property of type ChildDto, and both have `@ApiProperty({ example: ... })`, the parent's `example` is lost for non-body parameters (@Query, @Param, @Headers). The child DTO's examples leak through instead.

This happens because `getCustomType()` places schema-level options (like `example`) at the top level of the parameter object, while `SwaggerTypesMapper.mapParamTypes()` later strips all schema-option keys from the top level.

Issue Number: #3335

## What is the new behavior?
Schema-level options (example, default, format, etc.) are now moved into the `schema` object after `getCustomType()` returns. When there are extra metadata properties alongside a `$ref`, it uses the `allOf: [{ $ref }]` pattern, ensuring metadata is properly preserved for all parameter types.

## Does this PR introduce a breaking change?
- [x] No