### PR TITLE
fix(swagger-ui): preserve `$` characters when rendering custom HTML

### DIFF
--- a/lib/swagger-ui/swagger-ui.ts
+++ b/lib/swagger-ui/swagger-ui.ts
@@ -84,16 +84,21 @@ export function buildSwaggerHTML(
   const explorerCss = explorer
     ? ''
     : '.swagger-ui .topbar .download-url-wrapper { display: none }';
+
+  // The replacement values below are user-controlled (e.g. customCss,
+  // customSiteTitle, customfavIcon). Each is passed to `String.prototype.replace`
+  // through a callback rather than as a string so that `$$`, `$&`, "$`", "$'" and
+  // `$1`-`$9` sequences inside those values are inserted verbatim instead of being
+  // interpreted as replacement patterns (which would silently corrupt the output).
   return htmlTemplateString
-    .replace('<% customCss %>', customCss)
-    .replace('<% explorerCss %>', explorerCss)
-    .replace('<% favIconString %>', favIconString)
-    .replace(/<% baseUrl %>/g, baseUrl)
-    .replace('<% customJs %>', toTags(customJs, toExternalScriptTag))
-    .replace('<% customJsStr %>', toTags(customJsStr, toInlineScriptTag))
-    .replace(
-      '<% customCssUrl %>',
+    .replace('<% customCss %>', () => customCss)
+    .replace('<% explorerCss %>', () => explorerCss)
+    .replace('<% favIconString %>', () => favIconString)
+    .replace(/<% baseUrl %>/g, () => baseUrl)
+    .replace('<% customJs %>', () => toTags(customJs, toExternalScriptTag))
+    .replace('<% customJsStr %>', () => toTags(customJsStr, toInlineScriptTag))
+    .replace('<% customCssUrl %>', () =>
       toTags(customCssUrl, toExternalStylesheetTag)
     )
-    .replace('<% title %>', customSiteTitle);
+    .replace('<% title %>', () => customSiteTitle);
 }

--- a/test/swagger-ui/swagger-ui.spec.ts
+++ b/test/swagger-ui/swagger-ui.spec.ts
@@ -1,0 +1,47 @@
+import { buildSwaggerHTML } from '../../lib/swagger-ui/swagger-ui';
+
+describe('buildSwaggerHTML', () => {
+  it('inserts the custom site title verbatim', () => {
+    const html = buildSwaggerHTML('/', {
+      customSiteTitle: 'My API Docs'
+    });
+
+    expect(html).toContain('<title>My API Docs</title>');
+  });
+
+  it('preserves "$" replacement-pattern characters in customSiteTitle', () => {
+    const title = 'Cost $$ & $& Dashboard $1';
+    const html = buildSwaggerHTML('/', {
+      customSiteTitle: title
+    });
+
+    expect(html).toContain(`<title>${title}</title>`);
+  });
+
+  it('preserves "$" replacement-pattern characters in customCss', () => {
+    const css = '.price::after { content: "$$$ $& $1 $`" }';
+    const html = buildSwaggerHTML('/', {
+      customCss: css
+    });
+
+    expect(html).toContain(css);
+  });
+
+  it('preserves "$" replacement-pattern characters in inline customJsStr', () => {
+    const js = 'console.log("$$ $& $\' total")';
+    const html = buildSwaggerHTML('/', {
+      customJsStr: js
+    });
+
+    expect(html).toContain(`<script>${js}</script>`);
+  });
+
+  it('preserves "$" replacement-pattern characters in customfavIcon url', () => {
+    const favIcon = 'https://example.com/icon.png?v=$$$&a=$1';
+    const html = buildSwaggerHTML('/', {
+      customfavIcon: favIcon
+    });
+
+    expect(html).toContain(`<link rel='icon' href='${favIcon}' />`);
+  });
+});


### PR DESCRIPTION
## Summary

`buildSwaggerHTML` (`lib/swagger-ui/swagger-ui.ts`) builds the Swagger UI page by injecting user-controlled options into the HTML template with `String.prototype.replace(pattern, replacement)`, where `replacement` is a plain string.

When that replacement value is a string, JavaScript interprets `$`-sequences (`$$`, `$&`, `` $` ``, `$'`, `$1`–`$9`) as [special replacement patterns](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement). Because the injected values are user-provided (`customCss`, `customSiteTitle`, `customJsStr`, `customCssUrl`, `customfavIcon`), any such sequence in them is silently corrupted instead of being rendered verbatim.

Examples of corruption:
- `customSiteTitle: 'Cost $$ Dashboard'` → renders `Cost $ Dashboard`
- `customCss: '.price::after { content: "$&" }'` → `$&` expands to the matched placeholder text (`<% customCss %>`)
- `customfavIcon: 'https://cdn/icon.png?v=$1'` → `$1` resolves to an empty string

This is the same class of bug already fixed for the JS init script in `buildJSInitOptions` (#3896), but it lives in the separate HTML-rendering path.

The fix passes each replacement through a callback (`() => value`) so the value is inserted literally and `$`-sequences are never interpreted — exactly the technique used in `buildJSInitOptions`.

## Test plan

Added `test/swagger-ui/swagger-ui.spec.ts` covering `buildSwaggerHTML`:
- Renders `customSiteTitle` verbatim (baseline).
- Preserves `$`-sequences in `customSiteTitle`, `customCss`, inline `customJsStr`, and `customfavIcon`.

These tests fail on `master` (the placeholder/garbled output is produced) and pass with this change.

```
npx vitest run test/swagger-ui/
# Test Files  2 passed (2)
#      Tests  8 passed (8)
```

No behavioral change for values without `$` characters; the rendered HTML is byte-for-byte identical in the common case.
