### PR TITLE
fix(decorators): forward all OpenAPI parameter fields in @ApiHeader

### DIFF
--- a/lib/decorators/api-header.decorator.ts
+++ b/lib/decorators/api-header.decorator.ts
@@ -22,18 +22,31 @@ const defaultHeaderOptions: Partial<ApiHeaderOptions> = {
 export function ApiHeader(
   options: ApiHeaderOptions
 ): MethodDecorator & ClassDecorator {
+  // `schema` and `content` are mutually exclusive per the OpenAPI spec for a
+  // single parameter object, so only provide a default string schema when the
+  // caller has not opted in to `content`.
+  const paramSchema = options.content
+    ? undefined
+    : {
+        type: 'string',
+        ...(options.example ? { example: options.example } : {}),
+        ...(options.schema || {})
+      };
+
   const param = pickBy<ApiHeaderOptions & { in: ParameterLocation }>(
     {
       name: isNil(options.name) ? defaultHeaderOptions.name : options.name,
       in: 'header',
       description: options.description,
       required: options.required,
+      deprecated: options.deprecated,
+      allowEmptyValue: options.allowEmptyValue,
+      style: options.style,
+      explode: options.explode,
+      allowReserved: options.allowReserved,
+      content: options.content,
       examples: options.examples,
-      schema: {
-        type: 'string',
-        ...(options.example ? { example: options.example } : {}),
-        ...(options.schema || {})
-      }
+      schema: paramSchema
     },
     negate(isUndefined)
   );

--- a/test/decorators/api-header.decorator.spec.ts
+++ b/test/decorators/api-header.decorator.spec.ts
@@ -1,0 +1,117 @@
+import { Controller, Get } from '@nestjs/common';
+import { DECORATORS } from '../../lib/constants';
+import { ApiHeader } from '../../lib/decorators';
+
+describe('ApiHeader', () => {
+  describe('forwarded option fields', () => {
+    @Controller('')
+    class TestController {
+      @ApiHeader({
+        name: 'X-Simple',
+        description: 'a simple header'
+      })
+      @Get('simple')
+      simple(): void {}
+
+      @ApiHeader({
+        name: 'X-Full',
+        description: 'all optional parameter fields',
+        required: true,
+        deprecated: true,
+        allowEmptyValue: true,
+        style: 'simple',
+        explode: false,
+        allowReserved: true
+      })
+      @Get('full')
+      full(): void {}
+
+      @ApiHeader({
+        name: 'X-Content',
+        content: {
+          'application/json': {
+            schema: { type: 'object', properties: { foo: { type: 'string' } } }
+          }
+        }
+      })
+      @Get('content')
+      content(): void {}
+
+      @ApiHeader({
+        name: 'X-Example',
+        example: 'abc'
+      })
+      @Get('example')
+      example(): void {}
+    }
+
+    const controller = new TestController();
+
+    it('forwards deprecated/allowEmptyValue/style/explode/allowReserved to parameter metadata', () => {
+      const metadata = Reflect.getMetadata(
+        DECORATORS.API_PARAMETERS,
+        controller.full
+      );
+
+      expect(metadata).toEqual([
+        {
+          name: 'X-Full',
+          in: 'header',
+          description: 'all optional parameter fields',
+          required: true,
+          deprecated: true,
+          allowEmptyValue: true,
+          style: 'simple',
+          explode: false,
+          allowReserved: true,
+          schema: { type: 'string' }
+        }
+      ]);
+    });
+
+    it('does not emit a synthetic string schema when `content` is provided', () => {
+      const metadata = Reflect.getMetadata(
+        DECORATORS.API_PARAMETERS,
+        controller.content
+      );
+
+      expect(metadata).toEqual([
+        {
+          name: 'X-Content',
+          in: 'header',
+          content: {
+            'application/json': {
+              schema: { type: 'object', properties: { foo: { type: 'string' } } }
+            }
+          }
+        }
+      ]);
+      expect(metadata[0]).not.toHaveProperty('schema');
+    });
+
+    it('preserves the default string schema for the simple case', () => {
+      expect(
+        Reflect.getMetadata(DECORATORS.API_PARAMETERS, controller.simple)
+      ).toEqual([
+        {
+          name: 'X-Simple',
+          in: 'header',
+          description: 'a simple header',
+          schema: { type: 'string' }
+        }
+      ]);
+    });
+
+    it('keeps `example` on the generated schema', () => {
+      expect(
+        Reflect.getMetadata(DECORATORS.API_PARAMETERS, controller.example)
+      ).toEqual([
+        {
+          name: 'X-Example',
+          in: 'header',
+          schema: { type: 'string', example: 'abc' }
+        }
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix.

## What is the current behavior?
`@ApiHeader` only forwarded `description`, `required`, `examples` and `schema` onto the generated parameter metadata. The remaining OpenAPI Parameter Object fields it advertises via `ApiHeaderOptions extends Omit<ParameterObject, 'in'>` — `deprecated`, `allowEmptyValue`, `style`, `explode`, `allowReserved`, `content` — were silently dropped.

Minimal repro:

```ts
@ApiHeader({
  name: 'X-API-Version',
  deprecated: true,
  allowEmptyValue: true,
  style: 'simple',
  explode: false,
  allowReserved: true,
})
@Get()
find() {}
```

None of the flagged flags appear on the emitted parameter. A `content`-only header additionally ended up with an unwanted synthetic `schema: { type: 'string' }`, which is invalid per OpenAPI (`schema` and `content` are mutually exclusive on a Parameter Object).

## What is the new behavior?
- All fields defined on `BaseParameterObject` (`deprecated`, `allowEmptyValue`, `style`, `explode`, `allowReserved`, `content`) are now forwarded into the parameter metadata.
- When the caller supplies `content`, the default `schema: { type: 'string' }` is suppressed so the emitted parameter only carries `content`, matching the spec's mutual-exclusivity rule.
- Behaviour for existing callers is unchanged: the default `schema: { type: 'string' }` and the top-level `example` mapping to `schema.example` both still apply when no `content` is provided.

## Additional context
Added a dedicated `test/decorators/api-header.decorator.spec.ts` with four regressions (simple header, fully-populated header, `content`-only header, top-level `example`). The existing swagger-explorer `when headers are defined` suite continues to pass untouched.