### PR TITLE
feat(swagger): warn when @ApiTags receives hierarchy fields

### DIFF
--- a/lib/decorators/api-use-tags.decorator.ts
+++ b/lib/decorators/api-use-tags.decorator.ts
@@ -14,11 +14,7 @@ export function ApiTags(...tags: (string | ApiTagOptions)[]) {
       return tag;
     }
     if (tag.parent !== undefined || tag.kind !== undefined) {
-      logger.warn(
-        `Tag "${tag.name}" was declared with hierarchy fields (parent/kind) on @ApiTags, ` +
-          `which are dropped. Define them via DocumentBuilder.addTag("${tag.name}", ` +
-          `description, { parent, kind }) so they reach the root-level tags of the document.`
-      );
+      logger.warn(`Tag "${tag.name}" includes hierarchy fields (parent/kind) defined via @ApiTags, but those values are ignored there. Define them with DocumentBuilder.addTag("${tag.name}", description, { parent, kind }) to include them in the document's root-level tags.`);
     }
     return tag.name;
   });

--- a/lib/decorators/api-use-tags.decorator.ts
+++ b/lib/decorators/api-use-tags.decorator.ts
@@ -1,13 +1,26 @@
+import { Logger } from '@nestjs/common';
 import { DECORATORS } from '../constants';
 import { ApiTagOptions } from '../interfaces/open-api-spec.interface';
 import { createMixedDecorator } from './helpers';
+
+const logger = new Logger('ApiTags');
 
 /**
  * @publicApi
  */
 export function ApiTags(...tags: (string | ApiTagOptions)[]) {
-  const normalizedTags = tags.map((tag) =>
-    typeof tag === 'string' ? tag : tag.name
-  );
+  const normalizedTags = tags.map((tag) => {
+    if (typeof tag === 'string') {
+      return tag;
+    }
+    if (tag.parent !== undefined || tag.kind !== undefined) {
+      logger.warn(
+        `Tag "${tag.name}" was declared with hierarchy fields (parent/kind) on @ApiTags, ` +
+          `which are dropped. Define them via DocumentBuilder.addTag("${tag.name}", ` +
+          `description, { parent, kind }) so they reach the root-level tags of the document.`
+      );
+    }
+    return tag.name;
+  });
   return createMixedDecorator(DECORATORS.API_TAGS, normalizedTags);
 }

--- a/test/decorators/api-use-tags.decorator.spec.ts
+++ b/test/decorators/api-use-tags.decorator.spec.ts
@@ -1,6 +1,13 @@
 import 'reflect-metadata';
+import { Logger } from '@nestjs/common';
 import { DECORATORS } from '../../lib/constants';
 import { ApiTags } from '../../lib/decorators/api-use-tags.decorator';
+
+// Hierarchy fields (parent/kind) on @ApiTags emit a warning when the decorator
+// runs — which, for class-level decorators, happens at collection time. Mock
+// the logger at module scope so that output stays clean; the dedicated suite
+// below clears and asserts on this same spy.
+const warnSpy = vi.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
 
 describe('ApiTags', () => {
   describe('with string arguments (backward compatibility)', () => {
@@ -100,6 +107,64 @@ describe('ApiTags', () => {
         TestController.prototype.complexMixed
       );
       expect(tags).toEqual(['Cats', 'Dogs', 'Birds']);
+    });
+  });
+
+  describe('warns when hierarchy fields are used', () => {
+    beforeEach(() => {
+      warnSpy.mockClear();
+    });
+
+    it('should warn when parent is set on @ApiTags', () => {
+      class TestController {
+        @ApiTags({ name: 'Cats', parent: 'Animals' })
+        withParent() {}
+      }
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('"Cats"');
+      expect(warnSpy.mock.calls[0][0]).toContain('parent/kind');
+    });
+
+    it('should warn when kind is set on @ApiTags', () => {
+      class TestController {
+        @ApiTags({ name: 'Internal', kind: 'reference' })
+        withKind() {}
+      }
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy.mock.calls[0][0]).toContain('"Internal"');
+    });
+
+    it('should warn once per object tag carrying hierarchy fields', () => {
+      class TestController {
+        @ApiTags(
+          { name: 'Cats', parent: 'Animals' },
+          'Dogs',
+          { name: 'Birds', kind: 'navigation' }
+        )
+        mixed() {}
+      }
+
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('should not warn for plain string tags', () => {
+      class TestController {
+        @ApiTags('Cats', 'Pets')
+        plain() {}
+      }
+
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not warn for object tags without hierarchy fields', () => {
+      class TestController {
+        @ApiTags({ name: 'Cats' })
+        nameOnly() {}
+      }
+
+      expect(warnSpy).not.toHaveBeenCalled();
     });
   });
 

--- a/test/explorers/api-use-tags.explorer.spec.ts
+++ b/test/explorers/api-use-tags.explorer.spec.ts
@@ -1,9 +1,14 @@
 import 'reflect-metadata';
+import { Logger } from '@nestjs/common';
 import { ApiTags } from '../../lib/decorators/api-use-tags.decorator';
 import {
   exploreApiTagsMetadata,
   exploreGlobalApiTagsMetadata
 } from '../../lib/explorers/api-use-tags.explorer';
+
+// Some fixtures below declare hierarchy fields (parent/kind) on @ApiTags, which
+// emit a warning at class-decoration time. Silence it to keep test output clean.
+vi.spyOn(Logger.prototype, 'warn').mockImplementation(() => {});
 
 describe('api-use-tags.explorer', () => {
   describe('exploreGlobalApiTagsMetadata', () => {


### PR DESCRIPTION
## PR Type

- [x] Feature
- [ ] Bug fix
- [ ] Other

## What is the current behavior?

`@ApiTags` accepts the object form `{ name, parent, kind }` (added in #3725, released in v11.4.0), but it normalizes every entry to its `name`, **silently discarding `parent` and `kind`**:

```ts
const normalizedTags = tags.map((tag) =>
  typeof tag === 'string' ? tag : tag.name
);
```

The decorator-level hierarchy metadata never reaches `document.tags`, so the OpenAPI 3.2 tag hierarchy is lost with no feedback to the user. Root-level tag hierarchy is only honored when declared via `DocumentBuilder.addTag(name, description, { parent, kind })`.

Issue: #3922

## What is the new behavior?

When `parent` or `kind` is set on an `@ApiTags` object argument, the decorator now emits a runtime warning that points users to `DocumentBuilder.addTag()` — the supported way to define a root-level tag hierarchy.

```
[ApiTags] Tag "Sessions" was declared with hierarchy fields (parent/kind) on
@ApiTags, which are dropped. Define them via DocumentBuilder.addTag("Sessions",
description, { parent, kind }) so they reach the root-level tags of the document.
```

This implements the resolution agreed in #3922 ("Reject / warn"). String arguments and object arguments that only carry `name` are unaffected — no warning is emitted.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

Tag normalization is unchanged; only a diagnostic warning is added.

## Other information

Closes #3922. Tests added for the warn / no-warn cases in `test/decorators/api-use-tags.decorator.spec.ts`.
