### PR TITLE
fix(swagger): type Tag Object kind as a free-form string

### DIFF
--- a/lib/document-builder.ts
+++ b/lib/document-builder.ts
@@ -118,7 +118,7 @@ export class DocumentBuilder {
     name: string,
     description = '',
     externalDocs?: ExternalDocumentationObject,
-    options?: { parent?: string; kind?: 'navigation' | 'reference' }
+    options?: { parent?: string; kind?: string }
   ): this {
     this.document.tags = this.document.tags.concat(
       pickBy(

--- a/lib/interfaces/open-api-spec.interface.ts
+++ b/lib/interfaces/open-api-spec.interface.ts
@@ -197,13 +197,23 @@ export interface TagObject {
   description?: string;
   externalDocs?: ExternalDocumentationObject;
   parent?: string;
-  kind?: 'navigation' | 'reference';
+  /**
+   * A machine-readable string to categorize the tag (OpenAPI 3.2+).
+   * The value is free-form; commonly used values are `nav`, `badge`
+   * and `audience`.
+   */
+  kind?: string;
 }
 
 export interface ApiTagOptions {
   name: string;
   parent?: string;
-  kind?: 'navigation' | 'reference';
+  /**
+   * A machine-readable string to categorize the tag (OpenAPI 3.2+).
+   * The value is free-form; commonly used values are `nav`, `badge`
+   * and `audience`.
+   */
+  kind?: string;
 }
 
 export type ExamplesObject = Record<string, ExampleObject | ReferenceObject>;

--- a/test/document-builder.spec.ts
+++ b/test/document-builder.spec.ts
@@ -34,7 +34,7 @@ describe('DocumentBuilder', () => {
     it('should add tag with kind option', () => {
       const builder = new DocumentBuilder();
       builder.addTag('Internal', 'Internal APIs', undefined, {
-        kind: 'reference'
+        kind: 'audience'
       });
       const doc = builder.build();
 
@@ -42,7 +42,22 @@ describe('DocumentBuilder', () => {
       expect(doc.tags[0]).toEqual({
         name: 'Internal',
         description: 'Internal APIs',
-        kind: 'reference'
+        kind: 'audience'
+      });
+    });
+
+    it('should add tag with a free-form (custom) kind value', () => {
+      const builder = new DocumentBuilder();
+      builder.addTag('Beta', 'Beta endpoints', undefined, {
+        kind: 'lifecycle-stage'
+      });
+      const doc = builder.build();
+
+      expect(doc.tags).toHaveLength(1);
+      expect(doc.tags[0]).toEqual({
+        name: 'Beta',
+        description: 'Beta endpoints',
+        kind: 'lifecycle-stage'
       });
     });
 
@@ -50,7 +65,7 @@ describe('DocumentBuilder', () => {
       const builder = new DocumentBuilder();
       builder.addTag('Cats', 'Cat operations', undefined, {
         parent: 'Animals',
-        kind: 'navigation'
+        kind: 'nav'
       });
       const doc = builder.build();
 
@@ -59,7 +74,7 @@ describe('DocumentBuilder', () => {
         name: 'Cats',
         description: 'Cat operations',
         parent: 'Animals',
-        kind: 'navigation'
+        kind: 'nav'
       });
     });
 
@@ -69,7 +84,7 @@ describe('DocumentBuilder', () => {
         'Cats',
         'Cat operations',
         { url: 'https://example.com/cats' },
-        { parent: 'Animals', kind: 'navigation' }
+        { parent: 'Animals', kind: 'nav' }
       );
       const doc = builder.build();
 
@@ -79,7 +94,7 @@ describe('DocumentBuilder', () => {
         description: 'Cat operations',
         externalDocs: { url: 'https://example.com/cats' },
         parent: 'Animals',
-        kind: 'navigation'
+        kind: 'nav'
       });
     });
 


### PR DESCRIPTION
## PR Type

- [x] Bug fix
- [ ] Feature
- [ ] Other

## What is the current behavior?

`TagObject.kind`, `ApiTagOptions.kind` and the `DocumentBuilder.addTag()` `options.kind` parameter are all typed as:

```ts
kind?: 'navigation' | 'reference';
```

This closed union was introduced in #3725 (v11.4.0). However, the OpenAPI 3.2 Tag Object defines `kind` as a **machine-readable, free-form string**. The spec lists only `nav`, `badge` and `audience` as *conventional* values, and explicitly does not mandate them.

As a result the current type:

- rejects every conventional value the spec actually names (`nav`, `badge`, `audience`);
- offers two values (`navigation`, `reference`) that do not appear in the spec at all;
- rejects any custom/vendor value, even though the spec permits free-form text.

```ts
// rejected today, valid per OpenAPI 3.2:
builder.addTag('Cats', '', undefined, { kind: 'nav' });
```

Spec references: [OpenAPI 3.2 Tag Object](https://spec.openapis.org/oas/v3.2.0.html#tag-object), [learn.openapis.org — Enhanced Tags](https://learn.openapis.org/specification/tags.html).

## What is the new behavior?

`kind` is widened to `string` on `TagObject`, `ApiTagOptions` and `DocumentBuilder.addTag()`, with a JSDoc note pointing to the conventional values (`nav`, `badge`, `audience`). Any spec-conventional or custom value is now accepted.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

The type is widened, not narrowed — every value that compiled before still compiles. Existing `addTag` tests were updated to use spec-conventional values, and a test for a free-form custom value was added.

## Other information

Part of the OpenAPI 3.2 tag-hierarchy support added in #3725.
