### PR TITLE
fix(decorators): use getOwnMetadata to prevent parent property metadata leaking to child classes

### DIFF
--- a/lib/decorators/helpers.ts
+++ b/lib/decorators/helpers.ts
@@ -59,7 +59,7 @@ export function createPropertyDecorator<T extends Record<string, any> = any>(
         target
       );
     }
-    const existingMetadata = Reflect.getMetadata(metakey, target, propertyKey);
+    const existingMetadata = Reflect.getOwnMetadata(metakey, target, propertyKey);
     if (existingMetadata) {
       const newMetadata = pickBy(metadata, negate(isUndefined));
       const metadataToSave = overrideExisting

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -902,5 +902,51 @@ describe('SchemaObjectFactory', () => {
       expect(rankProp).toBeDefined();
     });
   });
+
+  describe('property override in class inheritance', () => {
+    it('should use the child class property type when overriding a parent property', () => {
+      class InfoPostDTO {
+        @ApiProperty()
+        name: string;
+      }
+
+      class InfoPutDTO extends InfoPostDTO {
+        @ApiProperty()
+        id: number;
+      }
+
+      class EntityPostDTO {
+        @ApiProperty()
+        id: number;
+
+        @ApiProperty({ type: () => InfoPostDTO })
+        info: InfoPostDTO;
+      }
+
+      class EntityPutDTO extends EntityPostDTO {
+        @ApiProperty({ type: () => InfoPutDTO })
+        info: InfoPutDTO;
+      }
+
+      const schemas: Record<string, any> = {};
+
+      schemaObjectFactory.exploreModelSchema(EntityPostDTO as any, schemas);
+      schemaObjectFactory.exploreModelSchema(EntityPutDTO as any, schemas);
+
+      // EntityPostDTO.info should reference InfoPostDTO
+      const postInfoProp = schemas['EntityPostDTO'].properties['info'];
+      expect(postInfoProp).toBeDefined();
+      expect(postInfoProp.$ref || postInfoProp.allOf?.[0]?.$ref).toContain(
+        'InfoPostDTO'
+      );
+
+      // EntityPutDTO.info should reference InfoPutDTO (not InfoPostDTO)
+      const putInfoProp = schemas['EntityPutDTO'].properties['info'];
+      expect(putInfoProp).toBeDefined();
+      expect(putInfoProp.$ref || putInfoProp.allOf?.[0]?.$ref).toContain(
+        'InfoPutDTO'
+      );
+    });
+  });
 });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When a child class extends a parent class and overrides a property with a different `@ApiProperty({ type })`, the parent's type is preserved instead of the child's. This happens because `createPropertyDecorator` in `helpers.ts` uses `Reflect.getMetadata()`, which traverses the prototype chain. When the child decorator runs, it finds the parent's metadata and merges it, keeping the parent's type.

Issue Number: #1321


## What is the new behavior?

Changed `Reflect.getMetadata` to `Reflect.getOwnMetadata` (in `lib/decorators/helpers.ts`, line 62) so that only the current class's own metadata is retrieved. This ensures that when a child class overrides a property with `@ApiProperty()`, the child's type is used correctly without inheriting the parent's metadata.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

A regression test has been added in `test/services/schema-object-factory.spec.ts` that verifies child class property type overrides work correctly with class inheritance.