### PR TITLE
fix(package): add exports field for esm resolution support

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,21 @@
   "repository": "https://github.com/nestjs/swagger",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./plugin": {
+      "types": "./dist/plugin/index.d.ts",
+      "import": "./dist/plugin/index.js",
+      "require": "./dist/plugin/index.js",
+      "default": "./dist/plugin/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "format": "prettier \"lib/**/*.ts\" --write",


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

When a consumer project sets `"type": "module"` in its `package.json` and imports from `@nestjs/swagger`, Node.js ESM resolution fails with:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package '@nestjs/swagger' imported from /path/to/dist/main.js
Did you mean to import "@nestjs/swagger/dist/index.js"?
```

The package currently ships without a top-level `"exports"` field, so Node's ESM resolver cannot locate the entry. The reproduction is the one in the issue: a fresh Nest project with `"type": "module"` plus `import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'`. The failure reproduces on Node 22 and Node 24 regardless of `moduleResolution` (`NodeNext`, `Node16`, `Bundler`, `Node`).

Fixes #3591

## What is the new behavior?

Adds an `"exports"` map to `package.json` that exposes:

- `.` - the library entry (`dist/index.js` + `dist/index.d.ts`)
- `./plugin` - the CLI compiler plugin subpath used via `@nestjs/swagger/plugin` in `nest-cli.json`
- `./package.json` - explicit metadata access for tooling that reads it

Each subpath declares `types`, `import`, `require`, and `default` conditions. The compiled output is still CommonJS, so both `import` and `require` conditions point at the same `dist/*.js` files - there is no dual-package hazard and no source or build changes are required. Existing CJS consumers continue to resolve the package exactly as before because the `main`/`types` fields are preserved alongside `exports`.

Verified locally by `npm pack`-ing the patched package and installing it into two throwaway projects:

- A project with `"type": "module"` - both `import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger'` and `import('@nestjs/swagger/plugin')` resolve cleanly under Node 22.
- A CommonJS project - `require('@nestjs/swagger')` and `require('@nestjs/swagger/plugin')` continue to work unchanged.