### PR TITLE
fix(type-helpers): preserve array-ness for nested DTO arrays in DeepPartialType

### DIFF
--- a/lib/type-helpers/deep-partial-type.helper.ts
+++ b/lib/type-helpers/deep-partial-type.helper.ts
@@ -132,18 +132,29 @@ export function DeepPartialType<T>(
         }
       }
 
-      // Unwrap array type: [SomeDto] → SomeDto
+      // Unwrap array type: [SomeDto] → SomeDto. An array can be expressed
+      // either through the `isArray` flag or by wrapping the type in a
+      // single-element tuple (commonly returned from a lazy factory, e.g.
+      // `type: () => [SomeDto]`). Capture the array-ness so it can be
+      // re-applied when we replace `type` with the wrapped nested class.
+      let isArray = metadata.isArray === true;
       if (Array.isArray(resolvedType) && resolvedType.length === 1) {
         resolvedType = resolvedType[0];
+        isArray = true;
       }
 
-      const nestedType = isDtoClass(resolvedType)
+      const isNestedDto = isDtoClass(resolvedType);
+      const nestedType = isNestedDto
         ? DeepPartialType(resolvedType, options)
         : metadata.type;
 
       const decoratorFactory = ApiProperty({
         ...metadata,
         type: nestedType,
+        // Preserve array semantics that may have been encoded inside a lazy
+        // factory; without this the unwrapped nested type would be emitted as
+        // a single object instead of an array.
+        ...(isNestedDto ? { isArray } : {}),
         required: false
       });
       decoratorFactory(DeepPartialTypeClass.prototype, key);

--- a/test/type-helpers/deep-partial-type.helper.spec.ts
+++ b/test/type-helpers/deep-partial-type.helper.spec.ts
@@ -49,8 +49,9 @@ describe('DeepPartialType', () => {
     class UpdateUserDto extends DeepPartialType(UserDto) {}
 
     it('should mark all top-level properties as optional', () => {
-      const fields =
-        modelPropertiesAccessor.getModelProperties(UpdateUserDto.prototype);
+      const fields = modelPropertiesAccessor.getModelProperties(
+        UpdateUserDto.prototype
+      );
       expect(fields).toContain('name');
       expect(fields).toContain('age');
       expect(fields).toContain('profile');
@@ -128,6 +129,53 @@ describe('DeepPartialType', () => {
       class UpdateUserDto extends DeepPartialType(UserDto) {}
       expect(getMetadata(UpdateUserDto, 'name').type).toBe(String);
       expect(getMetadata(UpdateUserDto, 'age').type).toBe(Number);
+    });
+  });
+
+  describe('array of nested DTO properties', () => {
+    class TagDto {
+      @ApiProperty({ type: String, required: true })
+      label: string;
+    }
+
+    class ArticleDto {
+      @ApiProperty({ type: String, required: true })
+      title: string;
+
+      // Array expressed through a lazy factory returning a tuple.
+      @ApiProperty({ type: () => [TagDto], required: true })
+      lazyTags: TagDto[];
+
+      // Array expressed through a tuple literal.
+      @ApiProperty({ type: [TagDto], required: true })
+      tupleTags: TagDto[];
+    }
+
+    it('should preserve array-ness for a lazy factory returning a tuple', () => {
+      class UpdateArticleDto extends DeepPartialType(ArticleDto) {}
+      const meta = getMetadata(UpdateArticleDto, 'lazyTags');
+
+      expect(meta.isArray).toBe(true);
+      expect(meta.required).toBe(false);
+      // Type is the wrapped nested partial, not the original TagDto.
+      expect(meta.type).not.toBe(TagDto);
+      expect(typeof meta.type).toBe('function');
+      expect(
+        Reflect.getMetadata(
+          DECORATORS.API_MODEL_PROPERTIES,
+          meta.type.prototype,
+          'label'
+        ).required
+      ).toBe(false);
+    });
+
+    it('should preserve array-ness for a tuple literal type', () => {
+      class UpdateArticleDto extends DeepPartialType(ArticleDto) {}
+      const meta = getMetadata(UpdateArticleDto, 'tupleTags');
+
+      expect(meta.isArray).toBe(true);
+      expect(meta.required).toBe(false);
+      expect(meta.type).not.toBe(TagDto);
     });
   });
 


### PR DESCRIPTION
## Summary

- `DeepPartialType` dropped the array semantics for properties declared as an array of DTOs through a lazy factory, e.g. `@ApiProperty({ type: () => [SomeDto] })`.
- For that declaration the reflected metadata stores `isArray: false` (the array-ness lives inside the factory's return value, not the `isArray` flag). `DeepPartialType` resolved the factory, unwrapped the single-element tuple to recurse into the nested DTO, then replaced `type` with the wrapped **scalar** nested class while leaving `isArray` untouched — so the emitted schema became a single object instead of an array.
- The fix tracks whether the resolved type was an array (via the existing `isArray` flag **or** the unwrapped tuple) and re-applies `isArray: true` when swapping in the nested `DeepPartialType` class. The tuple-literal form (`type: [SomeDto]`) already carried `isArray: true` and stays correct.

## Test plan

- [x] Added regression tests in `test/type-helpers/deep-partial-type.helper.spec.ts` covering an array of nested DTOs declared via a lazy factory (`() => [TagDto]`) and via a tuple literal (`[TagDto]`), asserting the resulting metadata keeps `isArray: true`, sets `required: false`, wraps the nested type, and makes the nested type's own properties optional.
- [x] `npx vitest run test/type-helpers/` — all type-helpers tests pass (27).
- [x] `npm run lint` — no new warnings in the changed file.
- [x] `npm run build` — succeeds.
- [x] Pre-existing failures under `test/plugin/*` (TypeScript-program visitor specs) reproduce on a clean checkout and are unrelated to this change.