### PR TITLE
feat(swagger): support raw component schemas

### DIFF
--- a/e2e/validate-schema.e2e-spec.ts
+++ b/e2e/validate-schema.e2e-spec.ts
@@ -1,10 +1,12 @@
-import { INestApplication } from '@nestjs/common';
+import { Controller, Get, INestApplication } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { writeFileSync } from 'fs';
 import { OpenAPIV3 } from 'openapi-types';
 import { join } from 'path';
 import type { BaseIssue, BaseSchema } from 'valibot';
 import {
+  ApiResponse,
+  ApiSchema,
   DocumentBuilder,
   getSchemaPath,
   OpenAPIObject,
@@ -27,6 +29,25 @@ import { toJsonSchema } from '@valibot/to-json-schema';
 import type { ZodType } from 'zod';
 import SwaggerParser = require('@apidevtools/swagger-parser');
 
+@ApiSchema({
+  name: 'RawUnionResponse',
+  oneOf: [{ type: 'string' }, { type: 'number' }],
+  description: 'Raw union schema component'
+})
+class RawUnionResponse {}
+
+@Controller('raw-component-schemas')
+class RawComponentSchemaController {
+  @Get('union')
+  @ApiResponse({
+    status: 200,
+    type: RawUnionResponse
+  })
+  getRawUnionResponse() {
+    return null;
+  }
+}
+
 function asResponseObject(
   response: ResponseObject | { $ref: string } | undefined
 ) {
@@ -46,7 +67,7 @@ describe('Validate OpenAPI schema', () => {
       {
         module: class {},
         imports: [ApplicationModule],
-        controllers: [ExpressController]
+        controllers: [ExpressController, RawComponentSchemaController]
       },
       {
         logger: false
@@ -370,6 +391,23 @@ describe('Validate OpenAPI schema', () => {
   it('should add extension to root', () => {
     const document = SwaggerModule.createDocument(app, options, documentOptions);
     expect(document['x-test']).toEqual({ test: 'test' });
+  });
+
+  it('should register raw component schema with combinators', () => {
+    const document = SwaggerModule.createDocument(app, options, documentOptions);
+
+    const response = asResponseObject(
+      document.paths['/api/raw-component-schemas/union']['get']['responses'][
+        '200'
+      ]
+    );
+    expect(response.content!['application/json'].schema).toEqual({
+      $ref: '#/components/schemas/RawUnionResponse'
+    });
+    expect(document.components?.schemas?.RawUnionResponse).toEqual({
+      oneOf: [{ type: 'string' }, { type: 'number' }],
+      description: 'Raw union schema component'
+    });
   });
 
   it('should add extension to info', () => {

--- a/lib/decorators/api-schema.decorator.ts
+++ b/lib/decorators/api-schema.decorator.ts
@@ -1,17 +1,12 @@
 import { DECORATORS } from '../constants.js';
-import { SchemaObjectMetadata } from '../interfaces/schema-object-metadata.interface.js';
+import { SchemaObject } from '../interfaces/open-api-spec.interface.js';
 import { createClassDecorator } from './helpers.js';
 
-export interface ApiSchemaOptions extends Pick<SchemaObjectMetadata, 'name'> {
+export interface ApiSchemaOptions extends SchemaObject {
   /**
    * Name of the schema.
    */
   name?: string;
-
-  /**
-   * Description of the schema.
-   */
-  description?: string;
 }
 
 /**

--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -38,6 +38,8 @@ import { ParamWithTypeMetadata } from './parameter-metadata-accessor.js';
 import { StandardSchemaOpenApiConverter } from './standard-schema-openapi.converter.js';
 import { SwaggerTypesMapper } from './swagger-types-mapper.js';
 
+const schemaCombinators = ['oneOf', 'anyOf', 'allOf'] as const;
+
 export class SchemaObjectFactory {
   private readonly standardSchemaOpenApiConverter =
     new StandardSchemaOpenApiConverter(this.standardSchemaConverter);
@@ -336,7 +338,6 @@ export class SchemaObjectFactory {
         throw err;
       }
 
-      const schemaCombinators = ['oneOf', 'anyOf', 'allOf'];
       const declaredSchemaCombinator = schemaCombinators.find(
         (combinator) => combinator in property
       );
@@ -394,27 +395,36 @@ export class SchemaObjectFactory {
       Reflect.getMetadata(DECORATORS.API_EXTENSION, type) || {};
 
     const { schemaName, schemaProperties } = this.getSchemaMetadata(type);
+    const isRawSchema = this.isRawSchema(schemaProperties);
 
-    const typeDefinition: SchemaObject = {
-      type: 'object',
-      properties: mapValues(keyBy(propertiesWithType, 'name'), (property) => {
-        const keysToOmit = [
-          'name',
-          'isArray',
-          'enumName',
-          'enumSchema',
-          'selfRequired'
-        ];
-
-        if ('required' in property && Array.isArray(property.required)) {
-          return omit(property, keysToOmit);
+    const typeDefinition: SchemaObject = isRawSchema
+      ? {
+          ...extensionProperties,
+          ...schemaProperties
         }
+      : {
+          type: 'object',
+          properties: mapValues(
+            keyBy(propertiesWithType, 'name'),
+            (property) => {
+              const keysToOmit = [
+                'name',
+                'isArray',
+                'enumName',
+                'enumSchema',
+                'selfRequired'
+              ];
 
-        return omit(property, [...keysToOmit, 'required']);
-      }) as Record<string, SchemaObject | ReferenceObject>,
-      ...extensionProperties,
-      ...schemaProperties
-    };
+              if ('required' in property && Array.isArray(property.required)) {
+                return omit(property, keysToOmit);
+              }
+
+              return omit(property, [...keysToOmit, 'required']);
+            }
+          ) as Record<string, SchemaObject | ReferenceObject>,
+          ...extensionProperties,
+          ...schemaProperties
+        };
 
     const typeDefinitionRequiredFields = propertiesWithType
       .filter((property) =>
@@ -424,7 +434,7 @@ export class SchemaObjectFactory {
       )
       .map((property) => property.name);
 
-    if (typeDefinitionRequiredFields.length > 0) {
+    if (!isRawSchema && typeDefinitionRequiredFields.length > 0) {
       typeDefinition['required'] = typeDefinitionRequiredFields;
     }
 
@@ -446,6 +456,12 @@ export class SchemaObjectFactory {
       Reflect.getOwnMetadata(DECORATORS.API_SCHEMA, type) ?? [];
     const { name, ...schemaProperties } = schemas[schemas.length - 1] ?? {};
     return { schemaName: name ?? type.name, schemaProperties };
+  }
+
+  private isRawSchema(schemaProperties: Omit<ApiSchemaOptions, 'name'>) {
+    return schemaCombinators.some(
+      (combinator) => combinator in schemaProperties
+    );
   }
 
   mergePropertyWithMetadata(

--- a/test/explorer/swagger-explorer.spec.ts
+++ b/test/explorer/swagger-explorer.spec.ts
@@ -1716,6 +1716,58 @@ describe('SwaggerExplorer', () => {
       expect(schemas.ExtraModel2).toBeDefined();
       expect(schemas.ExtraModel).toBeDefined();
     });
+
+    it('when an extra model uses a raw top-level schema', () => {
+      @ApiSchema({
+        oneOf: [
+          { $ref: '#/components/schemas/Cat' },
+          { $ref: '#/components/schemas/Dog' }
+        ],
+        discriminator: {
+          propertyName: 'type',
+          mapping: {
+            cat: '#/components/schemas/Cat',
+            dog: '#/components/schemas/Dog'
+          }
+        }
+      })
+      class ExtraUnionModel {}
+
+      @Controller()
+      @ApiExtraModels(ExtraUnionModel)
+      class FooController {
+        @Get()
+        find() {
+          return true;
+        }
+      }
+
+      const explorer = new SwaggerExplorer(schemaObjectFactory);
+      explorer.exploreController(
+        {
+          instance: new FooController(),
+          metatype: FooController
+        } as InstanceWrapper<FooController>,
+        new ApplicationConfig(),
+        { modulePath: 'path' }
+      );
+
+      const schemas = explorer.getSchemas();
+
+      expect(schemas.ExtraUnionModel).toEqual({
+        oneOf: [
+          { $ref: '#/components/schemas/Cat' },
+          { $ref: '#/components/schemas/Dog' }
+        ],
+        discriminator: {
+          propertyName: 'type',
+          mapping: {
+            cat: '#/components/schemas/Cat',
+            dog: '#/components/schemas/Dog'
+          }
+        }
+      });
+    });
   });
   describe('when a controller is excluded', () => {
     class Foo {}

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -1099,6 +1099,42 @@ describe('SchemaObjectFactory', () => {
           'Represents a user update.'
         );
       });
+
+      it('should register raw top-level schemas with combinators', () => {
+        @ApiSchema({
+          name: 'Pet',
+          oneOf: [
+            { $ref: '#/components/schemas/Cat' },
+            { $ref: '#/components/schemas/Dog' }
+          ],
+          discriminator: {
+            propertyName: 'type',
+            mapping: {
+              cat: '#/components/schemas/Cat',
+              dog: '#/components/schemas/Dog'
+            }
+          }
+        })
+        class PetDto {}
+
+        const schemas: Record<string, SchemasObject> = {};
+
+        schemaObjectFactory.exploreModelSchema(PetDto, schemas);
+
+        expect(schemas['Pet']).toEqual({
+          oneOf: [
+            { $ref: '#/components/schemas/Cat' },
+            { $ref: '#/components/schemas/Dog' }
+          ],
+          discriminator: {
+            propertyName: 'type',
+            mapping: {
+              cat: '#/components/schemas/Cat',
+              dog: '#/components/schemas/Dog'
+            }
+          }
+        });
+      });
     });
 
     it('should include extension properties', () => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

`@ApiSchema()` metadata is always merged into a generated object schema. Even when a class-level schema declares `oneOf`, `anyOf`, or `allOf`, the resulting `components.schemas` entry still gets generated object scaffolding such as `type: 'object'` and `properties: {}`.

This prevents using a class-level placeholder as a raw top-level component schema for cases like `oneOf` plus `discriminator.mapping`.

Issue Number: Fixes #3886

## What is the new behavior?

`@ApiSchema()` now accepts the full `SchemaObject` shape. When a class-level schema declares `oneOf`, `anyOf`, or `allOf`, `SchemaObjectFactory` registers it as a raw top-level component schema instead of wrapping it in generated object metadata.

This lets users define component schemas such as:

```ts
@ApiSchema({
  name: 'Pet',
  oneOf: [
    { $ref: '#/components/schemas/Cat' },
    { $ref: '#/components/schemas/Dog' },
  ],
  discriminator: {
    propertyName: 'type',
    mapping: {
      cat: '#/components/schemas/Cat',
      dog: '#/components/schemas/Dog',
    },
  },
})
class PetDto {}
```

The existing object-schema behavior is preserved for regular DTOs and for `@ApiSchema()` options without schema combinators.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Local checks:

- `npm test -- test/services/schema-object-factory.spec.ts`
- `npm test -- test/explorer/swagger-explorer.spec.ts`
- `npm run build`
- `npm run lint` (passes with existing warnings outside this change)
- `npm exec prettier -- --check lib/decorators/api-schema.decorator.ts lib/services/schema-object-factory.ts test/services/schema-object-factory.spec.ts test/explorer/swagger-explorer.spec.ts`
- `git diff --check`

Note: local Node is `v20.18.3`, while some dependencies now warn for `^20.19.0 || >=22.12.0`. I installed missing optional native packages for `rolldown` and `oxlint` without changing the lockfile to run the checks.
