### PR TITLE
fix(swagger-types-mapper): place multipleOf inside parameter schema

### DIFF
--- a/lib/services/swagger-types-mapper.ts
+++ b/lib/services/swagger-types-mapper.ts
@@ -146,6 +146,7 @@ export class SwaggerTypesMapper {
       'exclusiveMaximum',
       'exclusiveMinimum',
       'uniqueItems',
+      'multipleOf',
       'title',
       'format',
       'pattern',

--- a/test/services/swagger-types-mapper.spec.ts
+++ b/test/services/swagger-types-mapper.spec.ts
@@ -1,0 +1,49 @@
+import { SwaggerTypesMapper } from '../../lib/services/swagger-types-mapper';
+
+describe('SwaggerTypesMapper', () => {
+  let mapper: SwaggerTypesMapper;
+
+  beforeEach(() => {
+    mapper = new SwaggerTypesMapper();
+  });
+
+  describe('mapParamTypes', () => {
+    it('should move `multipleOf` into the schema for type-based parameters', () => {
+      const params = [
+        {
+          name: 'count',
+          in: 'query',
+          required: true,
+          type: Number,
+          multipleOf: 5
+        }
+      ];
+
+      const result = mapper.mapParamTypes(params as any) as any[];
+
+      expect(result[0]).not.toHaveProperty('multipleOf');
+      expect(result[0].schema).toEqual({
+        type: 'number',
+        multipleOf: 5
+      });
+    });
+
+    it('should move `multipleOf` into the schema for array parameters', () => {
+      const params = [
+        {
+          name: 'counts',
+          in: 'query',
+          required: true,
+          type: Number,
+          isArray: true,
+          multipleOf: 5
+        }
+      ];
+
+      const result = mapper.mapParamTypes(params as any) as any[];
+
+      expect(result[0]).not.toHaveProperty('multipleOf');
+      expect(result[0].schema.type).toBe('array');
+    });
+  });
+});


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

When a parameter (e.g. `@ApiQuery`, `@ApiParam`) is declared with a `multipleOf` constraint without an explicit `schema` host, the value is left at the parameter top level instead of being moved into `parameter.schema`. The resulting OpenAPI parameter object is invalid because OAS numeric validation keywords like `multipleOf` belong inside the parameter's schema, alongside `minimum`/`maximum`/etc.

Example input:

```ts
@ApiQuery({ name: 'count', type: Number, multipleOf: 5 })
```

Current output (truncated):

```json
{
  "name": "count",
  "in": "query",
  "required": true,
  "multipleOf": 5,           // <-- wrong location
  "schema": { "type": "number" }
}
```

The same problem exists for array-typed parameters — `multipleOf` is dropped entirely from the generated schema.

`SwaggerTypesMapper#getSchemaOptionsKeys` enumerates the SchemaObject keys that should be promoted from a parameter's top-level options into its `schema` block. `multipleOf` is missing from that list even though it is declared on `SchemaObject` and is generated by the plugin for DTOs (e.g. via `@IsDivisibleBy`).

## What is the new behavior?

`multipleOf` is now included in the schema options key list, so it is placed under `parameter.schema` for both scalar and array parameters, matching how `minimum`, `maximum`, `exclusiveMinimum`, etc. are already handled.

```json
{
  "name": "count",
  "in": "query",
  "required": true,
  "schema": { "type": "number", "multipleOf": 5 }
}
```

## Additional context (optional)

Added a small `SwaggerTypesMapper` unit test covering both the scalar and the array-parameter codepaths. The existing `swagger-explorer` suite (53 tests) continues to pass.