### PR TITLE
fix(schema): include type field when nullable is used with allOf

### DIFF
--- a/e2e/src/cats/dto/create-cat.dto.ts
+++ b/e2e/src/cats/dto/create-cat.dto.ts
@@ -96,6 +96,9 @@ export class CreateCatDto {
   @ApiProperty({ description: 'tag', required: false })
   readonly tag: TagDto;
 
+  @ApiProperty({ description: 'nullable tag', nullable: true, type: () => TagDto })
+  readonly nullableTag: TagDto;
+
   nested: {
     first: string;
     second: number;

--- a/e2e/validate-schema.e2e-spec.ts
+++ b/e2e/validate-schema.e2e-spec.ts
@@ -252,6 +252,18 @@ describe('Validate OpenAPI schema', () => {
     });
   });
 
+  it('should include type field when nullable is used with allOf (issue #3274)', () => {
+    const document = SwaggerModule.createDocument(app, options);
+    const createCatDtoSchema = document.components?.schemas
+      ?.CreateCatDto as SchemaObject;
+    expect(createCatDtoSchema.properties.nullableTag).toEqual({
+      description: 'nullable tag',
+      nullable: true,
+      type: 'object',
+      allOf: [{ $ref: '#/components/schemas/TagDto' }]
+    });
+  });
+
   it('should not add optional properties to required list', () => {
     const document = SwaggerModule.createDocument(app, options);
     const required = (document.components?.schemas?.Cat as SchemaObject)

--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -243,7 +243,7 @@ export class SchemaObjectFactory {
           schemaObjectMetadata.items[declaredSchemaCombinator] =
             property[declaredSchemaCombinator];
           delete property[declaredSchemaCombinator];
-        } else {
+        } else if (!schemaObjectMetadata['nullable']) {
           delete schemaObjectMetadata.type;
         }
       }
@@ -525,6 +525,7 @@ export class SchemaObjectFactory {
         name: metadata.name || key,
         required: metadata.required,
         ...validMetadataObject,
+        ...(validMetadataObject['nullable'] ? { type: 'object' } : {}),
         allOf: [{ $ref }]
       } as SchemaObjectMetadata;
     }

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -292,6 +292,7 @@ describe('SchemaObjectFactory', () => {
           profile: {
             description: 'Profile',
             nullable: true,
+            type: 'object',
             allOf: [
               {
                 $ref: '#/components/schemas/CreateProfileDto'
@@ -392,6 +393,35 @@ describe('SchemaObjectFactory', () => {
           }
         },
         required: ['firstname', 'lastname', 'parent']
+      });
+    });
+
+    it('should include type "object" for nullable $ref properties (issue #3274)', () => {
+      class ProfileDto {
+        @ApiProperty()
+        bio: string;
+      }
+
+      class UserWithNullableProfile {
+        @ApiProperty({
+          nullable: true,
+          type: () => ProfileDto
+        })
+        profile: ProfileDto;
+      }
+
+      const schemas: Record<string, SchemasObject> = {};
+      schemaObjectFactory.exploreModelSchema(
+        UserWithNullableProfile,
+        schemas
+      );
+      expect(
+        (schemas['UserWithNullableProfile'] as Record<string, any>).properties
+          .profile
+      ).toEqual({
+        nullable: true,
+        type: 'object',
+        allOf: [{ $ref: '#/components/schemas/ProfileDto' }]
       });
     });
 


### PR DESCRIPTION
## PR Checklist
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [x] Docs have been added / updated

## PR Type
- [x] Bugfix

## What is the current behavior?
When a property is `UserDto | null`, the schema has `nullable: true` and `allOf: [{ $ref }]` but no `type` field. Redocly's linter errors: "The type field must be defined when the nullable field is used."

Issue Number: #3274

## What is the new behavior?
Preserves `type: 'object'` for nullable properties with schema combinators. The `extractPropertiesFromType` combinator handler now keeps `type` when `nullable: true`.

## Does this PR introduce a breaking change?
- [x] No