### PR TITLE
fix(plugin): add require export for CLI entry

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "./plugin": {
       "types": "./dist/plugin/index.d.ts",
       "import": "./dist/plugin/index.js",
+      "require": "./dist/plugin/index.js",
       "default": "./dist/plugin/index.js"
     },
     "./package.json": "./package.json"

--- a/test/plugin/package-exports.spec.ts
+++ b/test/plugin/package-exports.spec.ts
@@ -1,0 +1,13 @@
+import { readFileSync } from 'node:fs';
+
+describe('package exports', () => {
+  it('should expose a require-compatible CLI plugin entry', () => {
+    const packageJson = JSON.parse(
+      readFileSync(new URL('../../package.json', import.meta.url), 'utf8')
+    );
+
+    expect(packageJson.exports['./plugin'].require).toBe(
+      './dist/plugin/index.js'
+    );
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
The v12 package export map does not provide a `require` condition for `@nestjs/swagger/plugin`. In monorepo setups, Nest CLI resolves the plugin entry through CommonJS resolution, falls back to the package root, and then reports that the plugin is incompatible because the root module does not expose any compiler hooks.

Issue Number: Fixes #3944

## What is the new behavior?
The `./plugin` export now includes an explicit `require` entry that points to `./dist/plugin/index.js`, so Nest CLI can resolve the intended plugin entry instead of falling back to the package root.

A regression test now asserts that the package export map keeps exposing a require-compatible CLI plugin entry.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
Docs were not updated because this is a package export map bug fix with regression coverage.

Local validation:

```bash
npm test -- test/plugin/package-exports.spec.ts
npm run build
npm exec -- prettier --check package.json test/plugin/package-exports.spec.ts
git diff --check
```
