### PR TITLE
fix(swagger): support const enum query params

### DIFF
--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -226,6 +226,18 @@ export class SchemaObjectFactory {
         }
       ) as ParameterObject[];
     }
+    if (this.isConstEnumObject(param.type as Record<string, any>)) {
+      const enumValues = getEnumValues(param.type as Record<string, any>);
+      const enumType = getEnumType(enumValues);
+      return {
+        ...param,
+        schema: {
+          type: enumType,
+          enum: enumValues
+        },
+        selfRequired: param.required
+      };
+    }
     if (this.isObjectLiteral(param.type)) {
       const schemaFromObjectLiteral = this.createFromObjectLiteral(
         param.name as string,

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -1162,6 +1162,40 @@ describe('SchemaObjectFactory', () => {
       );
       expect(paramResult.schema.$ref).toBeUndefined();
     });
+
+    it('should create enum schema for query params using SWC const-enum object metadata', () => {
+      const CampaignStatus = {
+        ACTIVE: 'active',
+        PAUSED: 'paused',
+        COMPLETED: 'completed'
+      } as const;
+      const schemas: Record<string, SchemasObject> = {};
+
+      const queryParams: ParamWithTypeMetadata[] = [
+        {
+          in: 'query',
+          type: CampaignStatus,
+          name: 'status',
+          required: false
+        } as any
+      ];
+
+      const result = schemaObjectFactory.createFromModel(queryParams, schemas);
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(
+        expect.objectContaining({
+          in: 'query',
+          name: 'status',
+          required: false,
+          schema: {
+            type: 'string',
+            enum: ['active', 'paused', 'completed']
+          },
+          selfRequired: false
+        })
+      );
+    });
   });
 
   describe('transformToArraySchemaProperty', () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?

When SWC emits const enum metadata as an object for a query parameter type, `SchemaObjectFactory#createQueryOrParamSchema()` treats that object as a literal object schema. That produces nested property metadata instead of an OpenAPI enum schema for the parameter.

Issue Number: Fixes #3909

## What is the new behavior?

`createQueryOrParamSchema()` now recognizes const-enum-like object metadata before the generic object literal branch and emits a parameter schema with `type` and `enum` values.

A regression test covers a query parameter whose `type` is a const-enum-style object.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Local checks:

- `npm test -- test/services/schema-object-factory.spec.ts`
- `npm run build`
- `npm run lint` (passes with existing warnings outside this change)
- `git diff --check`
