### PR TITLE
fix(schema): generate $ref for query parameters with DTO types

### DIFF
--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -120,8 +120,9 @@ export class SchemaObjectFactory {
       };
     }
     if (isFunction(param.type)) {
-      if (param.name) {
-        // We should not spread parameters that have a name
+      if (param.name !== undefined && param.name !== null) {
+        // We should not spread parameters that have a name (or an explicitly
+        // set empty name from @ApiQuery({ type: DtoClass })).
         // Just generate the schema for the type instead and link it with ref if needed
         return this.getCustomType(param, schemas);
       }

--- a/test/explorer/swagger-explorer.spec.ts
+++ b/test/explorer/swagger-explorer.spec.ts
@@ -2615,4 +2615,72 @@ describe('SwaggerExplorer', () => {
       GlobalParametersStorage.clear();
     });
   });
+
+  describe('when @ApiQuery is used with a DTO type and no name (issue #3652)', () => {
+    class QueryFilterDto {
+      @ApiProperty()
+      search: string;
+
+      @ApiProperty({ minimum: 0 })
+      page: number;
+    }
+
+    @Controller('')
+    class FooController {
+      @Get('/items')
+      @ApiQuery({ type: QueryFilterDto })
+      findAll(): void {}
+
+      @Get('/named')
+      @ApiQuery({ name: 'filter', type: QueryFilterDto })
+      findNamed(): void {}
+    }
+
+    it('should use $ref for @ApiQuery with a DTO type and no name', () => {
+      const explorer = new SwaggerExplorer(schemaObjectFactory);
+      const routes = explorer.exploreController(
+        {
+          instance: new FooController(),
+          metatype: FooController
+        } as InstanceWrapper<FooController>,
+        new ApplicationConfig(),
+        { modulePath: 'path' }
+      );
+
+      // Route with unnamed @ApiQuery({ type: QueryFilterDto }) should produce
+      // a single $ref parameter instead of expanding the DTO properties inline
+      expect(routes[0].root.parameters).toEqual([
+        {
+          name: 'QueryFilterDto',
+          in: 'query',
+          required: true,
+          schema: {
+            $ref: '#/components/schemas/QueryFilterDto'
+          }
+        }
+      ]);
+
+      // The schema should be registered in components/schemas
+      expect(explorer.getSchemas()['QueryFilterDto']).toBeDefined();
+      expect(explorer.getSchemas()['QueryFilterDto'].properties).toHaveProperty(
+        'search'
+      );
+      expect(explorer.getSchemas()['QueryFilterDto'].properties).toHaveProperty(
+        'page'
+      );
+
+      // Route with named @ApiQuery({ name: 'filter', type: QueryFilterDto })
+      // should still produce a named $ref parameter (existing behavior)
+      expect(routes[1].root.parameters).toEqual([
+        {
+          name: 'filter',
+          in: 'query',
+          required: true,
+          schema: {
+            $ref: '#/components/schemas/QueryFilterDto'
+          }
+        }
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #3652

**Bug:** When using `@ApiQuery({ type: SomeDto })` without a `name` property, the schema was expanded inline (spreading all DTO properties as individual query parameters) instead of generating a `$ref` to the DTO schema.

**Root Cause:** `createQueryOrParamSchema` used `if (param.name)` to decide whether to generate a `$ref`. Since `@ApiQuery` sets `name: ''` (empty string) by default, the falsy check caused the `$ref` path to be skipped entirely.

**Fix:** Changed the condition from `if (param.name)` to `if (param.name !== undefined && param.name !== null)`, so that an empty string now correctly takes the `$ref` code path.

## Changes

- `lib/services/schema-object-factory.ts`: Updated condition in `createQueryOrParamSchema` to use a strict null/undefined check instead of a falsy check for `param.name`.
- `test/explorer/swagger-explorer.spec.ts`: Added regression test verifying that `@ApiQuery({ type: DtoClass })` produces a `$ref` parameter and registers the schema in components, and that the existing named-parameter behavior is unchanged.

## Testing

- Added regression test in `test/explorer/swagger-explorer.spec.ts` that verifies `@ApiQuery` with a DTO type and no explicit name generates a single `$ref` parameter instead of inline-expanded properties.
- All existing tests pass (159 passing).