### PR TITLE
fix(plugin): emit object/null values for @example JSDoc tag

### DIFF
--- a/lib/plugin/utils/ast-utils.ts
+++ b/lib/plugin/utils/ast-utils.ts
@@ -349,9 +349,23 @@ export function createLiteralFromAnyValue(
   factory: ts.NodeFactory,
   item: unknown
 ) {
-  return Array.isArray(item)
-    ? factory.createArrayLiteralExpression(
-        item.map((item) => createLiteralFromAnyValue(factory, item))
+  if (Array.isArray(item)) {
+    return factory.createArrayLiteralExpression(
+      item.map((item) => createLiteralFromAnyValue(factory, item))
+    );
+  }
+  if (item === null) {
+    return factory.createNull();
+  }
+  if (typeof item === 'object') {
+    return factory.createObjectLiteralExpression(
+      Object.entries(item).map(([key, value]) =>
+        factory.createPropertyAssignment(
+          factory.createStringLiteral(key),
+          createLiteralFromAnyValue(factory, value)
+        )
       )
-    : createPrimitiveLiteral(factory, item);
+    );
+  }
+  return createPrimitiveLiteral(factory, item);
 }

--- a/test/plugin/fixtures/create-cat-alt2.dto.ts
+++ b/test/plugin/fixtures/create-cat-alt2.dto.ts
@@ -83,6 +83,20 @@ export abstract class Audit {
   testNumber: number;
 
   /**
+   * testObjectExample
+   *
+   * @example { "foo": "bar", "count": 2 }
+   */
+  testObjectExample: object;
+
+  /**
+   * testObjectArrayExample
+   *
+   * @example [{ "id": 1 }, { "id": 2 }]
+   */
+  testObjectArrayExample: object[];
+
+  /**
    * privateProperty
    * @example 'secret'
    */
@@ -102,7 +116,7 @@ export class Audit {
         _Audit_privateProperty.set(this, void 0);
     }
     static _OPENAPI_METADATA_FACTORY() {
-        return { createdAt: { required: true, type: () => Object, description: "test on createdAt" }, updatedAt: { required: true, type: () => Object }, version: { required: true, type: () => String, description: "test\\nversion", example: "version 123" }, testVersion: { required: true, type: () => Object, description: "testVersion", examples: ["0.0.1", "0.0.2"], deprecated: true }, testVersion2: { required: true, type: () => Object, description: "testVersion2", examples: ["0.0.1", "0.0.2"], deprecated: true }, testVersionArray: { required: true, type: () => [String], description: "testVersionArray", example: ["0.0.1", "0.0.2"] }, testVersionArray2: { required: true, type: () => [String], description: "testVersionArray", example: ["version 123", "version 321"] }, testVersionArray3: { required: true, type: () => [Number], description: "testVersionArray", example: [123, 321] }, testBoolean: { required: true, type: () => Boolean, description: "testBoolean", example: true }, testNumber: { required: true, type: () => Number, description: "testNumber", examples: [1, 5] } };
+        return { createdAt: { required: true, type: () => Object, description: "test on createdAt" }, updatedAt: { required: true, type: () => Object }, version: { required: true, type: () => String, description: "test\\nversion", example: "version 123" }, testVersion: { required: true, type: () => Object, description: "testVersion", examples: ["0.0.1", "0.0.2"], deprecated: true }, testVersion2: { required: true, type: () => Object, description: "testVersion2", examples: ["0.0.1", "0.0.2"], deprecated: true }, testVersionArray: { required: true, type: () => [String], description: "testVersionArray", example: ["0.0.1", "0.0.2"] }, testVersionArray2: { required: true, type: () => [String], description: "testVersionArray", example: ["version 123", "version 321"] }, testVersionArray3: { required: true, type: () => [Number], description: "testVersionArray", example: [123, 321] }, testBoolean: { required: true, type: () => Boolean, description: "testBoolean", example: true }, testNumber: { required: true, type: () => Number, description: "testNumber", examples: [1, 5] }, testObjectExample: { required: true, type: () => Object, description: "testObjectExample", example: { "foo": "bar", "count": 2 } }, testObjectArrayExample: { required: true, type: () => [Object], description: "testObjectArrayExample", example: [{ "id": 1 }, { "id": 2 }] } };
     }
 }
 _Audit_privateProperty = new WeakMap();


### PR DESCRIPTION
## Summary

The CLI plugin silently drops a model property's entire metadata when its `@example` JSDoc tag holds an **object** (or an array of objects).

`createLiteralFromAnyValue` (in `lib/plugin/utils/ast-utils.ts`) only handled arrays and primitives. For a plain object it fell through to `createPrimitiveLiteral`, which returns `undefined`. That `undefined` was then passed to `factory.createPropertyAssignment('example', undefined)`, which throws. The `ModelClassVisitor` wraps property inspection in a `try/catch` that swallows the error and returns the node unchanged, so the **whole property** disappears from the generated `_OPENAPI_METADATA_FACTORY`.

Example that triggered the bug:

```ts
export class Dto {
  /** @example [{ "id": 1 }, { "id": 2 }] */
  items: object[]; // <- this property was entirely omitted from metadata
}
```

### Fix

Extend `createLiteralFromAnyValue` to also handle plain objects (recursively, emitting an object literal) and `null`. Arrays and primitives behave exactly as before.

## Test plan

- Added two properties (`testObjectExample`, `testObjectArrayExample`) with object-valued `@example` tags to the existing `create-cat-alt2.dto` plugin fixture and updated the expected transpiled `_OPENAPI_METADATA_FACTORY` output.
- The new assertions **fail on master** (the object-example properties are missing from the emitted metadata) and **pass with this fix**.
- Full plugin suite green: `vitest run test/plugin` (58 passed). `oxlint lib/` clean (no new warnings) and `tsc -p tsconfig.build.json` builds.