### PR TITLE
fix(response-object-factory): wrap built-in nullable responses in oneOf

### DIFF
--- a/lib/services/response-object-factory.ts
+++ b/lib/services/response-object-factory.ts
@@ -58,30 +58,21 @@ export class ResponseObjectFactory {
         this.swaggerTypesMapper.mapTypeToOpenAPIType(typeName);
 
       const exampleKeys = ['example', 'examples'];
-      if (isArray) {
-        const content = this.mimetypeContentWrapper.wrap(produces, {
-          schema: {
-            type: 'array',
-            items: {
-              type: swaggerType
-            }
-          },
-          ...pick(response, exampleKeys)
-        });
-        return {
-          ...omit(response, exampleKeys),
-          ...content
-        };
-      }
-
+      const baseSchema: SchemaObject = isArray
+        ? { type: 'array', items: { type: swaggerType } }
+        : { type: swaggerType };
+      // Mirror the nullable handling in ResponseObjectMapper so the
+      // "nullable" flag does not leak into the response object root and
+      // is instead represented as "oneOf: [<schema>, { type: 'null' }]".
+      const schema: SchemaObject = response.nullable
+        ? { oneOf: [baseSchema, { type: 'null' }] }
+        : baseSchema;
       const content = this.mimetypeContentWrapper.wrap(produces, {
-        schema: {
-          type: swaggerType
-        },
+        schema,
         ...pick(response, exampleKeys)
       });
       return {
-        ...omit(response, exampleKeys),
+        ...omit(response, [...exampleKeys, 'nullable']),
         ...content
       };
     }

--- a/test/services/response-object-factory.spec.ts
+++ b/test/services/response-object-factory.spec.ts
@@ -71,5 +71,59 @@ describe('ResponseObjectFactory', () => {
       expect(result).not.toHaveProperty('example');
       expect(result).not.toHaveProperty('examples');
     });
+
+    it('should wrap built-in scalar in oneOf with type: null when nullable: true', () => {
+      const result = factory.create(
+        { type: String, description: 'OK', nullable: true } as any,
+        produces,
+        {},
+        factories
+      ) as any;
+
+      expect(result).not.toHaveProperty('nullable');
+      expect(result.content['application/json']).toEqual({
+        schema: { oneOf: [{ type: 'string' }, { type: 'null' }] }
+      });
+    });
+
+    it('should wrap built-in scalar array in oneOf with type: null when nullable: true', () => {
+      const result = factory.create(
+        { type: Number, isArray: true, description: 'OK', nullable: true } as any,
+        produces,
+        {},
+        factories
+      ) as any;
+
+      expect(result).not.toHaveProperty('nullable');
+      expect(result.content['application/json']).toEqual({
+        schema: {
+          oneOf: [
+            { type: 'array', items: { type: 'number' } },
+            { type: 'null' }
+          ]
+        }
+      });
+    });
+
+    it('should preserve example alongside nullable for built-in scalar', () => {
+      const result = factory.create(
+        {
+          type: String,
+          description: 'OK',
+          nullable: true,
+          example: 'hello'
+        } as any,
+        produces,
+        {},
+        factories
+      ) as any;
+
+      expect(result).not.toHaveProperty('nullable');
+      expect(result).not.toHaveProperty('example');
+      expect(result.content['application/json']).toEqual({
+        schema: { oneOf: [{ type: 'string' }, { type: 'null' }] },
+        example: 'hello'
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary

When `@ApiResponse({ type: String, nullable: true })` (or any other built-in scalar) was used, two things went wrong inside `ResponseObjectFactory.create`:

1. The schema emitted under `content[<mime>].schema` ignored the `nullable` flag entirely, so the produced spec did not mark the type as nullable.
2. The `nullable: true` property was leaked onto the OpenAPI ResponseObject root, where it is not a valid field.

`ResponseObjectMapper.toRefObject` / `toArrayRefObject` already handle this case correctly for non-built-in types by wrapping the schema in `oneOf: [<schema>, { type: 'null' }]` and stripping `nullable` from the response root. This PR mirrors that behaviour for the built-in scalar branch (both array and non-array shapes), so the output is consistent across all response shapes and valid OpenAPI.

### Before

```js
factory.create(
  { type: String, description: 'OK', nullable: true },
  ['application/json'], {}, factories
);
```

```jsonc
{
  "description": "OK",
  "nullable": true,                 // <-- leaked to ResponseObject
  "content": {
    "application/json": {
      "schema": { "type": "string" } // <-- nullable not represented
    }
  }
}
```

### After

```jsonc
{
  "description": "OK",
  "content": {
    "application/json": {
      "schema": {
        "oneOf": [{ "type": "string" }, { "type": "null" }]
      }
    }
  }
}
```

The same wrapping is applied for `isArray: true`, producing `oneOf: [{ type: 'array', items: { type: '<scalar>' } }, { type: 'null' }]`. `example` / `examples` siblings are still preserved alongside the wrapped schema.

## Test plan

- [x] Added three unit tests under `test/services/response-object-factory.spec.ts`:
  - scalar built-in + `nullable: true` produces `oneOf` and strips `nullable` from the response root.
  - array built-in + `nullable: true` wraps the array schema in `oneOf` with `{ type: 'null' }`.
  - `example` is still preserved alongside `nullable`.
- [x] `npm test -- test/services/` (64 tests, all pass).
- [x] `npm run test:e2e` (116 tests, all pass).
- [x] `npm run lint` (no new warnings/errors).
- [x] `npm run build` (clean).