### PR TITLE
fix(plugin): avoid duplicate keys when auto-generating @ApiOperation

### DIFF
--- a/lib/plugin/visitors/controller-class.visitor.ts
+++ b/lib/plugin/visitors/controller-class.visitor.ts
@@ -273,10 +273,22 @@ export class ControllerClassVisitor extends AbstractFileVisitor {
     ];
 
     const tags = getTsDocTagsOfNode(node, typeChecker);
-    const hasRemarksKey = hasPropertyKey(
-      'description',
-      factory.createNodeArray(apiOperationExistingProps)
-    );
+    const existingPropsArray = factory.createNodeArray(apiOperationExistingProps);
+    const hasRemarksKey = hasPropertyKey('description', existingPropsArray);
+    // Helper so we never unshift a key the user has already written in the
+    // explicit @ApiOperation({...}) call; otherwise the generated object
+    // literal would contain duplicate keys (e.g. `{ summary: 'doc', summary: 'user' }`).
+    const unshiftIfNotExisting = (key: string, value: string) => {
+      if (hasPropertyKey(key, existingPropsArray)) {
+        return;
+      }
+      properties.unshift(
+        factory.createPropertyAssignment(
+          key,
+          factory.createStringLiteral(value)
+        )
+      );
+    };
     if (!hasRemarksKey && tags.remarks) {
       // When the @remarks tag is used in the comment, it will be added to the description property of the @ApiOperation decorator.
       // In this case, even when the "controllerKeyOfComment" option is set to "description", the "summary" property will be used.
@@ -287,30 +299,13 @@ export class ControllerClassVisitor extends AbstractFileVisitor {
       properties.push(remarksPropertyAssignment);
 
       if (options.controllerKeyOfComment === 'description') {
-        properties.unshift(
-          factory.createPropertyAssignment(
-            'summary',
-            factory.createStringLiteral(extractedComments)
-          )
-        );
+        unshiftIfNotExisting('summary', extractedComments);
       } else {
-        const keyToGenerate = options.controllerKeyOfComment;
-        properties.unshift(
-          factory.createPropertyAssignment(
-            keyToGenerate,
-            factory.createStringLiteral(extractedComments)
-          )
-        );
+        unshiftIfNotExisting(options.controllerKeyOfComment, extractedComments);
       }
     } else {
       // No @remarks tag was found in the comment so use the attribute set by the user
-      const keyToGenerate = options.controllerKeyOfComment;
-      properties.unshift(
-        factory.createPropertyAssignment(
-          keyToGenerate,
-          factory.createStringLiteral(extractedComments)
-        )
-      );
+      unshiftIfNotExisting(options.controllerKeyOfComment, extractedComments);
     }
 
     const hasDeprecatedKey = hasPropertyKey(

--- a/test/plugin/controller-class-visitor.spec.ts
+++ b/test/plugin/controller-class-visitor.spec.ts
@@ -24,6 +24,10 @@ import {
   appControllerThrowsQuotesText,
   appControllerThrowsQuotesTextTranspiled
 } from './fixtures/app.controller-throws-quotes';
+import {
+  appControllerApiOperationDedupeText,
+  appControllerApiOperationDedupeTextTranspiled
+} from './fixtures/app.controller-api-operation-dedupe';
 
 describe('Controller methods', () => {
   it('should add response based on the return value (spaces)', () => {
@@ -152,5 +156,28 @@ describe('Controller methods', () => {
       }
     });
     expect(result.outputText).toEqual(appControllerThrowsQuotesTextTranspiled);
+  });
+
+  it('should not emit duplicate keys when user has supplied controllerKeyOfComment already', () => {
+    const options: ts.CompilerOptions = {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2021,
+      newLine: ts.NewLineKind.LineFeed,
+      noEmitHelpers: true,
+      experimentalDecorators: true
+    };
+    const filename = 'app.controller.ts';
+    const fakeProgram = ts.createProgram([filename], options);
+
+    const result = ts.transpileModule(appControllerApiOperationDedupeText, {
+      compilerOptions: options,
+      fileName: filename,
+      transformers: {
+        before: [before({ introspectComments: true }, fakeProgram)]
+      }
+    });
+    expect(result.outputText).toEqual(
+      appControllerApiOperationDedupeTextTranspiled
+    );
   });
 });

--- a/test/plugin/fixtures/app.controller-api-operation-dedupe.ts
+++ b/test/plugin/fixtures/app.controller-api-operation-dedupe.ts
@@ -1,0 +1,67 @@
+export const appControllerApiOperationDedupeText = `import { Controller, Get } from '@nestjs/common';
+import { ApiOperation } from '@nestjs/swagger';
+
+class Cat {}
+
+@Controller('cats')
+export class AppController {
+  /**
+   * auto-generated summary
+   */
+  @ApiOperation({ summary: 'user-supplied summary' })
+  @Get('a')
+  a(): Cat {
+    return new Cat();
+  }
+
+  /**
+   * auto-generated summary
+   *
+   * @remarks user remark
+   */
+  @ApiOperation({ summary: 'user-supplied summary' })
+  @Get('b')
+  b(): Cat {
+    return new Cat();
+  }
+}`;
+
+export const appControllerApiOperationDedupeTextTranspiled = `\"use strict\";
+Object.defineProperty(exports, \"__esModule\", { value: true });
+exports.AppController = void 0;
+const openapi = require(\"@nestjs/swagger\");
+const common_1 = require(\"@nestjs/common\");
+const swagger_1 = require(\"@nestjs/swagger\");
+class Cat {
+}
+let AppController = class AppController {
+    /**
+     * auto-generated summary
+     */
+    a() {
+        return new Cat();
+    }
+    /**
+     * auto-generated summary
+     *
+     * @remarks user remark
+     */
+    b() {
+        return new Cat();
+    }
+};
+exports.AppController = AppController;
+__decorate([
+    (0, swagger_1.ApiOperation)({ summary: 'user-supplied summary' }),
+    (0, common_1.Get)('a'),
+    openapi.ApiResponse({ status: 200, type: Cat })
+], AppController.prototype, \"a\", null);
+__decorate([
+    (0, swagger_1.ApiOperation)({ summary: 'user-supplied summary', description: \"user remark\" }),
+    (0, common_1.Get)('b'),
+    openapi.ApiResponse({ status: 200, type: Cat })
+], AppController.prototype, \"b\", null);
+exports.AppController = AppController = __decorate([
+    (0, common_1.Controller)('cats')
+], AppController);
+`;


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix (plugin / transformer).

## What is the current behavior?
When `introspectComments` is enabled and the user has already supplied `summary` (or `description`, depending on `controllerKeyOfComment`) on an explicit `@ApiOperation({...})`, the plugin still unshifts an auto-generated key, producing a duplicate-key object literal.

Minimal repro controller:

```ts
/** doc-summary */
@ApiOperation({ summary: 'user-summary' })
@Get()
findOne() {}
```

Transpiles to:

```ts
openapi.ApiOperation({ summary: \"doc-summary\", summary: 'user-summary' })
```

Runtime behaviour happens to be correct (JS picks the last duplicate key) but:
1. the emitted JS is a duplicate-key object literal, which linters flag in strict mode;
2. it is inconsistent with how the plugin already guards `description` (via `hasRemarksKey`) and `deprecated` (via `hasDeprecatedKey`) against the exact same scenario.

## What is the new behavior?
The unshift only runs when the explicit `@ApiOperation({...})` argument does not already contain the generated key. So the same input now produces:

```ts
openapi.ApiOperation({ summary: 'user-summary' })
```

All other cases are unchanged: empty `@ApiOperation({})`, missing decorator, `@remarks` blocks, and mixed `summary` + `description` combinations still work exactly as before.

## Additional context
Added a new fixture `test/plugin/fixtures/app.controller-api-operation-dedupe.ts` and a corresponding test in `controller-class-visitor.spec.ts` covering both the plain and the `@remarks`-combined cases. The existing `appControllerTextTranspiled` snapshot is untouched because none of its methods override the generated key.