### PR TITLE
fix(plugin): only unwrap Promise/Observable when they are the top-level type

### DIFF
--- a/lib/plugin/utils/plugin-utils.ts
+++ b/lib/plugin/utils/plugin-utils.ts
@@ -128,8 +128,18 @@ export function getTypeReferenceAsString(
   }
 }
 
+/**
+ * Returns `true` when the supplied type text refers to a top-level
+ * `Promise<...>` or `Observable<...>` instantiation.
+ *
+ * The match is anchored to the start of the string (or to a fully qualified
+ * `import("...").` prefix) so user-defined classes whose names happen to end
+ * with `Promise` / `Observable` (for example `MyPromise<T>` or
+ * `AsyncObservable<T>`) are not mistakenly unwrapped to their inner type
+ * argument.
+ */
 export function isPromiseOrObservable(type: string) {
-  return type.includes('Promise<') || type.includes('Observable<');
+  return /(^|\.)(Promise|Observable)</.test(type);
 }
 
 export function hasPropertyKey(

--- a/test/plugin/controller-class-visitor.spec.ts
+++ b/test/plugin/controller-class-visitor.spec.ts
@@ -32,6 +32,10 @@ import {
   appControllerApiOperationDedupeText,
   appControllerApiOperationDedupeTextTranspiled
 } from './fixtures/app.controller-api-operation-dedupe';
+import {
+  appControllerPromisePrefixText,
+  appControllerPromisePrefixTextTranspiled
+} from './fixtures/app.controller-promise-prefix';
 
 describe('Controller methods', () => {
   it('should add response based on the return value (spaces)', () => {
@@ -206,5 +210,26 @@ describe('Controller methods', () => {
     expect(result.outputText).toEqual(
       appControllerApiOperationDedupeTextTranspiled
     );
+  });
+
+  it('should not unwrap user-defined classes whose names end with Promise/Observable', () => {
+    const options: ts.CompilerOptions = {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2021,
+      newLine: ts.NewLineKind.LineFeed,
+      noEmitHelpers: true,
+      experimentalDecorators: true
+    };
+    const filename = 'app.controller.ts';
+    const fakeProgram = ts.createProgram([filename], options);
+
+    const result = ts.transpileModule(appControllerPromisePrefixText, {
+      compilerOptions: options,
+      fileName: filename,
+      transformers: {
+        before: [before({ introspectComments: false }, fakeProgram)]
+      }
+    });
+    expect(result.outputText).toEqual(appControllerPromisePrefixTextTranspiled);
   });
 });

--- a/test/plugin/fixtures/app.controller-promise-prefix.ts
+++ b/test/plugin/fixtures/app.controller-promise-prefix.ts
@@ -1,0 +1,77 @@
+export const appControllerPromisePrefixText = `import { Controller, Get } from '@nestjs/common';
+
+class Cat {}
+
+class MyPromise<T> {
+  value: T;
+}
+
+class AsyncObservable<T> {
+  value: T;
+}
+
+@Controller('cats')
+export class AppController {
+  /**
+   * Standard Promise should still unwrap to the inner type.
+   */
+  @Get()
+  findStandard(): Promise<Cat> { return null; }
+
+  /**
+   * MyPromise is a user-defined class that just happens to end with the
+   * word "Promise"; the inner Cat type must NOT replace it.
+   */
+  @Get()
+  findCustomPromise(): MyPromise<Cat> { return null; }
+
+  /**
+   * Same problem for any name that ends with "Observable".
+   */
+  @Get()
+  findCustomObservable(): AsyncObservable<Cat> { return null; }
+}`;
+
+export const appControllerPromisePrefixTextTranspiled = `\"use strict\";
+Object.defineProperty(exports, \"__esModule\", { value: true });
+exports.AppController = void 0;
+const openapi = require(\"@nestjs/swagger\");
+const common_1 = require(\"@nestjs/common\");
+class Cat {
+}
+class MyPromise {
+}
+class AsyncObservable {
+}
+let AppController = class AppController {
+    /**
+     * Standard Promise should still unwrap to the inner type.
+     */
+    findStandard() { return null; }
+    /**
+     * MyPromise is a user-defined class that just happens to end with the
+     * word \"Promise\"; the inner Cat type must NOT replace it.
+     */
+    findCustomPromise() { return null; }
+    /**
+     * Same problem for any name that ends with \"Observable\".
+     */
+    findCustomObservable() { return null; }
+};
+exports.AppController = AppController;
+__decorate([
+    (0, common_1.Get)(),
+    openapi.ApiResponse({ status: 200, type: Cat })
+], AppController.prototype, \"findStandard\", null);
+__decorate([
+    (0, common_1.Get)(),
+    openapi.ApiResponse({ status: 200 })
+], AppController.prototype, \"findCustomPromise\", null);
+__decorate([
+    (0, common_1.Get)(),
+    openapi.ApiResponse({ status: 200 })
+], AppController.prototype, \"findCustomObservable\", null);
+exports.AppController = AppController = __decorate([
+    (0, common_1.Controller)('cats')
+], AppController);
+`;


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix.

## What is the current behavior?

`isPromiseOrObservable` in `lib/plugin/utils/plugin-utils.ts` decides whether the plugin should "unwrap" a return type by doing a substring match for `Promise<` or `Observable<`. Any user-defined class whose name happens to *end* with one of those words therefore matches as well, so the inner type argument is silently substituted for the actual type in the generated metadata.

Example controller:

```ts
class Cat {}

class MyPromise<T> {
  value: T;
}

@Controller('cats')
export class AppController {
  @Get()
  findOne(): MyPromise<Cat> { return null; }
}
```

What the plugin emits today:

```js
openapi.ApiResponse({ status: 200, type: Cat })
```

`Cat` is a completely different class. The same bug affects DTO properties typed as `MyPromise<Cat>` (model-class visitor goes through the same `getTypeReferenceAsString` helper).

Also reproducible with anything ending in `Observable`, e.g. `AsyncObservable<Cat>`, `MyObservable<Cat>`.

## What is the new behavior?

Anchor the regex to the start of the type text (or to a fully qualified `import("...").` prefix) so only true `Promise<...>` / `Observable<...>` references are unwrapped. User-defined classes whose names happen to share the suffix are left alone, and no bogus `type: <inner>` is emitted.

## Additional context

- Added fixture `test/plugin/fixtures/app.controller-promise-prefix.ts` covering all three return types: standard `Promise<Cat>` (still unwraps), `MyPromise<Cat>` (no longer unwraps), `AsyncObservable<Cat>` (no longer unwraps).
- Added matching spec case in `test/plugin/controller-class-visitor.spec.ts`. The new case fails before the fix and passes after.
- All existing plugin tests still pass: `npx vitest run` 331/331; e2e 116/116; `npm run lint` reports no new errors.