### PR TITLE
feat(explorer): infer uuid format when ParseUUIDPipe is applied to a param

### DIFF
--- a/lib/services/parameter-metadata-accessor.ts
+++ b/lib/services/parameter-metadata-accessor.ts
@@ -15,6 +15,7 @@ import { reverseObjectKeys } from '../utils/reverse-object-keys.util';
 interface ParamMetadata {
   index: number;
   data?: string | number | object;
+  pipes?: unknown[];
 }
 type ParamsMetadata = Record<string, ParamMetadata>;
 
@@ -29,6 +30,7 @@ export interface ParamWithTypeMetadata {
   enumName?: string;
   enumSchema?: EnumSchemaAttributes;
   selfRequired?: boolean;
+  format?: string;
 }
 export type ParamsWithType = Record<string, ParamWithTypeMetadata>;
 
@@ -57,12 +59,17 @@ export class ParameterMetadataAccessor {
 
     const parametersWithType: ParamsWithType = mapValues(
       reverseObjectKeys(routeArgsMetadata),
-      (param: ParamMetadata) =>
-        ({
-          type: types[param.index],
+      (param: ParamMetadata) => {
+        const inferredFromPipes = this.inferSchemaFromPipes(param.pipes);
+        return {
+          type: inferredFromPipes?.type ?? types[param.index],
           name: param.data,
-          required: true
-        }) as unknown as ParamWithTypeMetadata
+          required: true,
+          ...(inferredFromPipes?.format
+            ? { format: inferredFromPipes.format }
+            : {})
+        } as unknown as ParamWithTypeMetadata;
+      }
     ) as unknown as ParamsWithType;
     const excludePredicate = (val: ParamWithTypeMetadata) =>
       val.in === PARAM_TOKEN_PLACEHOLDER || (val.name && val.in === 'body');
@@ -91,5 +98,46 @@ export class ParameterMetadataAccessor {
       default:
         return PARAM_TOKEN_PLACEHOLDER;
     }
+  }
+
+  /**
+   * Attempts to infer the parameter type/format from the pipes applied
+   * to the route argument decorator (e.g. `@Param('id', ParseUUIDPipe)`).
+   *
+   * Pipes can appear as either class references or instances, so both
+   * shapes are checked. When no known pipe is detected, `undefined` is
+   * returned so that the caller can fall back to the TypeScript-reflected
+   * type.
+   */
+  private inferSchemaFromPipes(
+    pipes: unknown[] | undefined
+  ): { type?: Type<unknown>; format?: string } | undefined {
+    if (!pipes || pipes.length === 0) {
+      return undefined;
+    }
+    for (const pipe of pipes) {
+      const pipeName = this.getPipeName(pipe);
+      if (!pipeName) {
+        continue;
+      }
+      if (pipeName === 'ParseUUIDPipe') {
+        return { type: String as unknown as Type<unknown>, format: 'uuid' };
+      }
+    }
+    return undefined;
+  }
+
+  private getPipeName(pipe: unknown): string | undefined {
+    if (!pipe) {
+      return undefined;
+    }
+    if (typeof pipe === 'function') {
+      return (pipe as Function).name;
+    }
+    if (typeof pipe === 'object') {
+      const ctor = (pipe as { constructor?: { name?: string } }).constructor;
+      return ctor?.name;
+    }
+    return undefined;
   }
 }

--- a/test/explorer/swagger-explorer.spec.ts
+++ b/test/explorer/swagger-explorer.spec.ts
@@ -4,6 +4,7 @@ import {
   Controller,
   Get,
   Param,
+  ParseUUIDPipe,
   Post,
   Query,
   Version,
@@ -2604,6 +2605,76 @@ describe('SwaggerExplorer', () => {
     });
   });
 
+  describe('when ParseUUIDPipe is applied to a param', () => {
+    class Foo {}
+
+    @Controller('')
+    class FooController {
+      @Get('foos/:id')
+      findOne(@Param('id', ParseUUIDPipe) id: string): Promise<Foo> {
+        return Promise.resolve({});
+      }
+
+      @Get('bars/:id')
+      findBar(
+        @Param('id', new ParseUUIDPipe({ version: '4' })) id: string
+      ): Promise<Foo> {
+        return Promise.resolve({});
+      }
+
+      @Get('bazs/:id')
+      findBaz(@Query('token', ParseUUIDPipe) token: string): Promise<Foo> {
+        return Promise.resolve({});
+      }
+    }
+
+    it('should infer the parameter schema as { type: "string", format: "uuid" }', () => {
+      const explorer = new SwaggerExplorer(schemaObjectFactory);
+      const routes = explorer.exploreController(
+        {
+          instance: new FooController(),
+          metatype: FooController
+        } as InstanceWrapper<FooController>,
+        new ApplicationConfig(),
+        { modulePath: 'path' }
+      );
+
+      expect(routes[0].root.parameters).toEqual([
+        {
+          in: 'path',
+          name: 'id',
+          required: true,
+          schema: {
+            type: 'string',
+            format: 'uuid'
+          }
+        }
+      ]);
+      expect(routes[1].root.parameters).toEqual([
+        {
+          in: 'path',
+          name: 'id',
+          required: true,
+          schema: {
+            type: 'string',
+            format: 'uuid'
+          }
+        }
+      ]);
+      expect(routes[2].root.parameters).toEqual([
+        {
+          in: 'query',
+          name: 'token',
+          required: true,
+          schema: {
+            type: 'string',
+            format: 'uuid'
+          }
+        }
+      ]);
+    });
+  });
+
   describe('when queries are defined', () => {
     class Foo {}
 
@@ -2910,12 +2981,8 @@ describe('SwaggerExplorer', () => {
           }
         );
 
-        expect(routes[0].root.operationId).toEqual(
-          `NoVersionController.foo`
-        );
-        expect(routes[1].root.operationId).toEqual(
-          `NoVersionController.bar.3`
-        );
+        expect(routes[0].root.operationId).toEqual(`NoVersionController.foo`);
+        expect(routes[1].root.operationId).toEqual(`NoVersionController.bar.3`);
       });
     });
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other

## Current behavior

When a controller handler uses `@Param('id', ParseUUIDPipe)` (or `@Query`, etc.), the generated OpenAPI schema only describes the parameter as `{ type: 'string' }`. In order to surface the UUID constraint in the docs, developers have to repeat the information with a matching `@ApiParam({ name: 'id', format: 'uuid', type: 'string' })` decorator:

```ts
@Delete('tenants/:tenantId/folders/:id')
@ApiParam({ name: 'tenantId', format: 'uuid', type: 'string' })
@ApiParam({ name: 'id', format: 'uuid', type: 'string' })
async delete(
  @Param('tenantId', ParseUUIDPipe) tenantId: string,
  @Param('id', ParseUUIDPipe) id: string,
) {}
```

## New behavior

The parameter metadata accessor now inspects the pipes attached to route argument decorators (which are already stored in `ROUTE_ARGS_METADATA` by Nest). When `ParseUUIDPipe` is detected - either as a class reference (`ParseUUIDPipe`) or as an instance (`new ParseUUIDPipe({ version: '4' })`) - the parameter is automatically emitted as `{ type: 'string', format: 'uuid' }` in the OpenAPI schema, so the redundant `@ApiParam` decorators are no longer required:

```ts
@Delete('tenants/:tenantId/folders/:id')
async delete(
  @Param('tenantId', ParseUUIDPipe) tenantId: string,
  @Param('id', ParseUUIDPipe) id: string,
) {}
```

An explicit `@ApiParam`/`@ApiQuery` decorator continues to take precedence, so existing documents are unaffected.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Fixes #1818