### PR TITLE
feat: add exampleMaxDepth to truncate large example values

### DIFF
--- a/lib/decorators/api-property.decorator.ts
+++ b/lib/decorators/api-property.decorator.ts
@@ -20,6 +20,15 @@ export type ApiPropertyCommonOptions = SchemaObjectMetadata & {
    * @see [Swagger link objects](https://swagger.io/docs/specification/links/)
    */
   link?: () => Type<unknown> | Function;
+  /**
+   * Limits the depth of `example` / `examples` values emitted for this single
+   * schema entry. Overrides `SwaggerDocumentOptions.exampleMaxDepth` for this
+   * property only; sibling and nested schemas are unaffected.
+   *
+   * The metadata is stripped before the document is returned so it never
+   * appears in the generated OpenAPI output.
+   */
+  exampleMaxDepth?: number;
 };
 
 export type ApiPropertyOptions =

--- a/lib/interfaces/swagger-document-options.interface.ts
+++ b/lib/interfaces/swagger-document-options.interface.ts
@@ -70,4 +70,20 @@ export interface SwaggerDocumentOptions {
    * @default false
    */
   excludeDynamicDefaults?: boolean;
+
+  /**
+   * When set, generated `example` and `examples` values on component schemas are
+   * truncated once their nested object/array depth exceeds this number. Useful
+   * when DTOs hold user-supplied `@ApiProperty({ example })` payloads or
+   * plugin-synthesized TSDoc `@example` metadata that inflates the document.
+   * Truncation only affects example values; schema graphs (`$ref`s,
+   * `properties`, `items`) are not modified. `0` collapses every non-primitive
+   * example to `{}`/`[]`. `undefined` (the default) leaves examples untouched.
+   *
+   * Per-property `@ApiProperty({ exampleMaxDepth })` overrides this value for
+   * a single schema entry without affecting siblings or children.
+   *
+   * @default undefined
+   */
+  exampleMaxDepth?: number;
 }

--- a/lib/swagger-scanner.ts
+++ b/lib/swagger-scanner.ts
@@ -19,6 +19,7 @@ import { SchemaObjectFactory } from './services/schema-object-factory';
 import { SwaggerTypesMapper } from './services/swagger-types-mapper';
 import { SwaggerExplorer } from './swagger-explorer';
 import { SwaggerTransformer } from './swagger-transformer';
+import { applyExampleMaxDepth } from './utils/apply-example-max-depth.util';
 import { getGlobalPrefix } from './utils/get-global-prefix';
 import { stripDynamicDefaults } from './utils/strip-dynamic-defaults.util';
 import { stripLastSlash } from './utils/strip-last-slash.util';
@@ -44,7 +45,8 @@ export class SwaggerScanner {
       linkNameFactory,
       autoTagControllers = true,
       onlyIncludeDecoratedEndpoints = false,
-      excludeDynamicDefaults = false
+      excludeDynamicDefaults = false,
+      exampleMaxDepth
     } = options;
 
     const untypedApp = app as any;
@@ -109,6 +111,11 @@ export class SwaggerScanner {
     if (excludeDynamicDefaults) {
       stripDynamicDefaults(schemas as Record<string, SchemaObject>);
     }
+
+    applyExampleMaxDepth(
+      schemas as Record<string, SchemaObject>,
+      exampleMaxDepth
+    );
 
     return {
       ...this.transformer.normalizePaths(flatten(denormalizedPaths)),

--- a/lib/utils/apply-example-max-depth.util.ts
+++ b/lib/utils/apply-example-max-depth.util.ts
@@ -1,0 +1,130 @@
+import { SchemaObject } from '../interfaces/open-api-spec.interface';
+
+/**
+ * Recursively walks every schema in `schemas` and truncates `example` /
+ * `examples` values whose nested object/array depth exceeds the effective
+ * limit. The schema graph itself (`$ref`, `properties`, `items`, combinators)
+ * is not modified — only example values are rewritten.
+ *
+ * Per-schema `exampleMaxDepth` (set via `@ApiProperty({ exampleMaxDepth })`)
+ * overrides `globalMaxDepth` for that entry only and is stripped from the
+ * output so it never leaks into the published OpenAPI document.
+ *
+ * When `globalMaxDepth` is `undefined` and no schema declares an override,
+ * the call is a no-op aside from removing any leftover `exampleMaxDepth`
+ * keys produced by the decorator.
+ */
+export function applyExampleMaxDepth(
+  schemas: Record<string, SchemaObject>,
+  globalMaxDepth: number | undefined
+): void {
+  for (const schema of Object.values(schemas)) {
+    walkSchema(schema as Record<string, unknown>, globalMaxDepth);
+  }
+}
+
+function walkSchema(
+  schema: Record<string, unknown> | null | undefined,
+  globalMaxDepth: number | undefined
+): void {
+  if (!schema || typeof schema !== 'object') {
+    return;
+  }
+
+  const perPropOverride =
+    typeof schema.exampleMaxDepth === 'number'
+      ? (schema.exampleMaxDepth as number)
+      : undefined;
+  const effectiveMax =
+    perPropOverride !== undefined ? perPropOverride : globalMaxDepth;
+
+  if (effectiveMax !== undefined) {
+    if ('example' in schema) {
+      schema.example = trimExampleValue(schema.example, effectiveMax);
+    }
+    if ('examples' in schema && Array.isArray(schema.examples)) {
+      schema.examples = (schema.examples as unknown[]).map((entry) =>
+        trimExampleValue(entry, effectiveMax)
+      );
+    }
+  }
+
+  // Strip the metadata so it never reaches the published OpenAPI output, even
+  // when no truncation actually ran (e.g. override set but example absent).
+  if ('exampleMaxDepth' in schema) {
+    delete schema.exampleMaxDepth;
+  }
+
+  if (schema.properties && typeof schema.properties === 'object') {
+    for (const prop of Object.values(
+      schema.properties as Record<string, unknown>
+    )) {
+      walkSchema(prop as Record<string, unknown>, globalMaxDepth);
+    }
+  }
+  if (schema.items) {
+    walkSchema(schema.items as Record<string, unknown>, globalMaxDepth);
+  }
+  for (const key of ['allOf', 'oneOf', 'anyOf'] as const) {
+    const combinator = schema[key];
+    if (Array.isArray(combinator)) {
+      for (const sub of combinator) {
+        walkSchema(sub as Record<string, unknown>, globalMaxDepth);
+      }
+    }
+  }
+  if (
+    schema.additionalProperties &&
+    typeof schema.additionalProperties === 'object'
+  ) {
+    walkSchema(
+      schema.additionalProperties as Record<string, unknown>,
+      globalMaxDepth
+    );
+  }
+}
+
+function trimExampleValue(
+  value: unknown,
+  remainingDepth: number,
+  path: WeakSet<object> = new WeakSet()
+): unknown {
+  if (value === null || typeof value !== 'object') {
+    return value;
+  }
+  const isArray = Array.isArray(value);
+  // Walk only plain object literals and arrays. Date / Map / Set / Buffer /
+  // class instances serialize through their own `toJSON` (or as primitives)
+  // and `Object.entries(new Date())` is `[]`, which would otherwise rewrite
+  // user-supplied `@ApiProperty({ example: new Date() })` to `{}`.
+  if (!isArray && (value as { constructor?: Function }).constructor !== Object) {
+    return value;
+  }
+
+  if (remainingDepth <= 0) {
+    return isArray ? [] : {};
+  }
+  // Path-local cycle guard: only short-circuit when the same object is
+  // reachable through a real cycle, not when sibling properties simply share
+  // a reference (a non-cyclic DAG, e.g. `{ a: shared, b: shared }`).
+  if (path.has(value as object)) {
+    return isArray ? [] : {};
+  }
+  path.add(value as object);
+  try {
+    if (isArray) {
+      return (value as unknown[]).map((entry) =>
+        trimExampleValue(entry, remainingDepth - 1, path)
+      );
+    }
+    const trimmed: Record<string, unknown> = {};
+    for (const [key, child] of Object.entries(
+      value as Record<string, unknown>
+    )) {
+      trimmed[key] = trimExampleValue(child, remainingDepth - 1, path);
+    }
+    return trimmed;
+  } finally {
+    path.delete(value as object);
+  }
+}

--- a/test/utils/apply-example-max-depth.util.spec.ts
+++ b/test/utils/apply-example-max-depth.util.spec.ts
@@ -1,0 +1,471 @@
+import { ApiProperty } from '../../lib/decorators';
+import { SchemaObject } from '../../lib/interfaces/open-api-spec.interface';
+import { ModelPropertiesAccessor } from '../../lib/services/model-properties-accessor';
+import { SchemaObjectFactory } from '../../lib/services/schema-object-factory';
+import { SwaggerTypesMapper } from '../../lib/services/swagger-types-mapper';
+import { applyExampleMaxDepth } from '../../lib/utils/apply-example-max-depth.util';
+
+describe('applyExampleMaxDepth', () => {
+  describe('global option', () => {
+    it('truncates deeply nested object examples to {}/[] beyond the limit', () => {
+      const schemas: Record<string, SchemaObject> = {
+        Dto: {
+          type: 'object',
+          properties: {
+            payload: {
+              type: 'object',
+              example: {
+                a: 1,
+                b: { c: { d: { e: 'too deep' } } }
+              }
+            }
+          }
+        }
+      };
+
+      applyExampleMaxDepth(schemas, 2);
+
+      // root container (depth 1) + one nested level (depth 2) survive,
+      // anything below collapses to a placeholder of the matching shape.
+      expect(schemas.Dto.properties!.payload['example']).toEqual({
+        a: 1,
+        b: { c: {} }
+      });
+    });
+
+    it('treats arrays the same as objects when measuring depth', () => {
+      const schemas: Record<string, SchemaObject> = {
+        Dto: {
+          type: 'object',
+          properties: {
+            list: {
+              type: 'array',
+              example: [{ id: 1, nested: { deep: 'cut' } }]
+            }
+          }
+        }
+      };
+
+      applyExampleMaxDepth(schemas, 2);
+
+      // depth 1 = array root, depth 2 = element object — children collapse.
+      expect(schemas.Dto.properties!.list['example']).toEqual([
+        { id: 1, nested: {} }
+      ]);
+    });
+
+    it('leaves primitive examples untouched at any depth', () => {
+      const schemas: Record<string, SchemaObject> = {
+        Dto: {
+          type: 'object',
+          properties: {
+            label: { type: 'string', example: 'hello' },
+            count: { type: 'number', example: 0 },
+            active: { type: 'boolean', example: false },
+            nothing: { type: 'string', example: null }
+          }
+        }
+      };
+
+      applyExampleMaxDepth(schemas, 0);
+
+      expect(schemas.Dto.properties!.label['example']).toBe('hello');
+      expect(schemas.Dto.properties!.count['example']).toBe(0);
+      expect(schemas.Dto.properties!.active['example']).toBe(false);
+      expect(schemas.Dto.properties!.nothing['example']).toBeNull();
+    });
+
+    it('collapses any non-primitive example to {} or [] when maxDepth is 0', () => {
+      const schemas: Record<string, SchemaObject> = {
+        Obj: {
+          type: 'object',
+          example: { a: 1 }
+        },
+        Arr: {
+          type: 'array',
+          example: [1, 2, 3]
+        }
+      };
+
+      applyExampleMaxDepth(schemas, 0);
+
+      expect(schemas.Obj['example']).toEqual({});
+      expect(schemas.Arr['example']).toEqual([]);
+    });
+
+    it('truncates entries inside the OpenAPI 3.1 examples array', () => {
+      const schemas: Record<string, SchemaObject> = {
+        Dto: {
+          type: 'object',
+          properties: {
+            payload: {
+              type: 'object',
+              examples: [
+                { a: { b: { c: 'cut' } } },
+                { x: { y: { z: 'cut' } } }
+              ]
+            }
+          }
+        }
+      };
+
+      applyExampleMaxDepth(schemas, 2);
+
+      expect(schemas.Dto.properties!.payload['examples']).toEqual([
+        { a: { b: {} } },
+        { x: { y: {} } }
+      ]);
+    });
+
+    it('walks into items, allOf, oneOf, anyOf, and additionalProperties', () => {
+      const schemas: Record<string, SchemaObject> = {
+        Dto: {
+          type: 'object',
+          properties: {
+            arr: {
+              type: 'array',
+              items: {
+                type: 'object',
+                example: { lvl1: { lvl2: 'cut' } }
+              }
+            },
+            combo: {
+              allOf: [
+                { type: 'object', example: { a: { b: 'cut' } } }
+              ],
+              oneOf: [
+                { type: 'object', example: { a: { b: 'cut' } } }
+              ],
+              anyOf: [
+                { type: 'object', example: { a: { b: 'cut' } } }
+              ]
+            } as any,
+            map: {
+              type: 'object',
+              additionalProperties: {
+                type: 'object',
+                example: { a: { b: 'cut' } }
+              }
+            }
+          }
+        }
+      };
+
+      applyExampleMaxDepth(schemas, 1);
+
+      expect(
+        schemas.Dto.properties!.arr['items']['example']
+      ).toEqual({ lvl1: {} });
+      expect(
+        schemas.Dto.properties!.combo['allOf'][0].example
+      ).toEqual({ a: {} });
+      expect(
+        schemas.Dto.properties!.combo['oneOf'][0].example
+      ).toEqual({ a: {} });
+      expect(
+        schemas.Dto.properties!.combo['anyOf'][0].example
+      ).toEqual({ a: {} });
+      expect(
+        schemas.Dto.properties!.map['additionalProperties'].example
+      ).toEqual({ a: {} });
+    });
+  });
+
+  describe('per-property override', () => {
+    it('overrides the global limit with the per-property exampleMaxDepth value', () => {
+      const schemas: Record<string, SchemaObject> = {
+        Dto: {
+          type: 'object',
+          properties: {
+            tight: {
+              type: 'object',
+              exampleMaxDepth: 1,
+              example: { a: { b: 'cut even though global is generous' } }
+            } as any,
+            loose: {
+              type: 'object',
+              example: { a: { b: { c: 'kept up to global=3' } } }
+            }
+          }
+        }
+      };
+
+      applyExampleMaxDepth(schemas, 3);
+
+      expect(schemas.Dto.properties!.tight['example']).toEqual({ a: {} });
+      expect(schemas.Dto.properties!.loose['example']).toEqual({
+        a: { b: { c: 'kept up to global=3' } }
+      });
+    });
+
+    it('applies the override even when the global option is unset', () => {
+      const schemas: Record<string, SchemaObject> = {
+        Dto: {
+          type: 'object',
+          exampleMaxDepth: 1,
+          example: { a: { b: 'cut' } }
+        } as any
+      };
+
+      applyExampleMaxDepth(schemas, undefined);
+
+      expect(schemas.Dto['example']).toEqual({ a: {} });
+    });
+
+    it('does not cascade the override to children of the matching schema', () => {
+      const schemas: Record<string, SchemaObject> = {
+        Dto: {
+          type: 'object',
+          exampleMaxDepth: 1,
+          properties: {
+            inner: {
+              type: 'object',
+              example: { a: { b: { c: 'should follow global, not parent override' } } }
+            }
+          }
+        } as any
+      };
+
+      applyExampleMaxDepth(schemas, 3);
+
+      expect(schemas.Dto.properties!.inner['example']).toEqual({
+        a: { b: { c: 'should follow global, not parent override' } }
+      });
+    });
+  });
+
+  describe('output leakage', () => {
+    it('strips exampleMaxDepth from every visited schema', () => {
+      const schemas: Record<string, SchemaObject> = {
+        Dto: {
+          type: 'object',
+          exampleMaxDepth: 2,
+          properties: {
+            inner: {
+              type: 'object',
+              exampleMaxDepth: 5,
+              example: { ok: true }
+            } as any,
+            list: {
+              type: 'array',
+              items: {
+                type: 'object',
+                exampleMaxDepth: 1,
+                example: { a: { b: 'cut' } }
+              } as any
+            }
+          }
+        } as any
+      };
+
+      applyExampleMaxDepth(schemas, undefined);
+
+      const serialized = JSON.stringify(schemas);
+      expect(serialized).not.toContain('exampleMaxDepth');
+    });
+
+    it('strips the metadata even when the override never triggers truncation', () => {
+      const schemas: Record<string, SchemaObject> = {
+        Dto: {
+          type: 'object',
+          exampleMaxDepth: 5
+        } as any
+      };
+
+      applyExampleMaxDepth(schemas, undefined);
+
+      expect('exampleMaxDepth' in schemas.Dto).toBe(false);
+    });
+  });
+
+  describe('no-op safety', () => {
+    it('does not modify schemas when neither the global option nor any override is set', () => {
+      const schemas: Record<string, SchemaObject> = {
+        Dto: {
+          type: 'object',
+          properties: {
+            payload: {
+              type: 'object',
+              example: { a: { b: { c: { d: 'kept' } } } }
+            },
+            list: {
+              type: 'array',
+              example: [{ deeply: { nested: 'kept' } }]
+            }
+          }
+        }
+      };
+      const before = JSON.stringify(schemas);
+
+      applyExampleMaxDepth(schemas, undefined);
+
+      expect(JSON.stringify(schemas)).toBe(before);
+    });
+  });
+
+  describe('shared references (non-cyclic DAG)', () => {
+    it('trims every occurrence when sibling properties share a reference', () => {
+      const shared = { x: 1, y: { deeper: 'kept' } };
+      const schemas: Record<string, SchemaObject> = {
+        Dto: {
+          type: 'object',
+          example: { a: shared, b: shared }
+        } as any
+      };
+
+      applyExampleMaxDepth(schemas, 5);
+
+      // Both occurrences are non-cyclic; the second must not be collapsed
+      // because of the first one's traversal.
+      expect(schemas.Dto['example']).toEqual({
+        a: { x: 1, y: { deeper: 'kept' } },
+        b: { x: 1, y: { deeper: 'kept' } }
+      });
+    });
+
+    it('does not collapse repeated references inside an array', () => {
+      const shared = { id: 7 };
+      const schemas: Record<string, SchemaObject> = {
+        Dto: {
+          type: 'object',
+          example: [shared, shared, shared]
+        } as any
+      };
+
+      applyExampleMaxDepth(schemas, 3);
+
+      expect(schemas.Dto['example']).toEqual([
+        { id: 7 },
+        { id: 7 },
+        { id: 7 }
+      ]);
+    });
+  });
+
+  describe('non-plain object instances', () => {
+    it('preserves Date / Map / Set / class instances inside examples as-is', () => {
+      const date = new Date('2026-01-01T00:00:00.000Z');
+      const map = new Map<string, number>([['k', 1]]);
+      const set = new Set<number>([1, 2, 3]);
+      class Custom {
+        constructor(public name = 'foo') {}
+      }
+      const instance = new Custom();
+
+      const schemas: Record<string, SchemaObject> = {
+        Dto: {
+          type: 'object',
+          example: { ts: date, lookup: map, members: set, who: instance }
+        } as any
+      };
+
+      applyExampleMaxDepth(schemas, 5);
+
+      const out = schemas.Dto['example'] as Record<string, unknown>;
+      expect(out.ts).toBe(date);
+      expect(out.lookup).toBe(map);
+      expect(out.members).toBe(set);
+      expect(out.who).toBe(instance);
+    });
+
+    it('does not rewrite a Date used as the entire example value', () => {
+      const date = new Date('2026-05-08T00:00:00.000Z');
+      const schemas: Record<string, SchemaObject> = {
+        Dto: {
+          type: 'string',
+          example: date
+        } as any
+      };
+
+      applyExampleMaxDepth(schemas, 0);
+
+      expect(schemas.Dto['example']).toBe(date);
+    });
+  });
+
+  describe('circular safety', () => {
+    it('terminates on circular example values via WeakSet guard', () => {
+      const cyclic: Record<string, unknown> = { name: 'root' };
+      cyclic.self = cyclic;
+
+      const schemas: Record<string, SchemaObject> = {
+        Dto: {
+          type: 'object',
+          example: cyclic
+        }
+      };
+
+      expect(() => applyExampleMaxDepth(schemas, 5)).not.toThrow();
+
+      const trimmed = schemas.Dto['example'] as Record<string, unknown>;
+      expect(trimmed.name).toBe('root');
+      // Cycle is replaced by a placeholder of the same shape (object → {}).
+      expect(trimmed.self).toEqual({});
+    });
+  });
+
+  describe('integration with SchemaObjectFactory output', () => {
+    let schemaObjectFactory: SchemaObjectFactory;
+
+    beforeEach(() => {
+      schemaObjectFactory = new SchemaObjectFactory(
+        new ModelPropertiesAccessor(),
+        new SwaggerTypesMapper()
+      );
+    });
+
+    it('truncates a user-supplied @ApiProperty example end-to-end', () => {
+      const big = {
+        list: Array.from({ length: 5 }, (_, i) => ({
+          id: i,
+          nested: { a: 1, b: 2, c: { x: 'y' } }
+        }))
+      };
+      class WithExample {
+        @ApiProperty({ example: big })
+        payload: object;
+      }
+
+      const schemas: Record<string, SchemaObject> = {};
+      schemaObjectFactory.exploreModelSchema(WithExample, schemas);
+
+      const before = JSON.stringify(schemas).length;
+      applyExampleMaxDepth(schemas, 2);
+      const after = JSON.stringify(schemas).length;
+
+      // root object (depth 1) + list array (depth 2) survive; each element is
+      // collapsed because it sits at depth 3.
+      expect(after).toBeLessThan(before);
+      expect(schemas.WithExample.properties!.payload['example']).toEqual({
+        list: [{}, {}, {}, {}, {}]
+      });
+    });
+
+    it('honours per-property @ApiProperty({ exampleMaxDepth }) and strips it from the schema', () => {
+      class Dto {
+        @ApiProperty({
+          exampleMaxDepth: 1,
+          example: { a: { b: 'cut' } }
+        } as any)
+        bounded: object;
+
+        @ApiProperty({
+          example: { a: { b: 'kept' } }
+        })
+        unbounded: object;
+      }
+
+      const schemas: Record<string, SchemaObject> = {};
+      schemaObjectFactory.exploreModelSchema(Dto, schemas);
+      applyExampleMaxDepth(schemas, undefined);
+
+      expect(
+        schemas.Dto.properties!.bounded['example']
+      ).toEqual({ a: {} });
+      expect(
+        schemas.Dto.properties!.unbounded['example']
+      ).toEqual({ a: { b: 'kept' } });
+      expect(JSON.stringify(schemas)).not.toContain('exampleMaxDepth');
+    });
+  });
+});


### PR DESCRIPTION
Closes #3879 (revives #967).

Deeply nested DTOs blow up the generated `example` blob — the issue
reports a 45k-line example that locks up Swagger UI. This adds an
opt-in option to cap how deep example values are emitted.

### Usage

Document-wide:

```ts
SwaggerModule.createDocument(app, config, { exampleMaxDepth: 3 });
```

Per-property override:

```ts
class CreatePostDto {
  @ApiProperty({
    exampleMaxDepth: 1,
    example: { /* very large object */ }
  })
  payload: object;
}
```

Default is `undefined` (no truncation), so existing users see no
change. `0` collapses any non-primitive example to `{}` / `[]`.

### Notes

- Only example values are rewritten. `$ref`, `properties`, `items` and
  the existing circular-dependency guard in `SchemaObjectFactory` are
  untouched.
- The per-property `exampleMaxDepth` is stripped from the emitted
  schema so it never appears in the document.
- Non-plain runtime values (`Date`, `Map`, `Set`, class instances) are
  treated as leaves and passed through as-is, matching the convention
  used by `stripDynamicDefaults`.
- Cycle handling uses a path-local `WeakSet`, so non-cyclic DAGs (the
  same object reachable from multiple siblings) are still trimmed
  fully.
- Scope of this PR is `components.schemas`. Inline examples on
  `RequestBody` / `Response` / `Parameter`, and runtime validation of
  the option value (NaN / negative / Infinity), I'd rather keep as
  separate follow-ups — happy to fold either in here if you prefer.

### Tests

New spec at `test/utils/apply-example-max-depth.util.spec.ts`. Covers
the global limit, per-property override and non-cascade, output-leak
strip, items / allOf / oneOf / anyOf / additionalProperties traversal,
non-cyclic DAGs, `Date` / `Map` / `Set` / class instance pass-through,
cycle guard, and an end-to-end check via `SchemaObjectFactory`. Full
suite 349/349.
