### PR TITLE
fix(core): add exports field to package.json for ESM compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,17 @@
   "repository": "https://github.com/nestjs/swagger",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./plugin": {
+      "types": "./dist/plugin/index.d.ts",
+      "default": "./dist/plugin/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "format": "prettier \"lib/**/*.ts\" --write",

--- a/test/esm-exports.spec.ts
+++ b/test/esm-exports.spec.ts
@@ -1,0 +1,41 @@
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+describe('Package ESM exports', () => {
+  let packageJson: any;
+
+  beforeAll(() => {
+    const packageJsonPath = resolve(__dirname, '..', 'package.json');
+    packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+  });
+
+  it('should have an exports field', () => {
+    expect(packageJson.exports).toBeDefined();
+  });
+
+  it('should define "." entry point with types and default', () => {
+    const mainExport = packageJson.exports['.'];
+    expect(mainExport).toBeDefined();
+    expect(mainExport.types).toBe('./dist/index.d.ts');
+    expect(mainExport.default).toBe('./dist/index.js');
+  });
+
+  it('should define "./plugin" subpath export', () => {
+    const pluginExport = packageJson.exports['./plugin'];
+    expect(pluginExport).toBeDefined();
+    expect(pluginExport.types).toBe('./dist/plugin/index.d.ts');
+    expect(pluginExport.default).toBe('./dist/plugin/index.js');
+  });
+
+  it('should expose package.json via exports', () => {
+    expect(packageJson.exports['./package.json']).toBe('./package.json');
+  });
+
+  it('should have main field pointing to dist/index.js', () => {
+    expect(packageJson.main).toBe('dist/index.js');
+  });
+
+  it('should have types field pointing to dist/index.d.ts', () => {
+    expect(packageJson.types).toBe('dist/index.d.ts');
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When a project uses `"type": "module"` in its `package.json`, importing `@nestjs/swagger` fails because Node.js ESM resolution requires an `exports` field to resolve bare specifiers. Without it, consumers get errors like `Cannot find package '@nestjs/swagger'` or `ERR_PACKAGE_PATH_NOT_EXPORTED`.

Issue Number: #3591


## What is the new behavior?

The `package.json` now includes an `exports` field with entries for:
- `"."` — main entry point (`dist/index.js` + types)
- `"./plugin"` — plugin subpath (`dist/plugin/index.js` + types)
- `"./package.json"` — allows reading the package metadata

This enables proper ESM resolution while maintaining full backward compatibility with CommonJS consumers via the existing `main` and `types` fields.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

6 regression tests added in `test/esm-exports.spec.ts` to verify the exports field structure.