### PR TITLE
fix(swagger): include DTO name in circular dependency error

### DIFF
--- a/lib/services/schema-object-factory.ts
+++ b/lib/services/schema-object-factory.ts
@@ -584,8 +584,13 @@ export class SchemaObjectFactory {
     pendingSchemaRefs: string[]
   ): SchemaObjectMetadata {
     if (isUndefined(trueMetadataType)) {
+      const errorIn =
+        pendingSchemaRefs?.length > 0
+          ? `in "${pendingSchemaRefs[pendingSchemaRefs.length - 1]}" `
+          : '';
+
       throw new Error(
-        `A circular dependency has been detected (property key: "${key}"). To resolve this, use a lazy resolver for the property type ("type: () => ClassType") on each side of the relationship, or break the cycle by introducing a reference via @ApiExtraModels.`
+        `A circular dependency has been detected ${errorIn}(property key: "${key}"). To resolve this, use a lazy resolver for the property type ("type: () => ClassType") on each side of the relationship, or break the cycle by introducing a reference via @ApiExtraModels.`
       );
     }
     let { schemaName: schemaObjectName } = this.getSchemaMetadata(


### PR DESCRIPTION
Improve the circular dependency error message by including the DTO name where the unresolved relationship was detected.

This makes debugging easier in large projects where the current message does not provide enough context to identify the source of the error.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The circular dependency error message did not indicate where the error was occurring, or which object it was affecting.

Issue Number: N/A


## What is the new behavior?

Class/object name showing before key name


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information
 "@nestjs/swagger": "^7.1.1",
