### PR TITLE
fix(schema): downgrade duplicate DTO detection from error to warning

### DIFF
--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -313,7 +313,7 @@ export class SchemaObjectFactory {
     }
 
     if (schemas[schemaName] && !isEqual(schemas[schemaName], typeDefinition)) {
-      Logger.error(
+      Logger.warn(
         `Duplicate DTO detected: "${schemaName}" is defined multiple times with different schemas.\n` +
           `Consider using unique class names or applying @ApiExtraModels() decorator with custom schema names.\n` +
           `Note: This will throw an error in the next major version.`

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -178,8 +178,8 @@ describe('SchemaObjectFactory', () => {
       });
     });
 
-    it('should log an error when detecting duplicate DTOs with different schemas', () => {
-      const loggerErrorSpy = vi.spyOn(Logger, 'error').mockImplementation(() => {});
+    it('should log a warning when detecting duplicate DTOs with different schemas', () => {
+      const loggerWarnSpy = vi.spyOn(Logger, 'warn').mockImplementation(() => {});
       const schemas: Record<string, SchemasObject> = {};
 
       class DuplicateDTO {
@@ -203,17 +203,49 @@ describe('SchemaObjectFactory', () => {
         schemas
       );
 
-      expect(loggerErrorSpy).toHaveBeenCalledWith(
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
         `Duplicate DTO detected: "DuplicateDTO" is defined multiple times with different schemas.\n` +
           `Consider using unique class names or applying @ApiExtraModels() decorator with custom schema names.\n` +
           `Note: This will throw an error in the next major version.`
       );
 
-      loggerErrorSpy.mockRestore();
+      loggerWarnSpy.mockRestore();
     });
 
-    it('should not throw an error or log error when detecting duplicate DTOs with the same schemas', () => {
+    it('should not log an error when detecting duplicate DTOs with different schemas', () => {
       const loggerErrorSpy = vi.spyOn(Logger, 'error').mockImplementation(() => {});
+      const loggerWarnSpy = vi.spyOn(Logger, 'warn').mockImplementation(() => {});
+      const schemas: Record<string, SchemasObject> = {};
+
+      class DuplicateDTO {
+        @ApiProperty()
+        property1: string;
+      }
+
+      schemaObjectFactory.exploreModelSchema(DuplicateDTO, schemas);
+
+      class DuplicateDTOWithDifferentSchema {
+        @ApiProperty()
+        property2: string;
+      }
+
+      Object.defineProperty(DuplicateDTOWithDifferentSchema, 'name', {
+        value: 'DuplicateDTO'
+      });
+
+      schemaObjectFactory.exploreModelSchema(
+        DuplicateDTOWithDifferentSchema,
+        schemas
+      );
+
+      expect(loggerErrorSpy).not.toHaveBeenCalled();
+
+      loggerErrorSpy.mockRestore();
+      loggerWarnSpy.mockRestore();
+    });
+
+    it('should not log a warning when detecting duplicate DTOs with the same schemas', () => {
+      const loggerWarnSpy = vi.spyOn(Logger, 'warn').mockImplementation(() => {});
       const schemas: Record<string, SchemasObject> = {};
 
       class DuplicateDTO {
@@ -237,9 +269,9 @@ describe('SchemaObjectFactory', () => {
         schemas
       );
 
-      expect(loggerErrorSpy).not.toHaveBeenCalled();
+      expect(loggerWarnSpy).not.toHaveBeenCalled();
 
-      loggerErrorSpy.mockRestore();
+      loggerWarnSpy.mockRestore();
     });
 
     it('should create openapi schema', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

PR #3400 introduced duplicate DTO detection that calls `Logger.error()` when same-named DTOs with different schemas are found. This is too severe for users who intentionally have same-named DTOs across different modules, causing unnecessary alarm in production logs.

Issue Number: #3446


## What is the new behavior?

Duplicate DTO detection now uses `Logger.warn()` instead of `Logger.error()`. The message already states "This will throw an error in the next major version," so warning is the appropriate severity level. This gives users visibility into the issue without treating it as a critical error.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

- Changed `Logger.error` to `Logger.warn` in `schema-object-factory.ts`
- Updated existing test to assert on `Logger.warn` instead of `Logger.error`
- Added new test to verify `Logger.error` is NOT called for duplicate DTOs
- Renamed test for same-schema duplicates to reflect warn instead of error