### PR TITLE
fix(api-property): preserve nested array leaf type in @ApiProperty

### DIFF
--- a/lib/decorators/api-property.decorator.ts
+++ b/lib/decorators/api-property.decorator.ts
@@ -77,11 +77,24 @@ export function createApiPropertyDecorator(
   }
 
   if (Array.isArray(options.type)) {
+    // `getTypeIsArrayTuple` strips one level of array wrapping, so when
+    // `options.type` is still an array here the caller provided a nested
+    // array type (e.g. `type: [[String]]` or `type: [String], isArray: true`).
+    // Capture the inner type before reassignment - reading `options.type[0]`
+    // after the assignment below would index into the string `'array'` and
+    // produce `items.items.type === 'a'` (the first character of `'array'`).
+    const innerType = options.type[0];
     options.type = 'array';
     options.items = {
       type: 'array',
       items: {
-        type: options.type[0]
+        // Normalize built-in constructors (String, Number, Boolean, ...) to
+        // their OpenAPI primitive names; `JSON.stringify` would otherwise drop
+        // a raw constructor entirely from the emitted document.
+        type:
+          typeof innerType === 'function'
+            ? innerType.name.charAt(0).toLowerCase() + innerType.name.slice(1)
+            : innerType
       }
     };
   }

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -891,6 +891,31 @@ describe('SchemaObjectFactory', () => {
         required: ['testStringArray']
       });
     });
+
+    it('should resolve nested array type to the correct leaf type', () => {
+      class NestedArrayDto {
+        @ApiProperty({ type: [[String]] })
+        matrix: string[][];
+      }
+
+      const schemas = {};
+      schemaObjectFactory.exploreModelSchema(NestedArrayDto, schemas);
+      expect(schemas[NestedArrayDto.name]).toEqual({
+        type: 'object',
+        properties: {
+          matrix: {
+            type: 'array',
+            items: {
+              type: 'array',
+              items: {
+                type: 'string'
+              }
+            }
+          }
+        },
+        required: ['matrix']
+      });
+    });
   });
 
   describe('createEnumSchemaType', () => {


### PR DESCRIPTION
## Summary
- `@ApiProperty({ type: [[String]] })` (and the equivalent `type: [String], isArray: true`) was emitting `items.items.type === "a"` because `options.type[0]` was being read *after* `options.type` had been reassigned to the string `'array'`, indexing into the first character of `'array'`.
- Capture the inner type before the reassignment, and normalize built-in constructors (`String`, `Number`, `Boolean`, ...) to their OpenAPI primitive names so they actually appear in the JSON-serialized document (raw constructors are silently dropped by `JSON.stringify`).
- Bug was introduced in #903 (Jul 2021) and has been live ever since; no regression test exercised the nested-array branch of `createApiPropertyDecorator`.

## Test plan
- [x] New unit test in `test/services/schema-object-factory.spec.ts` — `should resolve nested array type to the correct leaf type` — fails on master with `items.items.type: "a"` and passes after the fix with `items.items.type: "string"`.
- [x] `npx vitest run test/services/schema-object-factory.spec.ts` — 49 passed.
- [x] `npx vitest run test/decorators test/services test/explorer test/utils` — 254 passed.
- [x] `npm run lint` — no new warnings (16 pre-existing warnings unchanged).
- [x] `npm run build` — clean.