### PR TITLE
fix(swagger-explorer): prevent enum schema mutation across multiple document generations

### DIFF
--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -409,19 +409,15 @@ export class SchemaObjectFactory {
       }
     }
 
-    param.schema =
+    const newSchema =
       param.isArray || param.schema?.['items']
         ? { type: 'array', items: { $ref } }
         : { $ref };
 
-    return omit(param, [
-      'isArray',
-      'items',
-      'enumName',
-      'enum',
-      'x-enumNames',
-      'enumSchema'
-    ]);
+    return omit(
+      { ...param, schema: newSchema },
+      ['isArray', 'items', 'enumName', 'enum', 'x-enumNames', 'enumSchema']
+    );
   }
 
   createEnumSchemaType(

--- a/test/explorer/swagger-explorer.spec.ts
+++ b/test/explorer/swagger-explorer.spec.ts
@@ -1355,6 +1355,55 @@ describe('SwaggerExplorer', () => {
         }
       ]);
     });
+
+    it('should generate enum schema on second document generation (multi-doc regression)', () => {
+      // Reproduce issue #2182: enum schema missing in second specification.
+      // The bug was that createEnumParam mutated the Reflect metadata object
+      // by overwriting param.schema with { $ref }, so on the second call the
+      // original enum values (stored in param.schema.enum) were gone.
+
+      @Controller('')
+      class MultiDocController {
+        @Get('items')
+        @ApiQuery({ name: 'color', enum: QueryEnum, enumName: 'QueryEnum' })
+        findItems(): Promise<void> {
+          return Promise.resolve();
+        }
+      }
+
+      const config = new ApplicationConfig();
+
+      // First document generation
+      const explorer1 = new SwaggerExplorer(schemaObjectFactory);
+      explorer1.exploreController(
+        {
+          instance: new MultiDocController(),
+          metatype: MultiDocController
+        } as InstanceWrapper<MultiDocController>,
+        config,
+        { modulePath: '', globalPrefix: '' }
+      );
+      const schemas1 = explorer1.getSchemas();
+
+      // Second document generation — must produce the same enum schema
+      const explorer2 = new SwaggerExplorer(schemaObjectFactory);
+      explorer2.exploreController(
+        {
+          instance: new MultiDocController(),
+          metatype: MultiDocController
+        } as InstanceWrapper<MultiDocController>,
+        config,
+        { modulePath: '', globalPrefix: '' }
+      );
+      const schemas2 = explorer2.getSchemas();
+
+      // Both documents must contain a fully-populated enum schema
+      expect(schemas1['QueryEnum']).toBeDefined();
+      expect(schemas1['QueryEnum'].enum).toEqual([1, 2, 3]);
+
+      expect(schemas2['QueryEnum']).toBeDefined();
+      expect(schemas2['QueryEnum'].enum).toEqual([1, 2, 3]);
+    });
   });
 
   describe('when headers are defined', () => {


### PR DESCRIPTION
## Summary

Fixes #2182

**Bug:** When generating two separate Swagger documents in the same process, enum query parameters were missing their schema (`$ref` pointed to an undefined component) in the second document.

**Root Cause:** `SchemaObjectFactory.createEnumParam` assigned directly to `param.schema`, mutating the object that is stored by reference inside `Reflect` decorator metadata. On the second document generation the metadata already had `param.schema = { $ref }` with no `enum` values, so the enum schema was never re-registered.

**Fix:** Instead of mutating `param.schema` in place, a shallow copy of `param` is spread with the new `schema` property before passing to `omit`. The original metadata object is never modified.

## Changes

- `lib/services/schema-object-factory.ts`: Replace `param.schema = newSchema` mutation with `omit({ ...param, schema: newSchema }, [...])` spread to avoid mutating shared Reflect metadata.
- `test/explorer/swagger-explorer.spec.ts`: Add regression test that runs `exploreController` twice with two separate `SwaggerExplorer` instances and asserts the enum schema is fully populated in both resulting documents.

## Testing

- Added regression test `should generate enum schema on second document generation (multi-doc regression)` in `test/explorer/swagger-explorer.spec.ts` that verifies the `QueryEnum` schema (with `enum: [1, 2, 3]`) is present after both the first and second document generation.
- All 159 existing tests pass.