### PR TITLE
fix(plugin): handle same-file type references in SWC readonly metadata generation

### DIFF
--- a/lib/plugin/utils/type-reference-to-identifier.util.ts
+++ b/lib/plugin/utils/type-reference-to-identifier.util.ts
@@ -1,7 +1,12 @@
+import { posix } from 'path';
 import * as ts from 'typescript';
 import { PluginOptions } from '../merge-options';
 import { pluginDebugLogger } from '../plugin-debug-logger';
-import { replaceImportPath } from './plugin-utils';
+import {
+  convertPath,
+  getOutputExtension,
+  replaceImportPath
+} from './plugin-utils';
 
 export function typeReferenceToIdentifier(
   typeReferenceDescriptor: {
@@ -41,6 +46,30 @@ export function typeReferenceToIdentifier(
       ref = wrapTypeInArray(ref, typeReferenceDescriptor.arrayDepth);
     }
     identifier = factory.createIdentifier(ref);
+  } else if (
+    options.readonly &&
+    !typeReference?.includes('import') &&
+    isSameFileUserType(type, hostFilename)
+  ) {
+    // Same-file type reference in readonly mode (SWC/metadata.ts generation).
+    // The type is defined in the same file as the property that references it.
+    // We must use the t["./path"].TypeName pattern instead of a bare identifier,
+    // because bare identifiers are not in scope in the generated metadata.ts.
+    const sameFileImportPath = buildSameFileImportPath(
+      hostFilename,
+      options
+    );
+    // Build a synthetic async import expression for the type imports map
+    const syntheticImportRef = `await import("${sameFileImportPath}")`;
+    if (!typeImports[sameFileImportPath]) {
+      typeImports[sameFileImportPath] = syntheticImportRef;
+    }
+
+    let ref = `t["${sameFileImportPath}"].${typeReferenceDescriptor.typeName}`;
+    if (typeReferenceDescriptor.isArray) {
+      ref = wrapTypeInArray(ref, typeReferenceDescriptor.arrayDepth);
+    }
+    identifier = factory.createIdentifier(ref);
   } else {
     let ref = typeReference;
     if (typeReferenceDescriptor.isArray) {
@@ -49,6 +78,39 @@ export function typeReferenceToIdentifier(
     identifier = factory.createIdentifier(ref);
   }
   return identifier;
+}
+
+/**
+ * Checks whether a type is a user-defined type declared in the same file
+ * as hostFilename (as opposed to a built-in type like String, Number, etc.).
+ */
+function isSameFileUserType(type: ts.Type, hostFilename: string): boolean {
+  if (!type.symbol || !type.symbol.declarations) {
+    return false;
+  }
+  const normalizedHost = convertPath(hostFilename);
+  return type.symbol.declarations.some((decl) => {
+    const declFile = convertPath(decl.getSourceFile().fileName);
+    return (
+      declFile === normalizedHost && !decl.getSourceFile().isDeclarationFile
+    );
+  });
+}
+
+function buildSameFileImportPath(
+  hostFilename: string,
+  options: PluginOptions
+): string {
+  const from = convertPath(options.pathToSource);
+  const to = convertPath(hostFilename).replace(/\.[jt]s$/, '');
+  let relativePath = posix.relative(from, to);
+  if (relativePath[0] !== '.') {
+    relativePath = './' + relativePath;
+  }
+  if (options.esmCompatible) {
+    relativePath += getOutputExtension(hostFilename);
+  }
+  return relativePath;
 }
 
 function wrapTypeInArray(typeRef: string, arrayDepth: number) {
@@ -67,12 +129,38 @@ function assertReferenceableType(
   if (!type.symbol) {
     return true;
   }
-  if (!(type.symbol as any).isReferenced) {
-    return true;
-  }
+  // Type comes from a different file (has import path) — always referenceable
   if (parsedTypeName.includes('import')) {
     return true;
   }
+  // Check if this is a same-file user-defined type that isn't exported.
+  // Built-in types (String, Number, Date, Object, etc.) are declared in .d.ts
+  // files and should always pass. Only reject types that are declared in the
+  // same host file but not exported.
+  if (!isSameFileUserType(type, hostFilename)) {
+    // Not a same-file type — it's either a built-in or from another file
+    return true;
+  }
+  // Same-file type: check whether it is exported.
+  const declarations =
+    type.symbol.declarations ??
+    (type.symbol.valueDeclaration
+      ? [type.symbol.valueDeclaration]
+      : []);
+  const isExported = declarations.some((decl) => {
+    if (!decl) return false;
+    return (
+      ts.canHaveModifiers(decl) &&
+      ts.getModifiers(decl)?.some(
+        (mod) => mod.kind === ts.SyntaxKind.ExportKeyword
+      )
+    );
+  });
+  if (isExported) {
+    // Exported same-file type — referenceable via t["./path"].TypeName
+    return true;
+  }
+  // Not exported — not referenceable in metadata.ts
   const errorMessage = `Type "${parsedTypeName}" is not referenceable ("${hostFilename}"). To fix this, make sure to export this type.`;
   if (options.debug) {
     pluginDebugLogger.debug(errorMessage);

--- a/test/plugin/fixtures/project/cats/dto/create-cat.dto.ts
+++ b/test/plugin/fixtures/project/cats/dto/create-cat.dto.ts
@@ -23,6 +23,10 @@ class NonExportedClass {
   prop: string;
 }
 
+export class SameFileClass {
+  value: string;
+}
+
 export enum CategoryState {
   OK = 'OK',
   DEPRECATED = 'DEPRECATED'
@@ -127,6 +131,9 @@ export class CreateCatDto {
   // Both props should be ignored
   nonExportedEnum: NonExportedEnum;
   nonExportedClass: NonExportedClass;
+
+  // Exported same-file class should use t["./path"].ClassName pattern
+  sameFileRef: SameFileClass;
 
   // Default value should be ignored
   logger = new ConsoleLogger();

--- a/test/plugin/fixtures/serialized-meta-esm.fixture.ts
+++ b/test/plugin/fixtures/serialized-meta-esm.fixture.ts
@@ -91,6 +91,7 @@ export default async () => {
         [
           import('./cats/dto/create-cat.dto.js'),
           {
+            SameFileClass: { value: { required: true, type: () => String } },
             CreateCatDto: {
               isIn: { required: true, type: () => String },
               pattern: {
@@ -170,6 +171,10 @@ export default async () => {
                   first: { required: true, type: () => String },
                   second: { required: true, type: () => Number }
                 })
+              },
+              sameFileRef: {
+                required: true,
+                type: () => t['./cats/dto/create-cat.dto.js'].SameFileClass
               },
               logger: { required: true, type: () => Object }
             }

--- a/test/plugin/fixtures/serialized-meta.fixture.ts
+++ b/test/plugin/fixtures/serialized-meta.fixture.ts
@@ -89,6 +89,7 @@ export default async () => {
         [
           import('./cats/dto/create-cat.dto'),
           {
+            SameFileClass: { value: { required: true, type: () => String } },
             CreateCatDto: {
               isIn: { required: true, type: () => String },
               pattern: {
@@ -168,6 +169,10 @@ export default async () => {
                   first: { required: true, type: () => String },
                   second: { required: true, type: () => Number }
                 })
+              },
+              sameFileRef: {
+                required: true,
+                type: () => t['./cats/dto/create-cat.dto'].SameFileClass
               },
               logger: { required: true, type: () => Object }
             }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When using the SWC plugin with `readonly` metadata generation, types defined in the same file as the DTO that references them produce bare identifiers (e.g. `SameFileClass`) in the generated `metadata.ts`. These identifiers are not in scope of the generated async function, causing a `ReferenceError` at runtime.

Issue Number: #2636


## What is the new behavior?

Same-file type references now use the `t["./relative-path"].ClassName` pattern (consistent with cross-file references), ensuring they resolve correctly at runtime. An `isSameFileUserType()` helper detects when a type is declared in the same source file, and `buildSameFileImportPath()` constructs the proper relative import path. The `assertReferenceableType()` function has also been updated to correctly distinguish between built-in types and unexported same-file types.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

**Files changed:**
- `lib/plugin/utils/type-reference-to-identifier.util.ts`: Added `isSameFileUserType()` and `buildSameFileImportPath()` helpers; extended the main function to emit `t["./path"].TypeName` for same-file types in readonly mode; improved `assertReferenceableType()` to check export status of same-file types.
- `test/plugin/fixtures/project/cats/dto/create-cat.dto.ts`: Added `SameFileClass` and a `sameFileRef` property to `CreateCatDto`.
- `test/plugin/fixtures/serialized-meta.fixture.ts`: Updated expected output with same-file reference pattern.
- `test/plugin/fixtures/serialized-meta-esm.fixture.ts`: Updated expected ESM output with same-file reference pattern.