### PR TITLE
fix(plugin): remap import paths within rootDir to outDir

### DIFF
--- a/lib/plugin/utils/plugin-utils.ts
+++ b/lib/plugin/utils/plugin-utils.ts
@@ -197,7 +197,15 @@ export function replaceImportPath(
       ? safeDecodeURIComponent(convertPath(options.pathToSource))
       : getOutputDir(fileName, options);
 
-    let relativePath = posix.relative(from, decodedImportPath);
+    const targetPath =
+      options.outDir && options.rootDir &&
+      decodedImportPath.startsWith(convertPath(options.rootDir))
+        ? posix.join(
+            convertPath(options.outDir),
+            posix.relative(convertPath(options.rootDir), decodedImportPath)
+          )
+        : decodedImportPath;
+    let relativePath = posix.relative(from, targetPath);
     relativePath = relativePath[0] !== '.' ? './' + relativePath : relativePath;
 
     const normalizedPath = normalizePackagePath(relativePath);

--- a/test/plugin/plugin-utils.spec.ts
+++ b/test/plugin/plugin-utils.spec.ts
@@ -150,6 +150,31 @@ describe('plugin-utils', () => {
       expect(result.typeReference).toContain('../entities/test.entity');
     });
 
+    it('should remap import paths within rootDir to outDir (rootDir = src/)', () => {
+      // Standard layout with rootDir pointing to src/:
+      //   rootDir : /project/src
+      //   outDir  : /project/dist
+      //   source  : /project/src/dto/nested/test.dto.ts
+      //   output  : /project/dist/dto/nested/test.dto.js
+      //   import  : /project/src/entities/test.entity     (within rootDir)
+      //   target  : /project/dist/entities/test.entity     (remapped to outDir)
+      //
+      // Without fix: require("../../../src/entities/test.entity")  (broken)
+      // With fix:    require("../../entities/test.entity")          (correct)
+      const typeReference =
+        'import("/project/src/entities/test.entity").TestEnum';
+      const fileName = '/project/src/dto/nested/test.dto.ts';
+      const options = {
+        rootDir: '/project/src',
+        outDir: '/project/dist'
+      };
+
+      const result = replaceImportPath(typeReference, fileName, options);
+
+      expect(result.typeReference).toContain('../../entities/test.entity');
+      expect(result.typeReference).not.toContain('/src/');
+    });
+
     it('should fall back to source-based path when outDir/rootDir are absent', () => {
       // Baseline behaviour must be preserved when options do not include outDir/rootDir.
       const typeReference =


### PR DESCRIPTION
## Summary

When `rootDir` and `outDir` are set in tsconfig (required by TypeScript 6), the CLI plugin's `replaceImportPath` generates broken `require()` calls that navigate from `dist/` back into `src/`.

**Example:** A DTO at `src/common/dto/order.dto.ts` importing an enum from `src/types/currency.ts` produces:
```js
// dist/common/dto/order.dto.js
require("../../../src/types/currency")  // broken — src/ doesn't exist at runtime
```
instead of:
```js
require("../../types/currency")  // correct — resolves within dist/
```

This breaks in Docker containers and production deployments where only `dist/` is available.

## Root cause

`replaceImportPath` correctly rebases the *current* file's directory onto the output tree via `getOutputDir`, but uses the *source* path of the imported module as-is. `posix.relative(outputDir, sourceImportPath)` then produces a path that escapes `dist/` and navigates into `src/`.

## Fix

Apply the same `rootDir` → `outDir` transformation to the import target path when it falls within `rootDir`, so both sides of `posix.relative()` are in the output coordinate space. Paths outside `rootDir` (e.g. monorepo cross-package imports) are left unchanged.

## Context

- TypeScript 6 makes `rootDir` mandatory (TS5011 error) when the common source directory differs from the tsconfig location
- This regression was introduced alongside the `getOutputDir` fix in #2707 — the current-file side was corrected but the import-target side was missed
- Related: #3154, #1386

## Test plan

- [x] Added test case for `rootDir = src/` with import within rootDir
- [x] Existing monorepo test (import outside rootDir) still passes
- [x] All 247 tests pass
- [x] Verified fix against real NestJS project with `@nestjs/swagger` plugin + TypeScript 6

🤖 Generated with [Claude Code](https://claude.ai/claude-code)