### PR TITLE
fix(plugin): handle IsIn enum inference when type falls back to Object

### DIFF
--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -742,6 +742,36 @@ export class SchemaObjectFactory {
     | ParameterObject
     | (SchemaObject & { selfRequired?: boolean }) {
     const typeRef = nestedArrayType || metadata.type;
+    if (metadata.enum && typeRef === Object) {
+      const enumValues = getEnumValues(metadata.enum);
+      const enumType = getEnumType(enumValues);
+
+      if (metadata.isArray) {
+        return this.transformToArraySchemaProperty(
+          {
+            ...metadata,
+            items: {
+              type: enumType,
+              enum: enumValues
+            }
+          } as SchemaObjectMetadata,
+          key,
+          { type: enumType, enum: enumValues }
+        );
+      }
+
+      return this.createSchemaMetadata(
+        key,
+        {
+          ...metadata,
+          type: enumType,
+          enum: enumValues
+        } as SchemaObjectMetadata,
+        schemas,
+        pendingSchemaRefs,
+        enumType
+      );
+    }
     if (this.isConstEnumObject(typeRef as Record<string, any>)) {
       const enumValues = getEnumValues(typeRef as Record<string, any>);
       const enumType = getEnumType(enumValues);

--- a/test/plugin/model-class-visitor.spec.ts
+++ b/test/plugin/model-class-visitor.spec.ts
@@ -600,4 +600,40 @@ describe('API model properties', () => {
     });
     expect(result.outputText).toEqual(createCatMatchesDtoTextTranspiled);
   });
+
+  it('should emit IsIn enum metadata for literal union properties that fall back to Object', () => {
+    const options: ts.CompilerOptions = {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      newLine: ts.NewLineKind.LineFeed,
+      noEmitHelpers: true,
+      experimentalDecorators: true,
+      strict: true
+    };
+    const filename = 'literal-union-is-in.dto.ts';
+    const fakeProgram = ts.createProgram([filename], options);
+
+    const dtoText = `
+      import { IsIn } from 'class-validator';
+
+      type Hoge = 'a' | 1;
+
+      export class LiteralUnionIsInDto {
+        @IsIn(['a', 1])
+        gender!: Hoge;
+      }
+    `;
+
+    const result = ts.transpileModule(dtoText, {
+      compilerOptions: options,
+      fileName: filename,
+      transformers: {
+        before: [before({ classValidatorShim: true }, fakeProgram)]
+      }
+    });
+
+    expect(result.outputText).toContain(
+      `gender: { required: true, type: () => Object, enum: ['a', 1] }`
+    );
+  });
 });

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -1273,6 +1273,88 @@ describe('SchemaObjectFactory', () => {
       expect(props.code.type).toBe('string');
       expect(props.code.enum).toEqual([1, 2, 3]);
     });
+
+    it('should infer string enum type when plugin metadata falls back to Object', () => {
+      class ObjectFallbackMixedEnumDto {
+        static _OPENAPI_METADATA_FACTORY() {
+          return {
+            gender: {
+              required: true,
+              type: () => Object,
+              enum: ['a', 1]
+            }
+          };
+        }
+      }
+
+      const schemas: Record<string, SchemasObject> = {};
+      schemaObjectFactory.exploreModelSchema(
+        ObjectFallbackMixedEnumDto,
+        schemas
+      );
+
+      const props = schemas.ObjectFallbackMixedEnumDto.properties as any;
+      expect(props.gender).toEqual({
+        type: 'string',
+        enum: ['a', 1]
+      });
+    });
+
+    it('should infer number enum type when plugin metadata falls back to Object', () => {
+      class ObjectFallbackNumberEnumDto {
+        static _OPENAPI_METADATA_FACTORY() {
+          return {
+            value: {
+              required: true,
+              type: () => Object,
+              enum: [1, 2]
+            }
+          };
+        }
+      }
+
+      const schemas: Record<string, SchemasObject> = {};
+      schemaObjectFactory.exploreModelSchema(
+        ObjectFallbackNumberEnumDto,
+        schemas
+      );
+
+      const props = schemas.ObjectFallbackNumberEnumDto.properties as any;
+      expect(props.value).toEqual({
+        type: 'number',
+        enum: [1, 2]
+      });
+    });
+
+    it('should move enum metadata into array items when plugin array metadata falls back to Object', () => {
+      class ObjectFallbackArrayEnumDto {
+        static _OPENAPI_METADATA_FACTORY() {
+          return {
+            values: {
+              required: true,
+              type: () => [Object],
+              enum: ['a', 'b'],
+              isArray: true
+            }
+          };
+        }
+      }
+
+      const schemas: Record<string, SchemasObject> = {};
+      schemaObjectFactory.exploreModelSchema(
+        ObjectFallbackArrayEnumDto,
+        schemas
+      );
+
+      const props = schemas.ObjectFallbackArrayEnumDto.properties as any;
+      expect(props.values).toEqual({
+        type: 'array',
+        items: {
+          type: 'string',
+          enum: ['a', 'b']
+        }
+      });
+    });
   });
 
   describe('SWC const-enum compatibility (issue #3326)', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`classValidatorShim` can emit `enum` metadata from `@IsIn(...)`, but when the plugin falls back to `type: () => Object` for a literal-union property, 11.4.1 keeps `type: object` in the generated schema. That produces an invalid schema for downstream tools.

Issue Number: N/A


## What is the new behavior?

When schema metadata has `enum` and the inferred type is the plugin fallback `Object`, `SchemaObjectFactory` now infers the scalar schema type from the enum values instead of keeping `object`.

Example output:

```json
{
  "type": "string",
  "enum": ["a", 1]
}
```


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

- Added regression coverage in `test/services/schema-object-factory.spec.ts` for `type: () => Object` + `enum` metadata.
- Added plugin coverage in `test/plugin/model-class-visitor.spec.ts` for `@IsIn(['a', 1])` on a literal-union property.
