### PR TITLE
feat(decorators): support RegExp instances in @ApiProperty({ pattern })

### DIFF
--- a/lib/decorators/api-property.decorator.ts
+++ b/lib/decorators/api-property.decorator.ts
@@ -84,6 +84,10 @@ export function createApiPropertyDecorator(
     };
   }
 
+  if (options.pattern instanceof RegExp) {
+    options.pattern = options.pattern.source;
+  }
+
   return createPropertyDecorator(
     DECORATORS.API_MODEL_PROPERTIES,
     options,

--- a/lib/interfaces/schema-object-metadata.interface.ts
+++ b/lib/interfaces/schema-object-metadata.interface.ts
@@ -7,10 +7,13 @@ export type EnumAllowedTypes =
   | Record<string, any>
   | (() => any[] | Record<string, any>);
 
-interface SchemaObjectCommonMetadata
-  extends Omit<SchemaObject, 'type' | 'required' | 'properties' | 'enum'> {
+interface SchemaObjectCommonMetadata extends Omit<
+  SchemaObject,
+  'type' | 'required' | 'properties' | 'enum' | 'pattern'
+> {
   isArray?: boolean;
   name?: string;
+  pattern?: string | RegExp;
   enum?: EnumAllowedTypes;
 }
 

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -421,6 +421,69 @@ describe('SchemaObjectFactory', () => {
       });
     });
 
+    it('should convert RegExp pattern to string in schema', () => {
+      class RegExpPatternDto {
+        @ApiProperty({ pattern: /^[+]?abc$/ })
+        code: string;
+      }
+
+      const schemas: Record<string, SchemasObject> = {};
+      schemaObjectFactory.exploreModelSchema(RegExpPatternDto, schemas);
+
+      expect(schemas[RegExpPatternDto.name]).toEqual({
+        type: 'object',
+        properties: {
+          code: {
+            type: 'string',
+            pattern: '^[+]?abc$'
+          }
+        },
+        required: ['code']
+      });
+    });
+
+    it('should strip flags when converting RegExp pattern', () => {
+      class RegExpFlagsDto {
+        @ApiProperty({ pattern: /abc/i })
+        value: string;
+      }
+
+      const schemas: Record<string, SchemasObject> = {};
+      schemaObjectFactory.exploreModelSchema(RegExpFlagsDto, schemas);
+
+      expect(schemas[RegExpFlagsDto.name]).toEqual({
+        type: 'object',
+        properties: {
+          value: {
+            type: 'string',
+            pattern: 'abc'
+          }
+        },
+        required: ['value']
+      });
+    });
+
+    it('should keep string pattern unchanged', () => {
+      class StringPatternDto {
+        @ApiProperty({ pattern: '^[a-z]+$' })
+        slug: string;
+      }
+
+      const schemas: Record<string, SchemasObject> = {};
+      schemaObjectFactory.exploreModelSchema(StringPatternDto, schemas);
+
+      expect(schemas[StringPatternDto.name]).toEqual({
+        type: 'object',
+        properties: {
+          slug: {
+            type: 'string',
+            pattern: '^[a-z]+$'
+          }
+        },
+        required: ['slug']
+      });
+    });
+
     it('should override base class metadata', () => {
       class CreatUserDto {
         @ApiProperty({ minLength: 0, required: true })


### PR DESCRIPTION
## Summary

- Automatically convert `RegExp` instances to their `.source` string when passed to `@ApiProperty({ pattern })` 
- Extend `SchemaObjectCommonMetadata` to accept `pattern?: string | RegExp`
- Fully backward compatible — string values work as before

## Test plan

- [x] All 158 tests pass (16 suites)
- [x] Build (`tsc`) passes with no new errors
- [x] Zero new `any` types introduced
- [x] Edge cases verified: null, undefined, string, empty RegExp — all safe via `instanceof RegExp`

Fixes #3719

🤖 Generated with [Claude Code](https://claude.ai/code)