### PR TITLE
fix(mimetype-content-wrapper): clone object per mimetype to avoid shared references

### DIFF
--- a/lib/services/mimetype-content-wrapper.ts
+++ b/lib/services/mimetype-content-wrapper.ts
@@ -1,3 +1,4 @@
+import { cloneDeep } from 'lodash';
 import { ContentObject } from '../interfaces/open-api-spec.interface';
 import { removeUndefinedKeys } from '../utils/remove-undefined-keys';
 
@@ -6,8 +7,12 @@ export class MimetypeContentWrapper {
     mimetype: string[],
     obj: Record<string, any>
   ): Record<'content', ContentObject> {
+    // Clone the object for each mimetype so the resulting media-type entries do
+    // not share the same (mutable) reference. Without this, mutating one
+    // media type's schema later would silently mutate all of them, and the
+    // caller's source object would be mutated by `removeUndefinedKeys`.
     const content = mimetype.reduce(
-      (acc, item) => ({ ...acc, [item]: removeUndefinedKeys(obj) }),
+      (acc, item) => ({ ...acc, [item]: removeUndefinedKeys(cloneDeep(obj)) }),
       {}
     );
     return { content };

--- a/test/services/mimetype-content-wrapper.spec.ts
+++ b/test/services/mimetype-content-wrapper.spec.ts
@@ -1,0 +1,65 @@
+import { MimetypeContentWrapper } from '../../lib/services/mimetype-content-wrapper';
+
+describe('MimetypeContentWrapper', () => {
+  let wrapper: MimetypeContentWrapper;
+
+  beforeEach(() => {
+    wrapper = new MimetypeContentWrapper();
+  });
+
+  it('should wrap the object under each provided mimetype', () => {
+    const { content } = wrapper.wrap(
+      ['application/json', 'application/xml'],
+      {
+        schema: { type: 'string' }
+      }
+    );
+
+    expect(content).toEqual({
+      'application/json': { schema: { type: 'string' } },
+      'application/xml': { schema: { type: 'string' } }
+    });
+  });
+
+  it('should strip undefined keys from the wrapped object', () => {
+    const { content } = wrapper.wrap(['application/json'], {
+      schema: { type: 'string' },
+      example: undefined
+    });
+
+    expect(content['application/json']).toEqual({
+      schema: { type: 'string' }
+    });
+    expect('example' in content['application/json']).toBe(false);
+  });
+
+  it('should not share the same object reference between mimetypes', () => {
+    const { content } = wrapper.wrap(
+      ['application/json', 'application/xml'],
+      {
+        schema: { type: 'string' }
+      }
+    );
+
+    expect(content['application/json']).not.toBe(content['application/xml']);
+    expect(content['application/json'].schema).not.toBe(
+      content['application/xml'].schema
+    );
+
+    // Mutating one mimetype entry must not affect the others.
+    (content['application/json'].schema as Record<string, any>).type =
+      'mutated';
+
+    expect(content['application/xml'].schema).toEqual({ type: 'string' });
+  });
+
+  it('should not mutate the source object passed in by the caller', () => {
+    const source = { schema: { type: 'string' } };
+    const { content } = wrapper.wrap(['application/json'], source);
+
+    (content['application/json'].schema as Record<string, any>).type =
+      'mutated';
+
+    expect(source.schema.type).toBe('string');
+  });
+});


### PR DESCRIPTION
## Summary

`MimetypeContentWrapper#wrap` builds the OpenAPI `content` object by mapping each media type to `removeUndefinedKeys(obj)` — but it reuses the **same object reference** for every media type and passes the caller's object directly into `removeUndefinedKeys` (which mutates in place).

Two consequences for responses/request bodies declared with multiple media types (e.g. `@ApiProduces('application/json', 'application/xml')` or multiple `@ApiConsumes`):

1. **Aliased entries** — every media-type entry in `content` points to the *same* object instance, so mutating one media type's schema later silently mutates all of them.
2. **Source mutation** — `removeUndefinedKeys` strips keys from the caller's original object rather than a copy.

Reproduction (current behavior):

```ts
const { content } = new MimetypeContentWrapper().wrap(
  ['application/json', 'application/xml'],
  { schema: { type: 'string' } }
);

content['application/json'] === content['application/xml']; // true (bug)
content['application/json'].schema.type = 'mutated';
content['application/xml'].schema.type; // 'mutated' (leaked)
```

The fix clones the object per media type with lodash `cloneDeep` (already used elsewhere in the codebase) so each entry is independent and the caller's source object is left untouched.

## Test plan

Added `test/services/mimetype-content-wrapper.spec.ts` covering:

- wrapping under each provided mimetype
- stripping `undefined` keys
- **distinct object/schema references between media types** (fails before the fix)
- **caller's source object is not mutated** (fails before the fix)

```
npx vitest run test/services            # 71 passed (incl. new spec)
npm run lint                            # exit 0
npm run build                           # exit 0
```