### PR TITLE
fix(type-helpers): eagerly apply plugin metadata properties in mapped type helpers

### DIFF
--- a/lib/type-helpers/omit-type.helper.ts
+++ b/lib/type-helpers/omit-type.helper.ts
@@ -8,6 +8,7 @@ import { omit } from 'lodash';
 import { DECORATORS } from '../constants';
 import { ApiProperty } from '../decorators';
 import { MetadataLoader } from '../plugin/metadata-loader';
+import { METADATA_FACTORY_NAME } from '../plugin/plugin-constants';
 import { ModelPropertiesAccessor } from '../services/model-properties-accessor';
 import { clonePluginMetadataFactory } from './mapped-types.utils';
 
@@ -51,6 +52,16 @@ export function OmitType<T, K extends keyof T>(
       const decoratorFactory = ApiProperty(metadata);
       decoratorFactory(OmitTypeClass.prototype, propertyKey);
     });
+
+    if (OmitTypeClass[METADATA_FACTORY_NAME]) {
+      const pluginMetadata = OmitTypeClass[METADATA_FACTORY_NAME]();
+      Object.keys(pluginMetadata).forEach((key) => {
+        if (!fields.includes(key)) {
+          const decoratorFactory = ApiProperty(pluginMetadata[key]);
+          decoratorFactory(OmitTypeClass.prototype, key);
+        }
+      });
+    }
   }
   applyFields(fields);
 

--- a/lib/type-helpers/partial-type.helper.ts
+++ b/lib/type-helpers/partial-type.helper.ts
@@ -65,15 +65,6 @@ export function PartialType<T>(
         mapValues(metadata, (item) => ({ ...item, required: false }))
     );
 
-    if (PartialTypeClass[METADATA_FACTORY_NAME]) {
-      const pluginFields = Object.keys(
-        PartialTypeClass[METADATA_FACTORY_NAME]()
-      );
-      pluginFields.forEach((key) =>
-        applyPartialDecoratorFn(PartialTypeClass, key)
-      );
-    }
-
     fields.forEach((key) => {
       const metadata =
         Reflect.getMetadata(
@@ -89,6 +80,21 @@ export function PartialType<T>(
       decoratorFactory(PartialTypeClass.prototype, key);
       applyPartialDecoratorFn(PartialTypeClass, key);
     });
+
+    if (PartialTypeClass[METADATA_FACTORY_NAME]) {
+      const pluginMetadata = PartialTypeClass[METADATA_FACTORY_NAME]();
+      const pluginFields = Object.keys(pluginMetadata);
+      pluginFields.forEach((key) => {
+        if (!fields.includes(key)) {
+          const decoratorFactory = ApiProperty({
+            ...pluginMetadata[key],
+            required: false
+          });
+          decoratorFactory(PartialTypeClass.prototype, key);
+        }
+        applyPartialDecoratorFn(PartialTypeClass, key);
+      });
+    }
   }
   applyFields(fields);
 

--- a/lib/type-helpers/pick-type.helper.ts
+++ b/lib/type-helpers/pick-type.helper.ts
@@ -8,6 +8,7 @@ import { pick } from 'lodash';
 import { DECORATORS } from '../constants';
 import { ApiProperty } from '../decorators';
 import { MetadataLoader } from '../plugin/metadata-loader';
+import { METADATA_FACTORY_NAME } from '../plugin/plugin-constants';
 import { ModelPropertiesAccessor } from '../services/model-properties-accessor';
 import { clonePluginMetadataFactory } from './mapped-types.utils';
 
@@ -52,6 +53,16 @@ export function PickType<T, K extends keyof T>(
       const decoratorFactory = ApiProperty(metadata);
       decoratorFactory(PickTypeClass.prototype, propertyKey);
     });
+
+    if (PickTypeClass[METADATA_FACTORY_NAME]) {
+      const pluginMetadata = PickTypeClass[METADATA_FACTORY_NAME]();
+      Object.keys(pluginMetadata).forEach((key) => {
+        if (!fields.includes(key)) {
+          const decoratorFactory = ApiProperty(pluginMetadata[key]);
+          decoratorFactory(PickTypeClass.prototype, key);
+        }
+      });
+    }
   }
   applyFields(fields);
 

--- a/test/type-helpers/partial-type-inheritance.spec.ts
+++ b/test/type-helpers/partial-type-inheritance.spec.ts
@@ -1,0 +1,291 @@
+import { Type } from '@nestjs/common';
+import { DECORATORS } from '../../lib/constants';
+import { ApiProperty } from '../../lib/decorators';
+import { METADATA_FACTORY_NAME } from '../../lib/plugin/plugin-constants';
+import { MetadataLoader } from '../../lib/plugin/metadata-loader';
+import { ModelPropertiesAccessor } from '../../lib/services/model-properties-accessor';
+import { SchemaObjectFactory } from '../../lib/services/schema-object-factory';
+import { SwaggerTypesMapper } from '../../lib/services/swagger-types-mapper';
+import { SchemasObject } from '../../lib/interfaces/open-api-spec.interface';
+import { PartialType } from '../../lib/type-helpers';
+
+describe('PartialType with extended class DTOs', () => {
+  const modelPropertiesAccessor = new ModelPropertiesAccessor();
+
+  describe('when a class extends PartialType(BaseClass) and adds its own @ApiProperty properties', () => {
+    class ClassADto {
+      @ApiProperty()
+      propA: string;
+    }
+
+    class ClassBDto extends PartialType(ClassADto) {
+      @ApiProperty()
+      propB: string;
+    }
+
+    it('should include properties from both the parent and child class', () => {
+      const prototype = ClassBDto.prototype as any as Type<unknown>;
+      const properties = modelPropertiesAccessor.getModelProperties(prototype);
+      expect(properties).toContain('propA');
+      expect(properties).toContain('propB');
+    });
+
+    it('should mark parent properties as optional (required: false)', () => {
+      const prototype = ClassBDto.prototype as any as Type<unknown>;
+      const metadata = Reflect.getMetadata(
+        DECORATORS.API_MODEL_PROPERTIES,
+        prototype,
+        'propA'
+      );
+      expect(metadata).toBeDefined();
+      expect(metadata.required).toBe(false);
+    });
+  });
+
+  describe('when parent class uses only plugin metadata (no @ApiProperty decorators)', () => {
+    // This is the core issue from #3333: parent properties from plugin metadata
+    // must be discoverable by child classes extending PartialType(Parent)
+    class PluginOnlyParent {
+      propFromParent: string;
+
+      static [METADATA_FACTORY_NAME]() {
+        return {
+          propFromParent: { required: true, type: () => String }
+        };
+      }
+    }
+
+    class ChildOfPartialPlugin extends PartialType(PluginOnlyParent) {
+      @ApiProperty()
+      childProp: string;
+    }
+
+    it('should include plugin-based parent properties in the child prototype chain', () => {
+      const prototype =
+        ChildOfPartialPlugin.prototype as any as Type<unknown>;
+      const properties = modelPropertiesAccessor.getModelProperties(prototype);
+      // After fix: plugin properties are eagerly applied as ApiProperty decorators
+      // on PartialTypeClass.prototype, making them discoverable via prototype chain
+      expect(properties).toContain('propFromParent');
+      expect(properties).toContain('childProp');
+    });
+
+    it('should mark plugin parent properties as optional', () => {
+      const prototype =
+        ChildOfPartialPlugin.prototype as any as Type<unknown>;
+      const metadata = Reflect.getMetadata(
+        DECORATORS.API_MODEL_PROPERTIES,
+        prototype,
+        'propFromParent'
+      );
+      expect(metadata).toBeDefined();
+      expect(metadata.required).toBe(false);
+    });
+  });
+
+  describe('when both parent and child use only plugin metadata', () => {
+    class PluginParent {
+      parentProp: string;
+
+      static [METADATA_FACTORY_NAME]() {
+        return {
+          parentProp: { required: true, type: () => String }
+        };
+      }
+    }
+
+    class PluginChild extends PartialType(PluginParent) {
+      childProp: number;
+
+      static [METADATA_FACTORY_NAME]() {
+        return {
+          childProp: { required: true, type: () => Number }
+        };
+      }
+    }
+
+    it('should include properties from both parent and child after applyMetadataFactory', () => {
+      const prototype = PluginChild.prototype as any as Type<unknown>;
+      modelPropertiesAccessor.applyMetadataFactory(prototype);
+      const properties = modelPropertiesAccessor.getModelProperties(prototype);
+      expect(properties).toContain('parentProp');
+      expect(properties).toContain('childProp');
+    });
+
+    it('should mark parent properties as optional', () => {
+      const prototype = PluginChild.prototype as any as Type<unknown>;
+      modelPropertiesAccessor.applyMetadataFactory(prototype);
+      const metadata = Reflect.getMetadata(
+        DECORATORS.API_MODEL_PROPERTIES,
+        prototype,
+        'parentProp'
+      );
+      expect(metadata).toBeDefined();
+      expect(metadata.required).toBe(false);
+    });
+  });
+
+  describe('when metadata is loaded via MetadataLoader (SWC readonly mode)', () => {
+    class LazyParent {
+      parentProp: string;
+    }
+
+    class LazyChild extends PartialType(LazyParent) {
+      @ApiProperty({ type: String })
+      childProp: string;
+    }
+
+    it('should include parent properties after metadata is loaded', async () => {
+      const metadataLoader = new MetadataLoader();
+
+      const SERIALIZED_METADATA = {
+        '@nestjs/swagger': {
+          models: [
+            [
+              Promise.resolve({ LazyParent }),
+              {
+                LazyParent: {
+                  parentProp: { required: true, type: () => String }
+                }
+              }
+            ]
+          ]
+        }
+      };
+
+      await metadataLoader.load(SERIALIZED_METADATA);
+
+      const prototype = LazyChild.prototype as any as Type<unknown>;
+      modelPropertiesAccessor.applyMetadataFactory(prototype);
+      const properties = modelPropertiesAccessor.getModelProperties(prototype);
+
+      expect(properties).toContain('parentProp');
+      expect(properties).toContain('childProp');
+    });
+
+    it('should mark parent properties as optional after metadata is loaded', async () => {
+      const metadataLoader = new MetadataLoader();
+
+      const SERIALIZED_METADATA = {
+        '@nestjs/swagger': {
+          models: [
+            [
+              Promise.resolve({ LazyParent }),
+              {
+                LazyParent: {
+                  parentProp: { required: true, type: () => String }
+                }
+              }
+            ]
+          ]
+        }
+      };
+
+      await metadataLoader.load(SERIALIZED_METADATA);
+
+      const prototype = LazyChild.prototype as any as Type<unknown>;
+      modelPropertiesAccessor.applyMetadataFactory(prototype);
+      const metadata = Reflect.getMetadata(
+        DECORATORS.API_MODEL_PROPERTIES,
+        prototype,
+        'parentProp'
+      );
+      expect(metadata).toBeDefined();
+      expect(metadata.required).toBe(false);
+    });
+  });
+
+  describe('schema generation with SchemaObjectFactory', () => {
+    let schemaObjectFactory: SchemaObjectFactory;
+
+    beforeEach(() => {
+      const accessor = new ModelPropertiesAccessor();
+      const mapper = new SwaggerTypesMapper();
+      schemaObjectFactory = new SchemaObjectFactory(accessor, mapper);
+    });
+
+    it('should generate schema with all properties for class extending PartialType with plugin metadata', () => {
+      class PluginBase {
+        baseProp: string;
+
+        static [METADATA_FACTORY_NAME]() {
+          return {
+            baseProp: { required: true, type: () => String }
+          };
+        }
+      }
+
+      class PluginChild extends PartialType(PluginBase) {
+        childProp: string;
+
+        static [METADATA_FACTORY_NAME]() {
+          return {
+            childProp: { required: true, type: () => String }
+          };
+        }
+      }
+
+      const schemas: Record<string, SchemasObject> = {};
+      schemaObjectFactory.exploreModelSchema(PluginChild, schemas);
+
+      expect(schemas['PluginChild']).toBeDefined();
+      expect(schemas['PluginChild'].properties).toHaveProperty('baseProp');
+      expect(schemas['PluginChild'].properties).toHaveProperty('childProp');
+    });
+
+    it('should mark parent properties as not required in schema', () => {
+      class BaseDto {
+        @ApiProperty({ type: String, required: true })
+        baseProp: string;
+      }
+
+      class ChildDto extends PartialType(BaseDto) {
+        @ApiProperty({ type: String, required: true })
+        childProp: string;
+      }
+
+      const schemas: Record<string, SchemasObject> = {};
+      schemaObjectFactory.exploreModelSchema(ChildDto, schemas);
+
+      const required = schemas['ChildDto'].required || [];
+      expect(required).toContain('childProp');
+      expect(required).not.toContain('baseProp');
+    });
+
+    it('should handle deep inheritance chains', () => {
+      class GrandParent {
+        grandProp: string;
+        static [METADATA_FACTORY_NAME]() {
+          return { grandProp: { required: true, type: () => String } };
+        }
+      }
+
+      class Parent extends GrandParent {
+        parentProp: string;
+        static [METADATA_FACTORY_NAME]() {
+          return { parentProp: { required: true, type: () => String } };
+        }
+      }
+
+      class Child extends PartialType(Parent) {
+        childProp: string;
+        static [METADATA_FACTORY_NAME]() {
+          return { childProp: { required: true, type: () => String } };
+        }
+      }
+
+      const schemas: Record<string, SchemasObject> = {};
+      schemaObjectFactory.exploreModelSchema(Child, schemas);
+
+      expect(schemas['Child']).toBeDefined();
+      expect(schemas['Child'].properties).toHaveProperty('grandProp');
+      expect(schemas['Child'].properties).toHaveProperty('parentProp');
+      expect(schemas['Child'].properties).toHaveProperty('childProp');
+
+      const required = schemas['Child'].required || [];
+      expect(required).toContain('childProp');
+      expect(required).not.toContain('grandProp');
+      expect(required).not.toContain('parentProp');
+    });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When `PartialType()`, `OmitType()`, or `PickType()` is applied to a class that relies on plugin metadata (`_OPENAPI_METADATA_FACTORY`) rather than explicit `@ApiProperty()` decorators, properties from the plugin metadata are not eagerly applied as decorators on the helper class prototype. This means child classes extending the mapped type cannot discover these properties, resulting in missing schema properties in the generated OpenAPI spec.

Issue Number: #3333


## What is the new behavior?

Plugin-only properties are now eagerly applied as `ApiProperty` decorators on the helper class prototype in all three mapped type helpers (`PartialType`, `OmitType`, `PickType`). This ensures child classes that extend a mapped type correctly inherit all properties, whether they originate from explicit decorators or the CLI plugin metadata factory.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

11 new tests added in `test/type-helpers/partial-type-inheritance.spec.ts` covering decorator-based, plugin-based, mixed, deep inheritance, and lazy metadata scenarios.