### PR TITLE
feat(api-query): support custom OpenAPI extensions

### DIFF
--- a/lib/decorators/api-query.decorator.ts
+++ b/lib/decorators/api-query.decorator.ts
@@ -1,5 +1,5 @@
 import { Type } from '@nestjs/common';
-import { omit } from 'lodash';
+import { clone, omit } from 'lodash';
 import { EnumSchemaAttributes } from '../interfaces/enum-schema-attributes.interface';
 import {
   ParameterObject,
@@ -29,6 +29,8 @@ interface ApiQueryCommonMetadata extends ParameterOptions {
     | (string & {});
   isArray?: boolean;
   enum?: SwaggerEnumType;
+  // Allow passing custom OpenAPI extensions for parameters
+  extensions?: Record<string, any>;
 }
 
 export type ApiQueryMetadata =
@@ -67,7 +69,7 @@ export function ApiQuery(
   const param: ApiQueryMetadata & Record<string, any> = {
     name: 'name' in options ? options.name : defaultQueryOptions.name,
     in: 'query',
-    ...omit(options, 'enum'),
+    ...omit(options, ['enum', 'extensions']),
     type
   };
 
@@ -79,6 +81,19 @@ export function ApiQuery(
 
   if (isArray) {
     param.isArray = isArray;
+  }
+
+  // Merge custom OpenAPI extensions into parameter metadata.
+  // Accept an `extensions` bag on the options similar to how `@ApiExtension` works
+  // (and consistent with `@ApiParam`).
+  const extensions = (options as ApiQueryCommonMetadata).extensions;
+  if (extensions && typeof extensions === 'object') {
+    const cloned = clone(extensions);
+    for (const [key, value] of Object.entries(cloned)) {
+      // Ensure extension keys are prefixed with 'x-'
+      const extKey = key.startsWith('x-') ? key : `x-${key}`;
+      param[extKey] = value;
+    }
   }
 
   return createParamDecorator(param, defaultQueryOptions);

--- a/test/decorators/api-query.decorator.spec.ts
+++ b/test/decorators/api-query.decorator.spec.ts
@@ -58,6 +58,85 @@ describe('ApiQuery', () => {
     });
   });
 
+  describe('extensions support', () => {
+    it('should merge extensions into parameter metadata when provided (method level)', () => {
+      class TestAppController {
+        @Get()
+        @ApiQuery({
+          name: 'search',
+          extensions: { 'x-permissions': ['test.customer.add'] }
+        })
+        public get(@Query('search') search: string): string {
+          return search;
+        }
+      }
+
+      const controller = new TestAppController();
+      expect(
+        Reflect.hasMetadata(DECORATORS.API_PARAMETERS, controller.get)
+      ).toBeTruthy();
+      expect(
+        Reflect.getMetadata(DECORATORS.API_PARAMETERS, controller.get)
+      ).toEqual([
+        {
+          in: 'query',
+          name: 'search',
+          required: true,
+          'x-permissions': ['test.customer.add']
+        }
+      ]);
+    });
+
+    it('should auto-prefix extension keys without x- (class level)', () => {
+      @ApiQuery({
+        name: 'search',
+        extensions: { permissions: ['test.customer.add'] }
+      })
+      @Controller('test')
+      class TestAppController {
+        @Get()
+        public get(@Query('search') search: string): string {
+          return search;
+        }
+      }
+
+      const controller = new TestAppController();
+      expect(
+        Reflect.hasMetadata(DECORATORS.API_PARAMETERS, controller.get)
+      ).toBeTruthy();
+      expect(
+        Reflect.getMetadata(DECORATORS.API_PARAMETERS, controller.get)
+      ).toEqual([
+        {
+          in: 'query',
+          name: 'search',
+          required: true,
+          'x-permissions': ['test.customer.add']
+        }
+      ]);
+    });
+
+    it('should not leave a raw "extensions" key in the parameter metadata', () => {
+      class TestAppController {
+        @Get()
+        @ApiQuery({
+          name: 'search',
+          extensions: { 'x-permissions': ['test.customer.add'] }
+        })
+        public get(@Query('search') search: string): string {
+          return search;
+        }
+      }
+
+      const controller = new TestAppController();
+      const metadata = Reflect.getMetadata(
+        DECORATORS.API_PARAMETERS,
+        controller.get
+      );
+      expect(metadata[0]).not.toHaveProperty('extensions');
+    });
+  });
+
   describe('when type is specified', () => {
     class TestAppController {
       @Get('string')


### PR DESCRIPTION
## Summary

`@ApiParam` accepts an `extensions` bag and flattens each entry into `x-*` keys on the emitted parameter object (added in #3625). `@ApiQuery` — its sibling decorator with identical `ParameterObject` semantics — does not.

As a result, passing `extensions` to `@ApiQuery` leaks a literal `extensions` object onto the parameter:

```jsonc
// @ApiQuery({ name: 'r', extensions: { 'x-perm': ['read'] } })
{ "name": "r", "in": "query", "extensions": { "x-perm": ["read"] }, "schema": { "type": "string" } }
```

The OpenAPI `Parameter Object` has no `extensions` property, so this is invalid spec output. The equivalent `@ApiParam` call correctly emits `"x-perm": ["read"]` at the parameter root.

This PR mirrors the `@ApiParam` implementation in `@ApiQuery`:
- adds an optional `extensions` field to `ApiQueryCommonMetadata`,
- omits `extensions` from the verbatim options spread,
- merges each entry as an `x-`-prefixed key on the parameter metadata (auto-prefixing keys that don't already start with `x-`).

No behaviour changes for callers that don't use `extensions`.

## Test plan

Added unit tests in `test/decorators/api-query.decorator.spec.ts`:
- merges `extensions` into parameter metadata (method level),
- auto-prefixes extension keys without `x-` (class level),
- asserts no raw `extensions` key remains on the emitted parameter (the regression).

Verified the new tests fail on `master` (the raw `extensions` key leaks) and pass with the fix. `npm run lint` and the decorator/explorer/service suites pass.