### PR TITLE
fix(response-object-factory): preserve example/examples for built-in scalar response types

### DIFF
--- a/e2e/src/cats/cats.controller.ts
+++ b/e2e/src/cats/cats.controller.ts
@@ -243,4 +243,34 @@ export class CatsController {
     }
   })
   rawSchemaResponse() {}
+
+  @Get('scalar-with-example')
+  @ApiResponse({ status: 200, type: Number, example: 42 })
+  scalarWithExample(): number {
+    return 42;
+  }
+
+  @Get('scalar-with-examples')
+  @ApiResponse({
+    status: 200,
+    type: Number,
+    examples: {
+      adult: { value: 5, summary: 'Adult cat age' },
+      kitten: { value: 1, summary: 'Kitten age' }
+    }
+  })
+  scalarWithExamples(): number {
+    return 5;
+  }
+
+  @Get('array-of-scalar-with-example')
+  @ApiResponse({
+    status: 200,
+    type: String,
+    isArray: true,
+    example: ['Mau', 'Persian']
+  })
+  arrayOfScalarWithExample(): string[] {
+    return ['Mau', 'Persian'];
+  }
 }

--- a/e2e/validate-schema.e2e-spec.ts
+++ b/e2e/validate-schema.e2e-spec.ts
@@ -205,6 +205,37 @@ describe('Validate OpenAPI schema', () => {
     });
   });
 
+  it('should preserve example/examples for built-in scalar response types', () => {
+    const document = SwaggerModule.createDocument(app, options);
+
+    const scalarExample =
+      document.paths['/api/cats/scalar-with-example']['get']['responses']['200'];
+    expect(scalarExample.content['application/json'].example).toEqual(42);
+    expect((scalarExample as any).example).toBeUndefined();
+
+    const scalarExamples =
+      document.paths['/api/cats/scalar-with-examples']['get']['responses']['200'];
+    expect(scalarExamples.content['application/json'].examples).toEqual({
+      adult: { value: 5, summary: 'Adult cat age' },
+      kitten: { value: 1, summary: 'Kitten age' }
+    });
+    expect((scalarExamples as any).examples).toBeUndefined();
+
+    const arrayExample =
+      document.paths['/api/cats/array-of-scalar-with-example']['get'][
+        'responses'
+      ]['200'];
+    expect(arrayExample.content['application/json'].schema).toEqual({
+      type: 'array',
+      items: { type: 'string' }
+    });
+    expect(arrayExample.content['application/json'].example).toEqual([
+      'Mau',
+      'Persian'
+    ]);
+    expect((arrayExample as any).example).toBeUndefined();
+  });
+
   it('should fix colons in url', async () => {
     const document = SwaggerModule.createDocument(app, options);
     expect(

--- a/lib/services/response-object-factory.ts
+++ b/lib/services/response-object-factory.ts
@@ -1,4 +1,4 @@
-import { isEmpty, isFunction, omit } from 'lodash';
+import { isEmpty, isFunction, omit, pick } from 'lodash';
 import { DECORATORS } from '../constants';
 import {
   ApiPropertyOptions,
@@ -65,7 +65,8 @@ export class ResponseObjectFactory {
             items: {
               type: swaggerType
             }
-          }
+          },
+          ...pick(response, exampleKeys)
         });
         return {
           ...omit(response, exampleKeys),
@@ -76,7 +77,8 @@ export class ResponseObjectFactory {
       const content = this.mimetypeContentWrapper.wrap(produces, {
         schema: {
           type: swaggerType
-        }
+        },
+        ...pick(response, exampleKeys)
       });
       return {
         ...omit(response, exampleKeys),

--- a/test/services/response-object-factory.spec.ts
+++ b/test/services/response-object-factory.spec.ts
@@ -1,0 +1,75 @@
+import { ResponseObjectFactory } from '../../lib/services/response-object-factory';
+
+describe('ResponseObjectFactory', () => {
+  let factory: ResponseObjectFactory;
+
+  beforeEach(() => {
+    factory = new ResponseObjectFactory();
+  });
+
+  const produces = ['application/json'];
+  const factories = {
+    linkName: () => 'link',
+    operationId: () => 'op'
+  };
+
+  describe('built-in primitive type responses', () => {
+    it('should preserve `example` when type is a built-in scalar', () => {
+      const result = factory.create(
+        { type: Number, description: 'OK', example: 42 } as any,
+        produces,
+        {},
+        factories
+      ) as any;
+
+      expect(result.content['application/json']).toEqual({
+        schema: { type: 'number' },
+        example: 42
+      });
+    });
+
+    it('should preserve `examples` when type is a built-in scalar', () => {
+      const examples = {
+        first: { summary: 'First', value: 1 },
+        second: { summary: 'Second', value: 2 }
+      };
+      const result = factory.create(
+        { type: Number, description: 'OK', examples } as any,
+        produces,
+        {},
+        factories
+      ) as any;
+
+      expect(result.content['application/json']).toEqual({
+        schema: { type: 'number' },
+        examples
+      });
+    });
+
+    it('should preserve `example` when type is a built-in scalar with isArray', () => {
+      const result = factory.create(
+        { type: Number, isArray: true, description: 'OK', example: [1, 2, 3] } as any,
+        produces,
+        {},
+        factories
+      ) as any;
+
+      expect(result.content['application/json']).toEqual({
+        schema: { type: 'array', items: { type: 'number' } },
+        example: [1, 2, 3]
+      });
+    });
+
+    it('should not leak example into the top-level response object', () => {
+      const result = factory.create(
+        { type: String, description: 'OK', example: 'hello' } as any,
+        produces,
+        {},
+        factories
+      ) as any;
+
+      expect(result).not.toHaveProperty('example');
+      expect(result).not.toHaveProperty('examples');
+    });
+  });
+});


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

When a response decorator is configured with a built-in scalar (or array of scalar) type and an example payload, the example is silently dropped from the generated OpenAPI document.

```ts
@ApiOkResponse({ type: Number, example: 42 })
findAge() { ... }
```

The generated 200 response has no example:

```json
{
  "description": "",
  "content": {
    "application/json": { "schema": { "type": "number" } }
  }
}
```

`ResponseObjectFactory#create` strips `example` and `examples` from the response via `omit(response, exampleKeys)` for the built-in-type branch, but it never re-attaches them to the generated media-type entry. The non-built-in (DTO) branch — handled by `ResponseObjectMapper` — already does the right thing via `pick(response, exampleKeys)` when it constructs the media type. The built-in-type branch is the outlier.

## What is the new behavior?

`example` / `examples` are now forwarded to `MimetypeContentWrapper.wrap` for both the scalar and array-of-scalar built-in-type code paths, mirroring the DTO behaviour. The example ends up next to `schema` inside each `content[<mimetype>]` entry, as required by the OpenAPI spec, and is no longer left behind at the response top level.

```json
{
  "description": "",
  "content": {
    "application/json": {
      "schema": { "type": "number" },
      "example": 42
    }
  }
}
```

## Additional context (optional)

Added a focused unit test for `ResponseObjectFactory` covering scalar `example`, scalar `examples`, the `isArray: true` codepath, and a guard that `example` does not leak back to the top-level response object. The full `swagger-explorer` and `response-object-mapper` suites continue to pass (63 tests).