### PR TITLE
fix(decorators): do not crash on Controller getter

### DIFF
--- a/lib/decorators/helpers.ts
+++ b/lib/decorators/helpers.ts
@@ -173,6 +173,10 @@ export function createParamDecorator<T extends Record<string, any> = any>(
         continue;
       }
 
+      if (!methodDescriptor.value) {
+        continue;
+      }
+
       const isApiMethod = Reflect.hasMetadata(
         METHOD_METADATA,
         methodDescriptor.value

--- a/test/decorators/api-query.decorator.spec.ts
+++ b/test/decorators/api-query.decorator.spec.ts
@@ -13,6 +13,10 @@ describe('ApiQuery', () => {
       }
 
       public noAPiMethod(): void {}
+
+      public get service() {
+        return null;
+      }
     }
 
     it('should attach metadata to all API methods', () => {


### PR DESCRIPTION
getter descriptors use the `.get` field rather than `.value`. If an @ApiQuery-decorated Controller has a getter, we should ignore the getters when applying the decoration to its members.

This change will prevent these types of Controllers from crashing on startup.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When a controller is decorated with `@ApiQuery()` and also contains a getter, the app will crash on startup.

Issue Number: N/A


## What is the new behavior?

When a controller is decorated with `@ApiQuery()` and also contains a getter, the app will start as expected.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
