### PR TITLE
fix(plugin): keep auto-inferred default response when only error Api*Response decorators are present

### DIFF
--- a/lib/plugin/visitors/controller-class.visitor.ts
+++ b/lib/plugin/visitors/controller-class.visitor.ts
@@ -1,3 +1,4 @@
+import { HttpStatus } from '@nestjs/common';
 import { compact, head } from 'lodash';
 import { posix } from 'path';
 import * as ts from 'typescript';
@@ -170,11 +171,15 @@ export class ControllerClassVisitor extends AbstractFileVisitor {
     const hasExplicitApiResponseDecorator = decorators.some((item) => {
       try {
         const decoratorName = getDecoratorName(item);
-        return (
-          decoratorName === ApiResponse.name ||
-          (decoratorName.startsWith('Api') &&
-            decoratorName.endsWith('Response'))
-        );
+        if (decoratorName === ApiResponse.name) return true;
+        const statusNameMatch = decoratorName.match(/^Api(.+)Response$/);
+        if (!statusNameMatch) return false;
+        const statusKey = statusNameMatch[1]
+          .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+          .toUpperCase();
+        const status = Number(HttpStatus[statusKey as keyof typeof HttpStatus]);
+        // Error factories (4xx/5xx) must not suppress the auto-inferred 2xx.
+        return isNaN(status) || status < 400;
       } catch {
         return false;
       }

--- a/lib/plugin/visitors/controller-class.visitor.ts
+++ b/lib/plugin/visitors/controller-class.visitor.ts
@@ -26,6 +26,30 @@ import { AbstractFileVisitor } from './abstract.visitor';
 
 type ClassMetadata = Record<string, ts.ObjectLiteralExpression>;
 
+function isSuccessOrRedirectApiResponseArg(decorator: ts.Decorator): boolean {
+  const [firstArg] = getDecoratorArguments(decorator);
+  if (!firstArg || !ts.isObjectLiteralExpression(firstArg)) return true;
+  const statusProp = firstArg.properties.find(
+    (p): p is ts.PropertyAssignment =>
+      ts.isPropertyAssignment(p) &&
+      ts.isIdentifier(p.name) &&
+      p.name.text === 'status'
+  );
+  if (!statusProp) return true;
+  const init = statusProp.initializer;
+  if (ts.isNumericLiteral(init)) return Number(init.text) < 400;
+  if (ts.isStringLiteral(init)) {
+    return (
+      init.text === '1XX' ||
+      init.text === '2XX' ||
+      init.text === '3XX' ||
+      init.text === 'default'
+    );
+  }
+  // Non-literal (e.g. HttpStatus.OK) — can't evaluate at compile time; preserve pre-PR behavior.
+  return true;
+}
+
 export class ControllerClassVisitor extends AbstractFileVisitor {
   private readonly _collectedMetadata: Record<
     string,
@@ -171,14 +195,16 @@ export class ControllerClassVisitor extends AbstractFileVisitor {
     const hasExplicitApiResponseDecorator = decorators.some((item) => {
       try {
         const decoratorName = getDecoratorName(item);
-        if (decoratorName === ApiResponse.name) return true;
+        // Error factories (4xx/5xx) must not suppress the auto-inferred 2xx.
+        if (decoratorName === ApiResponse.name) {
+          return isSuccessOrRedirectApiResponseArg(item);
+        }
         const statusNameMatch = decoratorName.match(/^Api(.+)Response$/);
         if (!statusNameMatch) return false;
         const statusKey = statusNameMatch[1]
           .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
           .toUpperCase();
         const status = Number(HttpStatus[statusKey as keyof typeof HttpStatus]);
-        // Error factories (4xx/5xx) must not suppress the auto-inferred 2xx.
         return isNaN(status) || status < 400;
       } catch {
         return false;

--- a/lib/plugin/visitors/controller-class.visitor.ts
+++ b/lib/plugin/visitors/controller-class.visitor.ts
@@ -26,30 +26,6 @@ import { AbstractFileVisitor } from './abstract.visitor';
 
 type ClassMetadata = Record<string, ts.ObjectLiteralExpression>;
 
-function isSuccessOrRedirectApiResponseArg(decorator: ts.Decorator): boolean {
-  const [firstArg] = getDecoratorArguments(decorator);
-  if (!firstArg || !ts.isObjectLiteralExpression(firstArg)) return true;
-  const statusProp = firstArg.properties.find(
-    (p): p is ts.PropertyAssignment =>
-      ts.isPropertyAssignment(p) &&
-      ts.isIdentifier(p.name) &&
-      p.name.text === 'status'
-  );
-  if (!statusProp) return true;
-  const init = statusProp.initializer;
-  if (ts.isNumericLiteral(init)) return Number(init.text) < 400;
-  if (ts.isStringLiteral(init)) {
-    return (
-      init.text === '1XX' ||
-      init.text === '2XX' ||
-      init.text === '3XX' ||
-      init.text === 'default'
-    );
-  }
-  // Non-literal (e.g. HttpStatus.OK) — can't evaluate at compile time; preserve pre-PR behavior.
-  return true;
-}
-
 export class ControllerClassVisitor extends AbstractFileVisitor {
   private readonly _collectedMetadata: Record<
     string,
@@ -197,7 +173,7 @@ export class ControllerClassVisitor extends AbstractFileVisitor {
         const decoratorName = getDecoratorName(item);
         // Error factories (4xx/5xx) must not suppress the auto-inferred 2xx.
         if (decoratorName === ApiResponse.name) {
-          return isSuccessOrRedirectApiResponseArg(item);
+          return this.isSuccessOrRedirectApiResponseArg(item);
         }
         const statusNameMatch = decoratorName.match(/^Api(.+)Response$/);
         if (!statusNameMatch) return false;
@@ -712,5 +688,29 @@ export class ControllerClassVisitor extends AbstractFileVisitor {
     );
     relativePath = relativePath[0] !== '.' ? './' + relativePath : relativePath;
     return relativePath;
+  }
+
+  private isSuccessOrRedirectApiResponseArg(decorator: ts.Decorator): boolean {
+    const [firstArg] = getDecoratorArguments(decorator);
+    if (!firstArg || !ts.isObjectLiteralExpression(firstArg)) return true;
+    const statusProp = firstArg.properties.find(
+      (p): p is ts.PropertyAssignment =>
+        ts.isPropertyAssignment(p) &&
+        ts.isIdentifier(p.name) &&
+        p.name.text === 'status'
+    );
+    if (!statusProp) return true;
+    const init = statusProp.initializer;
+    if (ts.isNumericLiteral(init)) return Number(init.text) < 400;
+    if (ts.isStringLiteral(init)) {
+      return (
+        init.text === '1XX' ||
+        init.text === '2XX' ||
+        init.text === '3XX' ||
+        init.text === 'default'
+      );
+    }
+    // Non-literal (e.g. HttpStatus.OK) — can't evaluate at compile time; preserve pre-PR behavior.
+    return true;
   }
 }

--- a/test/plugin/controller-class-visitor.spec.ts
+++ b/test/plugin/controller-class-visitor.spec.ts
@@ -9,6 +9,10 @@ import {
   appControllerApiResponseTextTranspiled
 } from './fixtures/app.controller-api-response';
 import {
+  appControllerApiResponseErrorText,
+  appControllerApiResponseErrorTextTranspiled
+} from './fixtures/app.controller-api-response-error';
+import {
   appControllerWithTabsText,
   appControllerWithTabsTextTranspiled
 } from './fixtures/app.controller-tabs';
@@ -112,6 +116,29 @@ describe('Controller methods', () => {
       }
     });
     expect(result.outputText).toEqual(appControllerOptionalQueryTextTranspiled);
+  });
+
+  it('should still auto-infer the default 2xx response when only error @Api*Response decorators are present', () => {
+    const options: ts.CompilerOptions = {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2021,
+      newLine: ts.NewLineKind.LineFeed,
+      noEmitHelpers: true,
+      experimentalDecorators: true
+    };
+    const filename = 'app.controller.ts';
+    const fakeProgram = ts.createProgram([filename], options);
+
+    const result = ts.transpileModule(appControllerApiResponseErrorText, {
+      compilerOptions: options,
+      fileName: filename,
+      transformers: {
+        before: [before({ introspectComments: true }, fakeProgram)]
+      }
+    });
+    expect(result.outputText).toEqual(
+      appControllerApiResponseErrorTextTranspiled
+    );
   });
 
   it('should add response based on the return value (without modifiers)', () => {

--- a/test/plugin/controller-class-visitor.spec.ts
+++ b/test/plugin/controller-class-visitor.spec.ts
@@ -118,7 +118,7 @@ describe('Controller methods', () => {
     expect(result.outputText).toEqual(appControllerOptionalQueryTextTranspiled);
   });
 
-  it('should still auto-infer the default 2xx response when only error @Api*Response decorators are present', () => {
+  it('should still auto-infer the default 2xx response when only error @Api*Response decorators are present (issue #3862)', () => {
     const options: ts.CompilerOptions = {
       module: ts.ModuleKind.CommonJS,
       target: ts.ScriptTarget.ES2021,

--- a/test/plugin/fixtures/app.controller-api-response-error.ts
+++ b/test/plugin/fixtures/app.controller-api-response-error.ts
@@ -1,0 +1,79 @@
+export const appControllerApiResponseErrorText = `import { Body, Controller, Get, Post } from '@nestjs/common';
+import {
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiUnauthorizedResponse,
+} from '@nestjs/swagger';
+
+class StartSessionDto {
+  token: string;
+}
+
+class SessionDto {
+  id: string;
+}
+
+@Controller('example')
+export class AppController {
+  @Post('session')
+  @ApiUnauthorizedResponse()
+  startSession(@Body() body: StartSessionDto): void {
+    return;
+  }
+
+  @Get('resource/:id')
+  @ApiNotFoundResponse({ description: 'Not found' })
+  getResource(): string {
+    return 'resource';
+  }
+
+  @Post('explicit')
+  @ApiCreatedResponse({ type: SessionDto })
+  @ApiUnauthorizedResponse()
+  createExplicit(): SessionDto {
+    return { id: '1' };
+  }
+}`;
+
+export const appControllerApiResponseErrorTextTranspiled = `"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.AppController = void 0;
+const openapi = require("@nestjs/swagger");
+const common_1 = require("@nestjs/common");
+const swagger_1 = require("@nestjs/swagger");
+class StartSessionDto {
+}
+class SessionDto {
+}
+let AppController = class AppController {
+    startSession(body) {
+        return;
+    }
+    getResource() {
+        return 'resource';
+    }
+    createExplicit() {
+        return { id: '1' };
+    }
+};
+exports.AppController = AppController;
+__decorate([
+    (0, common_1.Post)('session'),
+    (0, swagger_1.ApiUnauthorizedResponse)(),
+    openapi.ApiResponse({ status: 201 }),
+    __param(0, (0, common_1.Body)())
+], AppController.prototype, "startSession", null);
+__decorate([
+    (0, common_1.Get)('resource/:id'),
+    (0, swagger_1.ApiNotFoundResponse)({ description: 'Not found' }),
+    openapi.ApiResponse({ status: 200, type: String })
+], AppController.prototype, "getResource", null);
+__decorate([
+    (0, common_1.Post)('explicit'),
+    (0, swagger_1.ApiCreatedResponse)({ type: SessionDto }),
+    (0, swagger_1.ApiUnauthorizedResponse)()
+], AppController.prototype, "createExplicit", null);
+exports.AppController = AppController = __decorate([
+    (0, common_1.Controller)('example')
+], AppController);
+`;

--- a/test/plugin/fixtures/app.controller-api-response-error.ts
+++ b/test/plugin/fixtures/app.controller-api-response-error.ts
@@ -1,7 +1,9 @@
-export const appControllerApiResponseErrorText = `import { Body, Controller, Get, Post } from '@nestjs/common';
+export const appControllerApiResponseErrorText = `import { Body, Controller, Get, Post, Redirect } from '@nestjs/common';
 import {
   ApiCreatedResponse,
+  ApiFoundResponse,
   ApiNotFoundResponse,
+  ApiResponse,
   ApiUnauthorizedResponse,
 } from '@nestjs/swagger';
 
@@ -33,6 +35,19 @@ export class AppController {
   createExplicit(): SessionDto {
     return { id: '1' };
   }
+
+  @Post('refresh')
+  @ApiResponse({ status: 500, description: 'Server error' })
+  refreshSession(): void {
+    return;
+  }
+
+  @Get('redirect')
+  @Redirect()
+  @ApiFoundResponse({ description: 'Redirects to a URL' })
+  getRedirect(): { url: string; statusCode: number } {
+    return { url: 'https://example.com', statusCode: 302 };
+  }
 }`;
 
 export const appControllerApiResponseErrorTextTranspiled = `"use strict";
@@ -55,6 +70,12 @@ let AppController = class AppController {
     createExplicit() {
         return { id: '1' };
     }
+    refreshSession() {
+        return;
+    }
+    getRedirect() {
+        return { url: 'https://example.com', statusCode: 302 };
+    }
 };
 exports.AppController = AppController;
 __decorate([
@@ -73,6 +94,16 @@ __decorate([
     (0, swagger_1.ApiCreatedResponse)({ type: SessionDto }),
     (0, swagger_1.ApiUnauthorizedResponse)()
 ], AppController.prototype, "createExplicit", null);
+__decorate([
+    (0, common_1.Post)('refresh'),
+    (0, swagger_1.ApiResponse)({ status: 500, description: 'Server error' }),
+    openapi.ApiResponse({ status: 201 })
+], AppController.prototype, "refreshSession", null);
+__decorate([
+    (0, common_1.Get)('redirect'),
+    (0, common_1.Redirect)(),
+    (0, swagger_1.ApiFoundResponse)({ description: 'Redirects to a URL' })
+], AppController.prototype, "getRedirect", null);
 exports.AppController = AppController = __decorate([
     (0, common_1.Controller)('example')
 ], AppController);

--- a/test/plugin/fixtures/app.controller.ts
+++ b/test/plugin/fixtures/app.controller.ts
@@ -163,7 +163,8 @@ __decorate([
     openapi.ApiResponse({ status: 400, description: "Bad Request." }),
     openapi.ApiResponse({ status: 400, description: "Missing parameters." }),
     ApiResponse({ status: 403, description: 'Forbidden.' }),
-    (0, common_1.Post)()
+    (0, common_1.Post)(),
+    openapi.ApiResponse({ status: 201, type: Cat })
 ], AppController.prototype, \"create\", null);
 __decorate([
     openapi.ApiOperation({ summary: \"create a test Cat\", deprecated: true }),


### PR DESCRIPTION
## Summary

Fixes #3862 — regression introduced in 11.2.7 via PR #3803.

PR #3803 added a guard that suppresses the auto-inferred default response whenever *any* `Api*Response` decorator is present. The guard doesn't distinguish success (2xx) from error (4xx/5xx) decorators, so a handler with only `@ApiUnauthorizedResponse()` (or any other error-status decorator) loses its auto-inferred 2xx in the OpenAPI spec. Downstream client generators (NSwag, openapi-generator, ...) then treat the real 2xx response as an exception at runtime.

This PR scopes the guard to decorators whose status code is **below 400** so error factories no longer suppress the default. The redirect case the original PR fixed (`@ApiFoundResponse` on a `@Redirect()` handler) continues to work — 302 is still below 400.

## Approach

**Named `Api*Response` factories** — status codes are derived from the decorator name via the same `Api${PascalCase(HttpStatus key)}Response` convention the factories are generated from in `api-response.decorator.ts`. Unknown names (`ApiDefaultResponse`, user-defined `Api*Response`) fall back to the previous behavior (treated as explicit), so no existing explicit-response pattern regresses.

Mirrors the forward-direction idiom in `api-response.decorator.ts:148`:
```ts
// forward: generating factories
.filter((key) => !isNaN(Number(HttpStatus[key])))
// reverse: decoder in this PR
const status = Number(HttpStatus[statusKey as keyof typeof HttpStatus]);
return isNaN(status) || status < 400;
```

**Plain `@ApiResponse({ status })`** — the `status` argument is inspected: numeric literals (`status: 500`), the shorthand strings `'1XX'`/`'2XX'`/`'3XX'`, and `'default'` are classified by their code. Non-literal expressions (e.g. `HttpStatus.OK`) can't be evaluated at compile time and keep the pre-PR behavior (treated as explicit).

## Behavior matrix

| Handler decorators | Before (11.2.7–11.3.2) | After this PR |
|---|---|---|
| `@Post` + `@ApiUnauthorizedResponse` | only 401 ❌ | 201 + 401 ✅ |
| `@Get` + `@ApiNotFoundResponse` | only 404 ❌ | 200 + 404 ✅ |
| `@Post` + `@ApiResponse({ status: 500 })` | only 500 ❌ | 201 + 500 ✅ |
| `@Post` + `@ApiCreatedResponse` + `@ApiUnauthorizedResponse` | 201 + 401 ✅ | 201 + 401 ✅ (unchanged) |
| `@Get @Redirect @ApiFoundResponse` (#1639) | 302 only ✅ | 302 only ✅ (unchanged) |

## Tests

- New fixture `test/plugin/fixtures/app.controller-api-response-error.ts` covering five scenarios:
  - `@Post` + `@ApiUnauthorizedResponse` alone
  - `@Get` + `@ApiNotFoundResponse` alone
  - `@Post` + `@ApiCreatedResponse` + `@ApiUnauthorizedResponse` (explicit success, default still suppressed)
  - `@Post` + `@ApiResponse({ status: 500 })` alone (arg-inspection case)
  - `@Get` + `@Redirect` + `@ApiFoundResponse` (#1639 preservation)
- New regression test in `controller-class-visitor.spec.ts` (named after #3862).
- Existing #1639 fixture (`app.controller-api-response.ts`) still passes — redirect case preserved.
- Existing `app.controller` fixture updated: its `create()` handler uses multiple error-status `@ApiResponse` decorators and the expected output had baked in the 11.2.7 regression. Now expects the restored pre-11.2.7 behavior (default 201 alongside the error entries).
- Full test suite: 274/274 passing. `npm run lint` clean on changed files. `prettier --check` clean on changed files.

## Disclaimers

- Transparency: this PR was prepared in collaboration with an AI coding assistant. I reviewed and approved every change. Happy to iterate on feedback.
- Given the subtlety of the 11.2.7 regression (silent OpenAPI spec diff, only surfaces in downstream client generators), reviewers may want to independently verify no other response-generation paths are affected.