### PR TITLE
feat(schema-object-factory): include class name chain in circular dependency errors

### DIFF
--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -221,12 +221,29 @@ export class SchemaObjectFactory {
     const modelProperties =
       this.modelPropertiesAccessor.getModelProperties(prototype);
     const propertiesWithType = modelProperties.map((key) => {
-      const property = this.mergePropertyWithMetadata(
-        key,
-        prototype,
-        schemas,
-        pendingSchemasRefs
-      );
+      let property: ReturnType<typeof this.mergePropertyWithMetadata>;
+      try {
+        property = this.mergePropertyWithMetadata(
+          key,
+          prototype,
+          schemas,
+          pendingSchemasRefs
+        );
+      } catch (err) {
+        // Prepend the current class name to the error message so that, as the
+        // recursion unwinds, users see the full chain of classes involved in
+        // the failure (e.g. "[RootDto] [ParentDto] [ChildDto] A circular
+        // dependency has been detected ..."). This makes it much easier to
+        // locate the offending class in large codebases.
+        if (err instanceof Error) {
+          const className = type?.name || 'UnknownType';
+          const prefix = `[${className}] `;
+          if (!err.message.startsWith(prefix)) {
+            err.message = `${prefix}${err.message}`;
+          }
+        }
+        throw err;
+      }
 
       const schemaCombinators = ['oneOf', 'anyOf', 'allOf'];
       const declaredSchemaCombinator = schemaCombinators.find(
@@ -497,7 +514,7 @@ export class SchemaObjectFactory {
   ): SchemaObjectMetadata {
     if (isUndefined(trueMetadataType)) {
       throw new Error(
-        `A circular dependency has been detected (property key: "${key}"). Please, make sure that each side of a bidirectional relationships are using lazy resolvers ("type: () => ClassType").`
+        `A circular dependency has been detected (property key: "${key}"). To resolve this, use a lazy resolver for the property type ("type: () => ClassType") on each side of the relationship, or break the cycle by introducing a reference via @ApiExtraModels.`
       );
     }
     let { schemaName: schemaObjectName } = this.getSchemaMetadata(

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -1171,6 +1171,50 @@ describe('SchemaObjectFactory', () => {
     });
   });
 
+  describe('circular dependency error message (issue #3655)', () => {
+    it('should include the class name chain when a circular dependency is detected', () => {
+      // Simulate a circular dependency by providing a lazy type resolver that
+      // returns `undefined` — this mirrors the situation where a bidirectional
+      // relationship has not been set up with lazy resolvers on both sides.
+      class InnerDto {
+        child: any;
+      }
+      Reflect.defineMetadata(
+        DECORATORS.API_MODEL_PROPERTIES,
+        { type: () => undefined, required: true },
+        InnerDto.prototype,
+        'child'
+      );
+      Reflect.defineMetadata(
+        DECORATORS.API_MODEL_PROPERTIES_ARRAY,
+        [':child'],
+        InnerDto.prototype
+      );
+
+      class OuterDto {
+        inner: InnerDto;
+      }
+      Reflect.defineMetadata(
+        DECORATORS.API_MODEL_PROPERTIES,
+        { type: () => InnerDto, required: true },
+        OuterDto.prototype,
+        'inner'
+      );
+      Reflect.defineMetadata(
+        DECORATORS.API_MODEL_PROPERTIES_ARRAY,
+        [':inner'],
+        OuterDto.prototype
+      );
+
+      const schemas: Record<string, any> = {};
+      expect(() =>
+        schemaObjectFactory.exploreModelSchema(OuterDto as any, schemas)
+      ).toThrow(
+        /\[OuterDto\] \[InnerDto\] A circular dependency has been detected/
+      );
+    });
+  });
+
   describe('inherited property type override', () => {
     it('should use the child class type when a property is redeclared in a subclass', () => {
       class InfoPostDTO {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature / DX improvement in `SchemaObjectFactory`.

## What is the current behavior?

When a circular dependency is detected during Swagger schema generation, the error message only identifies the property key involved:

```
Error: A circular dependency has been detected (property key: "someKey"). Please, make sure that each side of a bidirectional relationships are using lazy resolvers ("type: () => ClassType").
```

In a large codebase (e.g. a monorepo with hundreds of DTOs), knowing only the property name is often not enough to locate the offending class — developers end up commenting code out or running a binary search to identify the cycle.

Closes #3655

## What is the new behavior?

`extractPropertiesFromType` now wraps the per-property extraction in a `try/catch` that prepends the currently-processed class name to the error message and re-throws. As the recursion unwinds, the error accumulates the full chain of classes that led to the failure:

```
Error: [RootResponseDto] [ParentEntity] [ChildEntity] A circular dependency has been detected (property key: "someProperty"). To resolve this, use a lazy resolver for the property type ("type: () => ClassType") on each side of the relationship, or break the cycle by introducing a reference via @ApiExtraModels.
```

The base error hint was also extended to mention `@ApiExtraModels` alongside lazy resolvers, since either approach can break a cycle.

This is a non-breaking change: existing error handling that already catches this error will continue to work, and the only user-visible difference is a more informative message.

## Additional context

- The implementation follows the approach suggested in the issue by the original reporter.
- A regression test was added in `test/services/schema-object-factory.spec.ts` that simulates a circular dependency across two DTOs and asserts that both class names appear in the thrown error message.
- The guard `if (!err.message.startsWith(prefix))` avoids double-prefixing when the same class happens to appear twice consecutively in the chain (defensive — unlikely in practice).