### PR TITLE
fix(schema): support enumName with oneOf and anyOf combinators

### DIFF
--- a/e2e/src/cats/classes/cat.class.ts
+++ b/e2e/src/cats/classes/cat.class.ts
@@ -99,6 +99,17 @@ export class Cat {
   })
   oneOfExample?: string[] | number[] | boolean[];
 
+  @ApiProperty({
+    enum: LettersEnum,
+    enumName: 'LettersEnum',
+    oneOf: [
+      { type: 'string' },
+      { type: 'number' }
+    ],
+    description: 'Enum named reference combined with oneOf combinators'
+  })
+  enumNamedWithOneOf?: LettersEnum | string | number;
+
   @ApiProperty({ type: [String], link: () => Cat })
   kittenIds?: string[];
 }

--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -468,9 +468,15 @@ export class SchemaObjectFactory {
       type: metadata.isArray ? 'array' : 'string'
     };
 
+    const existingCombinator = (['oneOf', 'anyOf'] as const).find(
+      (key) => key in metadata && Array.isArray(metadata[key])
+    );
+
     const refHost = metadata.isArray
       ? { items: { $ref } }
-      : { allOf: [{ $ref }] };
+      : existingCombinator
+        ? { [existingCombinator]: [...metadata[existingCombinator], { $ref }] }
+        : { allOf: [{ $ref }] };
 
     const paramObject = { ..._schemaObject, ...refHost };
     const pathsToOmit = ['enum', 'enumName', 'enumSchema', 'x-enumNames'];

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -178,6 +178,40 @@ describe('SchemaObjectFactory', () => {
       });
     });
 
+    it('should support enumName with oneOf', () => {
+      enum Status {
+        Active = 'active',
+        Inactive = 'inactive'
+      }
+
+      class DtoWithEnumOneOf {
+        @ApiProperty({
+          oneOf: [{ type: 'string' }],
+          enum: Status,
+          enumName: 'Status'
+        })
+        status: Status | string;
+      }
+
+      const schemas: Record<string, SchemasObject> = {};
+      schemaObjectFactory.exploreModelSchema(DtoWithEnumOneOf, schemas);
+
+      expect(schemas).toHaveProperty('Status');
+      expect(schemas.Status).toEqual({
+        type: 'string',
+        enum: ['active', 'inactive']
+      });
+      expect(schemas.DtoWithEnumOneOf.properties.status).toEqual({
+        oneOf: [
+          { type: 'string' },
+          { $ref: '#/components/schemas/Status' }
+        ]
+      });
+      expect(
+        schemas.DtoWithEnumOneOf.properties.status
+      ).not.toHaveProperty('allOf');
+    });
+
     it('should log a warning when detecting duplicate DTOs with different schemas', () => {
       const loggerWarnSpy = vi.spyOn(Logger, 'warn').mockImplementation(() => {});
       const schemas: Record<string, SchemasObject> = {};
@@ -831,6 +865,71 @@ describe('SchemaObjectFactory', () => {
       schemaObjectFactory.createEnumSchemaType('field', metadata, schemas);
 
       expect(schemas).toEqual({ MyEnum: { enum: [1, 2, 3], type: 'number' } });
+    });
+
+    it('should add $ref to existing oneOf when enumName is used with oneOf', () => {
+      const metadata = {
+        type: 'string',
+        enum: ['a', 'b', 'c'],
+        enumName: 'MyEnum',
+        isArray: false,
+        oneOf: [{ type: 'number' }]
+      } as any;
+      const schemas = {};
+
+      const result = schemaObjectFactory.createEnumSchemaType(
+        'field',
+        metadata,
+        schemas
+      );
+
+      expect(schemas).toEqual({
+        MyEnum: { enum: ['a', 'b', 'c'], type: 'string' }
+      });
+      expect(result).toEqual(
+        expect.objectContaining({
+          oneOf: [
+            { type: 'number' },
+            { $ref: '#/components/schemas/MyEnum' }
+          ]
+        })
+      );
+      expect(result).not.toHaveProperty('allOf');
+      expect(result).not.toHaveProperty('enum');
+      expect(result).not.toHaveProperty('enumName');
+      expect(result).not.toHaveProperty('type');
+    });
+
+    it('should add $ref to existing anyOf when enumName is used with anyOf', () => {
+      const metadata = {
+        type: 'string',
+        enum: ['x', 'y'],
+        enumName: 'MyEnum',
+        isArray: false,
+        anyOf: [{ type: 'number' }]
+      } as any;
+      const schemas = {};
+
+      const result = schemaObjectFactory.createEnumSchemaType(
+        'field',
+        metadata,
+        schemas
+      );
+
+      expect(schemas).toEqual({
+        MyEnum: { enum: ['x', 'y'], type: 'string' }
+      });
+      expect(result).toEqual(
+        expect.objectContaining({
+          anyOf: [
+            { type: 'number' },
+            { $ref: '#/components/schemas/MyEnum' }
+          ]
+        })
+      );
+      expect(result).not.toHaveProperty('allOf');
+      expect(result).not.toHaveProperty('enum');
+      expect(result).not.toHaveProperty('enumName');
     });
   });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When using `enumName` together with `oneOf` or `anyOf` in `@ApiProperty`, the `createEnumSchemaType` method always wraps the enum `$ref` in `allOf: [{ $ref }]`, ignoring any existing `oneOf`/`anyOf` combinator on the property metadata. This produces an invalid schema with conflicting combinators.

Issue Number: #1125


## What is the new behavior?

Before creating the `refHost`, the code now checks if metadata already has a `oneOf` or `anyOf` combinator. If so, the enum `$ref` is appended to that existing array instead of creating a conflicting `allOf` wrapper. This produces the correct schema output when `enumName` is combined with `oneOf` or `anyOf`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

Three new tests added:
- Integration test: `should support enumName with oneOf` via `exploreModelSchema`
- Unit test: `should add $ref to existing oneOf when enumName is used with oneOf`
- Unit test: `should add $ref to existing anyOf when enumName is used with anyOf`