### PR TITLE
fix(swagger-ui): replace hardcoded sentinel with per-call UUID in buildJSInitOptions

### DIFF
--- a/lib/swagger-ui/helpers.ts
+++ b/lib/swagger-ui/helpers.ts
@@ -1,26 +1,33 @@
+import { randomUUID } from 'crypto';
 import { SwaggerUIInitOptions } from '../interfaces/swagger-ui-init-options.interface';
 
 /**
  * Transforms options JS object into a string that can be inserted as 'variable' into JS file
  */
 export function buildJSInitOptions(initOptions: SwaggerUIInitOptions) {
-  const functionPlaceholder = '____FUNCTION_PLACEHOLDER____';
-  const fns = [];
+  const fns: Function[] = [];
+  const placeholders: string[] = [];
+
   let json = JSON.stringify(
     initOptions,
     (key, value) => {
       if (typeof value === 'function') {
+        const placeholder = randomUUID();
         fns.push(value);
-        return functionPlaceholder;
+        placeholders.push(placeholder);
+        return placeholder;
       }
       return value;
     },
     2
   );
 
-  json = json.replace(new RegExp('"' + functionPlaceholder + '"', 'g'), () =>
-    fns.shift()
-  );
+  // Replace each UUID placeholder with its function body using exact string
+  // matching — a global regex with a fixed pattern would be guessable by an
+  // attacker who controls document field values.
+  placeholders.forEach((placeholder, i) => {
+    json = json.replace(`"${placeholder}"`, fns[i].toString());
+  });
 
   return `let options = ${json};`;
 }


### PR DESCRIPTION
## Summary

- Replace the hardcoded `____FUNCTION_PLACEHOLDER____` sentinel in `buildJSInitOptions` with a per-call `randomUUID()` per function
- Switch from a global regex replace to exact per-placeholder string replacement

## Security motivation

The previous implementation used a fixed, publicly-known sentinel string. Any swagger document field containing that exact string — reachable via the `patchDocumentOnRequest` hook — would consume a real function from the serialization queue, displacing callbacks such as `requestInterceptor` to the wrong key and setting the intended key to `undefined`.

This silently disables auth header injection for all Swagger UI "Try it out" requests with no browser or server-side error, because the resulting JavaScript is syntactically valid.

**Attack path:**
1. App configures `patchDocumentOnRequest` (per-request doc filtering)
2. App uses `requestInterceptor` in `swaggerOptions` (standard auth pattern)
3. Attacker injects `____FUNCTION_PLACEHOLDER____` into any document string field via a controlled request
4. `swagger-ui-init.js` is served with the interceptor displaced — Swagger UI initialises without auth header injection

## Fix

Each function value now receives a `randomUUID()` as its placeholder during `JSON.stringify`. Functions are then restored via exact string replacement (one replace call per function) rather than a single global regex. A UUID generated at runtime cannot be predicted or pre-injected by an attacker.

```ts
// Before
const functionPlaceholder = '____FUNCTION_PLACEHOLDER____';
// ...global regex replace that matches any occurrence

// After
const placeholder = randomUUID(); // unique per function per call
// ...exact string replace for this specific placeholder only
```

## Test plan

- [ ] Existing unit tests pass: `npm test`
- [ ] Normal function options (e.g. `requestInterceptor`) still serialize correctly into `swagger-ui-init.js`
- [ ] Document fields containing the old sentinel string are no longer treated as function placeholders