### PR TITLE
fix(plugin): preserve package import paths

### DIFF
--- a/lib/plugin/utils/plugin-utils.ts
+++ b/lib/plugin/utils/plugin-utils.ts
@@ -129,6 +129,122 @@ export function getTypeReferenceAsString(
 }
 
 /**
+ * Best-effort extraction of a package-level import specifier from a type node.
+ * For a type imported as `import { ItemStatus } from '@repro/shared/messages';`,
+ * this returns `import("@repro/shared/messages").ItemStatus`.
+ */
+export function getImportedTypeReference(
+  typeNode: ts.TypeNode | undefined,
+  typeChecker: ts.TypeChecker
+): string | undefined {
+  const typeReferenceNode = getImportableTypeReferenceNode(typeNode);
+  if (!typeReferenceNode) {
+    return;
+  }
+
+  const typeName = typeReferenceNode.typeName;
+  if (ts.isQualifiedName(typeName)) {
+    const namespaceSymbol = typeChecker.getSymbolAtLocation(typeName.left);
+    const namespaceImport = namespaceSymbol?.declarations?.find(
+      ts.isNamespaceImport
+    );
+
+    if (
+      !namespaceImport ||
+      !ts.isImportDeclaration(namespaceImport.parent.parent) ||
+      !ts.isStringLiteral(namespaceImport.parent.parent.moduleSpecifier)
+    ) {
+      return;
+    }
+
+    const moduleSpecifier = namespaceImport.parent.parent.moduleSpecifier.text;
+    if (!isPackageSpecifier(moduleSpecifier)) {
+      return;
+    }
+    return `import("${moduleSpecifier}").${typeName.right.text}`;
+  }
+
+  const symbol = typeChecker.getSymbolAtLocation(typeName);
+  const declaration = symbol?.declarations?.find(
+    (item): item is ts.ImportClause | ts.ImportSpecifier =>
+      ts.isImportClause(item) || ts.isImportSpecifier(item)
+  );
+
+  if (!declaration) {
+    return;
+  }
+
+  const importDeclaration = ts.isImportClause(declaration)
+    ? declaration.parent
+    : declaration.parent.parent.parent;
+  if (
+    !ts.isImportDeclaration(importDeclaration) ||
+    !ts.isStringLiteral(importDeclaration.moduleSpecifier)
+  ) {
+    return;
+  }
+
+  const moduleSpecifier = importDeclaration.moduleSpecifier.text;
+  if (!isPackageSpecifier(moduleSpecifier)) {
+    return;
+  }
+
+  const importedName = ts.isImportClause(declaration)
+    ? 'default'
+    : (declaration.propertyName?.text ?? declaration.name.text);
+  return `import("${moduleSpecifier}").${importedName}`;
+}
+
+function getImportableTypeReferenceNode(
+  typeNode: ts.TypeNode | undefined
+): ts.TypeReferenceNode | undefined {
+  if (!typeNode) {
+    return undefined;
+  }
+  if (ts.isTypeReferenceNode(typeNode)) {
+    if (
+      ts.isIdentifier(typeNode.typeName) &&
+      ['Array', 'ReadonlyArray'].includes(typeNode.typeName.text) &&
+      typeNode.typeArguments?.length === 1
+    ) {
+      return getImportableTypeReferenceNode(typeNode.typeArguments[0]);
+    }
+    return typeNode;
+  }
+  if (ts.isArrayTypeNode(typeNode)) {
+    return getImportableTypeReferenceNode(typeNode.elementType);
+  }
+  if (ts.isUnionTypeNode(typeNode)) {
+    const candidates = typeNode.types.filter(
+      (item) =>
+        item.kind !== ts.SyntaxKind.UndefinedKeyword &&
+        item.kind !== ts.SyntaxKind.NullKeyword &&
+        !(
+          ts.isLiteralTypeNode(item) &&
+          item.literal.kind === ts.SyntaxKind.NullKeyword
+        )
+    );
+    return candidates.length === 1
+      ? getImportableTypeReferenceNode(candidates[0])
+      : undefined;
+  }
+  if (ts.isParenthesizedTypeNode(typeNode)) {
+    return getImportableTypeReferenceNode(typeNode.type);
+  }
+  if (ts.isTypeOperatorNode(typeNode)) {
+    return getImportableTypeReferenceNode(typeNode.type);
+  }
+}
+
+function isPackageSpecifier(moduleSpecifier: string): boolean {
+  return (
+    !moduleSpecifier.startsWith('.') &&
+    !isAbsolute(moduleSpecifier) &&
+    (moduleSpecifier.startsWith('@') || moduleSpecifier.includes('/'))
+  );
+}
+
+/**
  * Returns `true` when the supplied type text refers to a top-level
  * `Promise<...>` or `Observable<...>` instantiation.
  *
@@ -177,7 +293,7 @@ export function replaceImportPath(
     );
   }
 
-  let importPath = /\(\"([^)]).+(\")/.exec(typeReference)[0];
+  let importPath = /\("([^)]).+(")/.exec(typeReference)[0];
   if (!importPath) {
     return { typeReference: undefined, importPath: null };
   }
@@ -188,6 +304,10 @@ export function replaceImportPath(
   // have introduced in the import path so that posix.relative can correctly
   // compute a relative path against the (non-encoded) file name.
   const decodedImportPath = safeDecodeURIComponent(importPath);
+  const isPackagePath =
+    (decodedImportPath.startsWith('@') || decodedImportPath.includes('/')) &&
+    !decodedImportPath.startsWith('.') &&
+    !isAbsolute(decodedImportPath);
 
   try {
     if (isAbsolute(decodedImportPath)) {
@@ -204,6 +324,36 @@ export function replaceImportPath(
       importPath: null
     };
   } catch {
+    if (isPackagePath) {
+      const packageTypeReference = options.esmCompatible
+        ? typeReference
+        : typeReference.replace('import', 'require');
+
+      if (options.readonly) {
+        const { typeName, typeImportStatement } =
+          convertToAsyncImport(packageTypeReference);
+        return {
+          typeReference: typeImportStatement ?? packageTypeReference,
+          typeName,
+          importPath: decodedImportPath
+        };
+      }
+
+      if (options.esmCompatible) {
+        const { typeName, typeImportStatement } =
+          convertToAsyncImport(typeReference);
+        return {
+          typeReference: `(${typeImportStatement}).${typeName}`,
+          importPath: decodedImportPath
+        };
+      }
+
+      return {
+        typeReference: packageTypeReference,
+        importPath: decodedImportPath
+      };
+    }
+
     const from = options?.readonly
       ? safeDecodeURIComponent(convertPath(options.pathToSource))
       : getOutputDir(fileName, options);

--- a/lib/plugin/visitors/model-class.visitor.ts
+++ b/lib/plugin/visitors/model-class.visitor.ts
@@ -24,6 +24,7 @@ import {
   canReferenceNode,
   convertPath,
   extractTypeArgumentIfArray,
+  getImportedTypeReference,
   getDecoratorOrUndefinedByNames,
   getOutputExtension,
   getStringLiteralUnionValues,
@@ -362,7 +363,8 @@ export class ModelClassVisitor extends AbstractFileVisitor {
         typeChecker,
         existingProperties,
         hostFilename,
-        options
+        options,
+        sourceFile
       ),
       ...this.createDescriptionAndTsDocTagPropertyAssignments(
         factory,
@@ -415,7 +417,8 @@ export class ModelClassVisitor extends AbstractFileVisitor {
     typeChecker: ts.TypeChecker,
     existingProperties: ts.NodeArray<ts.PropertyAssignment>,
     hostFilename: string,
-    options: PluginOptions
+    options: PluginOptions,
+    sourceFile?: ts.SourceFile
   ): ts.PropertyAssignment[] {
     const key = 'type';
     if (hasPropertyKey(key, existingProperties)) {
@@ -506,7 +509,8 @@ export class ModelClassVisitor extends AbstractFileVisitor {
             typeChecker,
             existingProperties,
             hostFilename,
-            options
+            options,
+            sourceFile
           );
           if (!isNullable) {
             return propertyAssignments;
@@ -550,6 +554,13 @@ export class ModelClassVisitor extends AbstractFileVisitor {
     }
 
     const typeReferenceDescriptor = getTypeReferenceAsString(type, typeChecker);
+    if (node && typeReferenceDescriptor.typeName) {
+      const importedTypeReference = getImportedTypeReference(node, typeChecker);
+      if (importedTypeReference) {
+        typeReferenceDescriptor.typeName = importedTypeReference;
+      }
+    }
+
     if (!typeReferenceDescriptor.typeName) {
       return [];
     }
@@ -768,6 +779,18 @@ export class ModelClassVisitor extends AbstractFileVisitor {
     }
 
     const typeReferenceDescriptor = { typeName: getText(type, typeChecker) };
+    if (typeReferenceDescriptor.typeName) {
+      const typeNode = (node as any).type;
+      if (typeNode) {
+        const importedTypeReference = getImportedTypeReference(
+          typeNode,
+          typeChecker
+        );
+        if (importedTypeReference) {
+          typeReferenceDescriptor.typeName = importedTypeReference;
+        }
+      }
+    }
     const enumIdentifier = typeReferenceToIdentifier(
       typeReferenceDescriptor,
       hostFilename,

--- a/test/plugin/fixtures/package-imports/apps/api/src/item.dto.ts
+++ b/test/plugin/fixtures/package-imports/apps/api/src/item.dto.ts
@@ -1,0 +1,15 @@
+import { UUID } from 'crypto';
+import { ItemStatus, ItemStatus as StatusAlias } from '@repro/shared/messages';
+import * as SharedMessages from '@repro/shared/messages';
+
+class LocalStatus {}
+
+export class ItemDto {
+  status!: ItemStatus;
+  aliasedStatus!: StatusAlias;
+  statusList!: ItemStatus[];
+  nullableStatus!: ItemStatus | null;
+  namespacedStatus!: SharedMessages.ItemStatus;
+  uuid!: UUID;
+  localStatus!: LocalStatus;
+}

--- a/test/plugin/fixtures/package-imports/packages/shared/dist/messages/item.d.ts
+++ b/test/plugin/fixtures/package-imports/packages/shared/dist/messages/item.d.ts
@@ -1,0 +1,4 @@
+export declare enum ItemStatus {
+  Active = 'active',
+  Inactive = 'inactive'
+}

--- a/test/plugin/fixtures/package-imports/tsconfig.json
+++ b/test/plugin/fixtures/package-imports/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "experimentalDecorators": true,
+    "module": "CommonJS",
+    "newLine": "lf",
+    "noEmitHelpers": true,
+    "outDir": "apps/api/dist",
+    "paths": {
+      "@repro/shared/messages": ["packages/shared/dist/messages/item.d.ts"]
+    },
+    "rootDir": "apps/api/src",
+    "strict": true,
+    "target": "ES2020"
+  },
+  "include": ["apps/api/src/**/*.ts"]
+}

--- a/test/plugin/package-imports.spec.ts
+++ b/test/plugin/package-imports.spec.ts
@@ -1,0 +1,117 @@
+import { join } from 'path';
+import * as ts from 'typescript';
+import { before } from '../../lib/plugin/compiler-plugin';
+import { getImportedTypeReference } from '../../lib/plugin/utils/plugin-utils';
+
+function createFixtureProgram() {
+  const projectRoot = join(__dirname, 'fixtures', 'package-imports');
+  const parsedCmd = ts.getParsedCommandLineOfConfigFile(
+    join(projectRoot, 'tsconfig.json'),
+    undefined,
+    ts.sys as unknown as ts.ParseConfigFileHost
+  );
+  const program = ts.createProgram({
+    options: parsedCmd!.options,
+    rootNames: parsedCmd!.fileNames,
+    projectReferences: parsedCmd!.projectReferences
+  });
+  const sourceFile = program.getSourceFile(
+    join(projectRoot, 'apps', 'api', 'src', 'item.dto.ts')
+  )!;
+
+  return { program, sourceFile };
+}
+
+function getFixtureProperty(name: string) {
+  const { program, sourceFile } = createFixtureProgram();
+  const classDeclaration = sourceFile.statements.find(
+    (statement): statement is ts.ClassDeclaration =>
+      ts.isClassDeclaration(statement) && statement.name?.text === 'ItemDto'
+  )!;
+  const property = (
+    classDeclaration.members as ts.NodeArray<ts.PropertyDeclaration>
+  ).find((member) => member.name.getText(sourceFile) === name)!;
+
+  return {
+    checker: program.getTypeChecker(),
+    property
+  };
+}
+
+describe('package imports', () => {
+  describe('getImportedTypeReference', () => {
+    it('should preserve package import specifiers for named, aliased, array, nullable, and namespace references', () => {
+      const { checker, property: status } = getFixtureProperty('status');
+      const { property: aliasedStatus } = getFixtureProperty('aliasedStatus');
+      const { property: statusList } = getFixtureProperty('statusList');
+      const { property: nullableStatus } = getFixtureProperty('nullableStatus');
+      const { property: namespacedStatus } =
+        getFixtureProperty('namespacedStatus');
+
+      expect(getImportedTypeReference(status.type, checker)).toBe(
+        'import("@repro/shared/messages").ItemStatus'
+      );
+      expect(getImportedTypeReference(aliasedStatus.type, checker)).toBe(
+        'import("@repro/shared/messages").ItemStatus'
+      );
+      expect(getImportedTypeReference(statusList.type, checker)).toBe(
+        'import("@repro/shared/messages").ItemStatus'
+      );
+      expect(getImportedTypeReference(nullableStatus.type, checker)).toBe(
+        'import("@repro/shared/messages").ItemStatus'
+      );
+      expect(getImportedTypeReference(namespacedStatus.type, checker)).toBe(
+        'import("@repro/shared/messages").ItemStatus'
+      );
+    });
+
+    it('should ignore bare package imports and local types', () => {
+      const { checker, property: uuid } = getFixtureProperty('uuid');
+      const { property: localStatus } = getFixtureProperty('localStatus');
+
+      expect(getImportedTypeReference(uuid.type, checker)).toBeUndefined();
+      expect(
+        getImportedTypeReference(localStatus.type, checker)
+      ).toBeUndefined();
+    });
+  });
+
+  it('should preserve package import paths in generated metadata', () => {
+    const { program, sourceFile } = createFixtureProgram();
+    let outputText = '';
+
+    const emitResult = program.emit(
+      sourceFile,
+      (_fileName, text) => {
+        outputText = text;
+      },
+      undefined,
+      false,
+      {
+        before: [before({}, program)]
+      }
+    );
+
+    expect(emitResult.emitSkipped).toBe(false);
+    expect(outputText).toContain(
+      `status: { required: true, enum: require("@repro/shared/messages").ItemStatus }`
+    );
+    expect(outputText).toContain(
+      `aliasedStatus: { required: true, enum: require("@repro/shared/messages").ItemStatus }`
+    );
+    expect(outputText).toContain(
+      `statusList: { required: true, enum: require("@repro/shared/messages").ItemStatus, isArray: true }`
+    );
+    expect(outputText).toContain(
+      `nullableStatus: { required: true, nullable: true, enum: require("@repro/shared/messages").ItemStatus }`
+    );
+    expect(outputText).toContain(
+      `namespacedStatus: { required: true, enum: require("@repro/shared/messages").ItemStatus }`
+    );
+    expect(outputText).toContain(
+      `uuid: { required: true, type: () => Object }`
+    );
+    expect(outputText).not.toContain('packages/shared/dist/messages');
+    expect(outputText).not.toContain(`require("crypto").UUID`);
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When the CLI plugin sees a DTO property typed from a workspace package import such as `@repro/shared/messages`, TypeScript may resolve the type to the package physical output path. The generated `_OPENAPI_METADATA_FACTORY()` can then emit a filesystem-relative `require()` into `packages/shared/dist/...`, which is not stable at runtime after the package is installed from `node_modules`.

Issue Number: Fixes #3937


## What is the new behavior?

The model visitor now preserves explicit package import specifiers for imported property/enum types before normalizing paths. Package-style references keep emitting package-based `require()` calls, while relative and built-in/bare module behavior stays unchanged.

A regression fixture covers a monorepo-style DTO importing an enum from `@repro/shared/messages` and asserts the emitted metadata uses `require("@repro/shared/messages").ItemStatus` instead of a resolved sibling package path.


## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

Docs were not updated because this is a CLI plugin code-generation bug fix with regression coverage.

Local validation:

```bash
npm test -- test/plugin/plugin-utils.spec.ts test/plugin/model-class-visitor.spec.ts
npm test -- test/plugin
npm run build -- --pretty false
npm exec -- prettier --check lib/plugin/utils/plugin-utils.ts lib/plugin/visitors/model-class.visitor.ts test/plugin/plugin-utils.spec.ts test/plugin/model-class-visitor.spec.ts test/plugin/fixtures/package-imports/apps/api/src/item.dto.ts test/plugin/fixtures/package-imports/packages/shared/dist/messages/item.d.ts test/plugin/fixtures/package-imports/tsconfig.json
npm run lint
git diff --check
```

Note: local install required restoring optional native packages for Vitest/oxlint on macOS; no package manifest or lockfile changes are included.