### PR TITLE
fix(explorer): resolve class-level @ApiConsumes/@ApiProduces from metatype

### DIFF
--- a/lib/explorers/api-response.explorer.ts
+++ b/lib/explorers/api-response.explorer.ts
@@ -1,7 +1,7 @@
 import { HttpStatus, RequestMethod, Type } from '@nestjs/common';
 import { HTTP_CODE_METADATA, METHOD_METADATA } from '@nestjs/common/constants';
 import { isEmpty } from '@nestjs/common/utils/shared.utils';
-import { get, mapValues, omit } from 'lodash';
+import { mapValues, omit } from 'lodash';
 import { DECORATORS } from '../constants';
 import { ApiResponse, ApiResponseMetadata } from '../decorators';
 import { SchemaObject } from '../interfaces/open-api-spec.interface';
@@ -59,21 +59,22 @@ export const exploreApiResponseMetadata = (
   factories: FactoriesNeededByResponseFactory,
   instance: object,
   prototype: Type<unknown>,
-  method: Function
+  method: Function,
+  metatype?: Type<unknown>
 ) => {
   applyMetadataFactory(prototype, instance);
 
   const responses = Reflect.getMetadata(DECORATORS.API_RESPONSE, method);
   if (responses) {
+    // `@ApiProduces` is a class-level decorator that stores metadata on the
+    // class constructor (the metatype). Reading from `prototype` always
+    // returned undefined, silently dropping class-level produces overrides.
     const classProduces = Reflect.getMetadata(
       DECORATORS.API_PRODUCES,
-      prototype
+      metatype ?? prototype?.constructor
     );
     const methodProduces = Reflect.getMetadata(DECORATORS.API_PRODUCES, method);
-    const produces = mergeAndUniq<string[]>(
-      get(classProduces, 'produces'),
-      methodProduces
-    );
+    const produces = mergeAndUniq<string[]>(classProduces, methodProduces);
     return mapResponsesToSwaggerResponses(
       responses,
       schemas,

--- a/lib/swagger-explorer.ts
+++ b/lib/swagger-explorer.ts
@@ -261,7 +261,8 @@ export class SwaggerExplorer {
               ...mergedMethodMetadata
             },
             prototype,
-            targetCallback
+            targetCallback,
+            metatype
           );
         });
       }
@@ -277,7 +278,8 @@ export class SwaggerExplorer {
             ...mergedMethodMetadata
           },
           prototype,
-          targetCallback
+          targetCallback,
+          metatype
         )
       ];
     });
@@ -574,7 +576,8 @@ export class SwaggerExplorer {
   private migrateOperationSchema(
     document: DenormalizedDoc,
     prototype: Type<unknown>,
-    method: Function
+    method: Function,
+    metatype?: Type<unknown>
   ) {
     const parametersObject: Record<string, any>[] = get(
       document,
@@ -589,9 +592,12 @@ export class SwaggerExplorer {
     const requestBody = parametersObject[requestBodyIndex];
     parametersObject.splice(requestBodyIndex, 1);
 
+    // `@ApiConsumes` is a class-level decorator that stores metadata on the
+    // class constructor (the metatype). Reading from `prototype` always
+    // returned undefined, silently dropping class-level consumes overrides.
     const classConsumes = Reflect.getMetadata(
       DECORATORS.API_CONSUMES,
-      prototype
+      metatype ?? prototype?.constructor
     );
     const methodConsumes = Reflect.getMetadata(DECORATORS.API_CONSUMES, method);
     let consumes = mergeAndUniq(classConsumes, methodConsumes);

--- a/test/explorer/swagger-explorer.spec.ts
+++ b/test/explorer/swagger-explorer.spec.ts
@@ -3158,4 +3158,66 @@ describe('SwaggerExplorer', () => {
       );
     });
   });
+
+  describe('when @ApiConsumes/@ApiProduces are applied at the controller level', () => {
+    class Foo {
+      @ApiProperty()
+      name: string;
+    }
+
+    @ApiConsumes('application/xml')
+    @ApiProduces('application/xml')
+    @Controller('foos')
+    class FooController {
+      @Post()
+      @ApiBody({ type: Foo })
+      @ApiCreatedResponse({ type: Foo, description: 'Created' })
+      create(): Promise<Foo> {
+        return Promise.resolve(new Foo());
+      }
+    }
+
+    it('uses controller-level consumes for the requestBody content type', () => {
+      const explorer = new SwaggerExplorer(schemaObjectFactory);
+      const routes = explorer.exploreController(
+        {
+          instance: new FooController(),
+          metatype: FooController
+        } as InstanceWrapper<FooController>,
+        new ApplicationConfig(),
+        {}
+      );
+
+      expect(routes).toHaveLength(1);
+      expect(routes[0].root!.requestBody).toEqual({
+        required: true,
+        content: {
+          'application/xml': {
+            schema: { $ref: '#/components/schemas/Foo' }
+          }
+        }
+      });
+    });
+
+    it('uses controller-level produces for the response content type', () => {
+      const explorer = new SwaggerExplorer(schemaObjectFactory);
+      const routes = explorer.exploreController(
+        {
+          instance: new FooController(),
+          metatype: FooController
+        } as InstanceWrapper<FooController>,
+        new ApplicationConfig(),
+        {}
+      );
+
+      expect(routes).toHaveLength(1);
+      const created = routes[0].responses['201'] as ResponseObject;
+      expect(created.content).toEqual({
+        'application/xml': {
+          schema: { $ref: '#/components/schemas/Foo' }
+        }
+      });
+      expect(created.content['application/json']).toBeUndefined();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- `@ApiConsumes` and `@ApiProduces` are class+method decorators built on `createMixedDecorator`. When applied at the class level the metadata is written to the class constructor (the *metatype*), but the explorer was reading it back from the controller's *prototype* — where it never exists — so the lookups always returned `undefined`. Controller-level mime-type overrides were silently dropped and `requestBody` / response `content` always fell back to `application/json`, even when the controller declared `@ApiConsumes('application/xml')` or `@ApiProduces('application/xml')`.
- Read class-level metadata from the metatype in `swagger-explorer.ts#migrateOperationSchema` (consumes) and `api-response.explorer.ts#exploreApiResponseMetadata` (produces). `prototype.constructor` is used as a fallback so existing call sites stay backward-compatible.
- Drop the `get(classProduces, 'produces')` indirection in the response explorer that assumed an object shape that never matches what the decorator actually stores (a flat string array). Once `classProduces` is correctly populated, that `get(...)` would have continued returning `undefined`.

## Test plan
- [x] Added two `SwaggerExplorer` unit tests under `test/explorer/swagger-explorer.spec.ts` ("when @ApiConsumes/@ApiProduces are applied at the controller level") that build a controller with controller-level `@ApiConsumes('application/xml')` / `@ApiProduces('application/xml')` and assert `requestBody.content` and the `201` response `content` use `application/xml`.
- [x] Verified both tests fail on `master` with the expected mismatch (`application/json` returned instead of `application/xml`) and pass after the fix.
- [x] `npm run build` succeeds.
- [x] `npx vitest run test/explorer/` — 60/60 pass.
- [x] `npx vitest run --config vitest.e2e.config.mts` — 116/116 e2e pass.
- [x] `npm run lint` — 0 errors (only pre-existing warnings).