### PR TITLE
feat(swagger): add summary field to Tag Object (OpenAPI 3.2)

### DIFF
--- a/lib/document-builder.ts
+++ b/lib/document-builder.ts
@@ -118,12 +118,13 @@ export class DocumentBuilder {
     name: string,
     description = '',
     externalDocs?: ExternalDocumentationObject,
-    options?: { parent?: string; kind?: string }
+    options?: { summary?: string; parent?: string; kind?: string }
   ): this {
     this.document.tags = this.document.tags.concat(
       pickBy(
         {
           name,
+          summary: options?.summary,
           description,
           externalDocs,
           parent: options?.parent,

--- a/lib/interfaces/open-api-spec.interface.ts
+++ b/lib/interfaces/open-api-spec.interface.ts
@@ -194,6 +194,7 @@ export type LinkParametersObject = Record<string, any>;
 export type HeaderObject = BaseParameterObject;
 export interface TagObject {
   name: string;
+  summary?: string;
   description?: string;
   externalDocs?: ExternalDocumentationObject;
   parent?: string;

--- a/test/document-builder.spec.ts
+++ b/test/document-builder.spec.ts
@@ -78,6 +78,40 @@ describe('DocumentBuilder', () => {
       });
     });
 
+    it('should add tag with summary option', () => {
+      const builder = new DocumentBuilder();
+      builder.addTag('Cats', 'Cat operations', undefined, {
+        summary: 'Cats'
+      });
+      const doc = builder.build();
+
+      expect(doc.tags).toHaveLength(1);
+      expect(doc.tags[0]).toEqual({
+        name: 'Cats',
+        description: 'Cat operations',
+        summary: 'Cats'
+      });
+    });
+
+    it('should add tag with summary, parent and kind options', () => {
+      const builder = new DocumentBuilder();
+      builder.addTag('Cats', 'Cat operations', undefined, {
+        summary: 'Cats',
+        parent: 'Animals',
+        kind: 'navigation'
+      });
+      const doc = builder.build();
+
+      expect(doc.tags).toHaveLength(1);
+      expect(doc.tags[0]).toEqual({
+        name: 'Cats',
+        description: 'Cat operations',
+        summary: 'Cats',
+        parent: 'Animals',
+        kind: 'navigation'
+      });
+    });
+
     it('should add tag with externalDocs and hierarchy options', () => {
       const builder = new DocumentBuilder();
       builder.addTag(


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

OpenAPI 3.2 added three new fields to the Tag Object: `parent`, `kind`, and `summary`. PR #3725 added support for `parent` and `kind`, but `summary` was not included.

Per the [OpenAPI 3.2 spec](https://spec.openapis.org/oas/v3.2.0.html#tag-object):

> `summary` | `string` | A short summary of the tag, used for display purposes.

## What is the new behavior?

- `TagObject` interface now includes optional `summary` field.
- `DocumentBuilder.addTag()` accepts `summary` in its 4th-parameter options object, alongside the existing `parent` and `kind`.

```ts
const config = new DocumentBuilder()
  .addTag('account-updates', 'Account update operations', undefined, {
    summary: 'Account Updates'
  })
  .build();
```

`ApiTagOptions` and the `@ApiTags()` decorator are intentionally not extended in this PR — their hierarchy metadata (`parent`/`kind`) is currently discarded (see the existing tests in `test/decorators/api-use-tags.decorator.spec.ts` which assert this). I'll open a separate issue for that so it can be discussed independently.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

Refs #3725.