### PR TITLE
fix(plugin): emit @throws descriptions as proper string literals

### DIFF
--- a/lib/plugin/utils/ast-utils.ts
+++ b/lib/plugin/utils/ast-utils.ts
@@ -247,9 +247,12 @@ export function getTsDocErrorsOfNode(node: Node) {
       try {
         const docValue = renderDocNode(block.content).split('\n')[0].trim();
         const match = docValue.match(errorParsingRegex);
+        // Keep the raw description text so the caller can safely emit it as a
+        // string literal. Pre-wrapping it in quotes breaks round-tripping when
+        // the description itself contains a quote character.
         tagResults.push({
-          status: match[1],
-          description: `"${match[2]}"`
+          status: Number(match[1]),
+          description: match[2]
         });
       } catch {
         // Do nothing

--- a/lib/plugin/visitors/controller-class.visitor.ts
+++ b/lib/plugin/visitors/controller-class.visitor.ts
@@ -396,7 +396,7 @@ export class ControllerClassVisitor extends AbstractFileVisitor {
       properties.push(
         factory.createPropertyAssignment(
           'description',
-          factory.createNumericLiteral(tag.description)
+          factory.createStringLiteral(tag.description)
         )
       );
       const objectLiteralExpr = factory.createObjectLiteralExpression(

--- a/test/plugin/controller-class-visitor.spec.ts
+++ b/test/plugin/controller-class-visitor.spec.ts
@@ -20,6 +20,10 @@ import {
   appControllerWithoutModifiersText,
   appControllerWithoutModifiersTextTranspiled
 } from './fixtures/app.controller-without-modifiers';
+import {
+  appControllerThrowsQuotesText,
+  appControllerThrowsQuotesTextTranspiled
+} from './fixtures/app.controller-throws-quotes';
 
 describe('Controller methods', () => {
   it('should add response based on the return value (spaces)', () => {
@@ -127,5 +131,26 @@ describe('Controller methods', () => {
     expect(result.outputText).toEqual(
       appControllerWithoutModifiersTextTranspiled
     );
+  });
+
+  it('should emit a valid string literal for @throws descriptions that contain quotes', () => {
+    const options: ts.CompilerOptions = {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2021,
+      newLine: ts.NewLineKind.LineFeed,
+      noEmitHelpers: true,
+      experimentalDecorators: true
+    };
+    const filename = 'app.controller.ts';
+    const fakeProgram = ts.createProgram([filename], options);
+
+    const result = ts.transpileModule(appControllerThrowsQuotesText, {
+      compilerOptions: options,
+      fileName: filename,
+      transformers: {
+        before: [before({ introspectComments: true }, fakeProgram)]
+      }
+    });
+    expect(result.outputText).toEqual(appControllerThrowsQuotesTextTranspiled);
   });
 });

--- a/test/plugin/fixtures/app.controller-throws-quotes.ts
+++ b/test/plugin/fixtures/app.controller-throws-quotes.ts
@@ -1,0 +1,50 @@
+export const appControllerThrowsQuotesText = `import { Controller, Post } from '@nestjs/common';
+
+class Cat {}
+
+@Controller('cats')
+export class AppController {
+  /**
+   * create
+   *
+   * @throws {400} foo "bar".
+   * @throws {500} line one
+   * line two
+   */
+  @Post()
+  a(): Cat {
+    return new Cat();
+  }
+}`;
+
+export const appControllerThrowsQuotesTextTranspiled = `"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.AppController = void 0;
+const openapi = require("@nestjs/swagger");
+const common_1 = require("@nestjs/common");
+class Cat {
+}
+let AppController = class AppController {
+    /**
+     * create
+     *
+     * @throws {400} foo "bar".
+     * @throws {500} line one
+     * line two
+     */
+    a() {
+        return new Cat();
+    }
+};
+exports.AppController = AppController;
+__decorate([
+    openapi.ApiOperation({ summary: "create" }),
+    openapi.ApiResponse({ status: 400, description: "foo \\"bar\\"." }),
+    openapi.ApiResponse({ status: 500, description: "line one" }),
+    (0, common_1.Post)(),
+    openapi.ApiResponse({ status: 201, type: Cat })
+], AppController.prototype, "a", null);
+exports.AppController = AppController = __decorate([
+    (0, common_1.Controller)('cats')
+], AppController);
+`;


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix (plugin / TSDoc @throws handling).

## What is the current behavior?
`getTsDocErrorsOfNode` stored the parsed `@throws` description pre-wrapped in double quotes and the caller fed that already-quoted text into `factory.createNumericLiteral`. That accidentally produced a valid-looking string literal for the common case, but broke as soon as the description contained a character that needs escaping inside a double-quoted string.

Minimal repro:

```ts
/**
 * create
 * @throws {400} foo \"bar\".
 */
@Post()
a() {}
```

Transpiles to:

```js
openapi.ApiResponse({ status: 400, description: \"foo \"bar\".\" })
```

…which is a syntax error when the generated file is executed (the `\"bar\"` closes the string early). The same class of failure hits any `@throws` description with a `\"`, a control character, or similar.

## What is the new behavior?
- `getTsDocErrorsOfNode` now returns the raw description text and the status as a number.
- The plugin emits the description with `factory.createStringLiteral`, so the TypeScript printer escapes the text correctly.

After the fix the same input becomes:

```js
openapi.ApiResponse({ status: 400, description: \"foo \\\"bar\\\".\" })
```

Regular descriptions (and numeric statuses) produce byte-identical output; the existing `app.controller` fixture is unchanged.

## Additional context
Added a dedicated fixture `test/plugin/fixtures/app.controller-throws-quotes.ts` and a new test case in `controller-class-visitor.spec.ts` to cover the embedded-quote / multi-line `@throws` path.