### PR TITLE
fix(document-builder): accept multi-digit OpenAPI version segments

### DIFF
--- a/lib/document-builder.ts
+++ b/lib/document-builder.ts
@@ -53,7 +53,11 @@ export class DocumentBuilder {
   }
 
   public setOpenAPIVersion(version: string): this {
-    if (version.match(/^\d\.\d\.\d$/)) {
+    // OpenAPI Specification versions follow semver, so each segment may contain
+    // one or more digits (e.g. `3.0.10`, `3.10.0`). Anchored regex accepts any
+    // non-negative integer per segment; the previous `^\d\.\d\.\d$` pattern
+    // rejected otherwise-valid spec versions.
+    if (/^\d+\.\d+\.\d+$/.test(version)) {
       this.document.openapi = version;
     } else {
       this.logger.warn(

--- a/test/document-builder.spec.ts
+++ b/test/document-builder.spec.ts
@@ -108,4 +108,37 @@ describe('DocumentBuilder', () => {
       });
     });
   });
+
+  describe('setOpenAPIVersion', () => {
+    it('accepts a three-part numeric version with single-digit segments', () => {
+      const builder = new DocumentBuilder().setOpenAPIVersion('3.1.0');
+      expect(builder.build().openapi).toBe('3.1.0');
+    });
+
+    it('accepts a version with multi-digit segments', () => {
+      // OpenAPI spec versions follow semver; segments may have multiple digits
+      // (e.g. 3.0.10, 3.10.0). The previous `^\d\.\d\.\d$` regex rejected those.
+      const builder1 = new DocumentBuilder().setOpenAPIVersion('3.0.10');
+      expect(builder1.build().openapi).toBe('3.0.10');
+
+      const builder2 = new DocumentBuilder().setOpenAPIVersion('3.10.0');
+      expect(builder2.build().openapi).toBe('3.10.0');
+
+      const builder3 = new DocumentBuilder().setOpenAPIVersion('10.20.30');
+      expect(builder3.build().openapi).toBe('10.20.30');
+    });
+
+    it('rejects malformed versions and keeps the default', () => {
+      const defaultVersion = new DocumentBuilder().build().openapi;
+
+      const builder = new DocumentBuilder().setOpenAPIVersion('not-a-version');
+      expect(builder.build().openapi).toBe(defaultVersion);
+
+      const builder2 = new DocumentBuilder().setOpenAPIVersion('3.0');
+      expect(builder2.build().openapi).toBe(defaultVersion);
+
+      const builder3 = new DocumentBuilder().setOpenAPIVersion('3.0.0-beta');
+      expect(builder3.build().openapi).toBe(defaultVersion);
+    });
+  });
 });


### PR DESCRIPTION
## What kind of change does this PR introduce?
Bug fix (DocumentBuilder).

## What is the current behavior?
`DocumentBuilder.setOpenAPIVersion` validates its argument with:

```ts
if (version.match(/^\d\.\d\.\d$/)) { … }
```

The regex requires **exactly one digit per segment**. OpenAPI Specification versions follow semver — `3.0.x` has already reached `3.0.4`, a future `3.0.10` or `3.10.0` would be entirely valid — but any of those would be silently rejected today with only a warn-level log, and the default version on the document would be kept.

Minimal repro:

```ts
const builder = new DocumentBuilder().setOpenAPIVersion('3.0.10');
// builder.build().openapi is still the default (3.0.0), no error,
// only a WARN-level log: 'The OpenApi version is invalid. Expecting format \"x.x.x\"'
```

## What is the new behavior?
Widened the regex to `/^\d+\.\d+\.\d+$/`, so each segment may contain any non-negative integer. Genuinely malformed inputs (`3.0`, `3.0.0-beta`, …) still fall through to the existing warning.

## Additional context
Added three unit-test cases to `test/document-builder.spec.ts` covering:
- The previously-accepted single-digit case (`3.1.0`) — regression guard.
- Multi-digit segments (`3.0.10`, `3.10.0`, `10.20.30`).
- Malformed inputs, to confirm they still leave the default in place.