### PR TITLE
fix: Added missing summary type to the response object

### DIFF
--- a/lib/interfaces/open-api-spec.interface.ts
+++ b/lib/interfaces/open-api-spec.interface.ts
@@ -163,6 +163,7 @@ export interface ResponsesObject extends Record<
 }
 
 export interface ResponseObject {
+  summary?: string;
   description: string;
   headers?: HeadersObject;
   content?: ContentObject;

--- a/test/decorators/api-response.decorator.spec.ts
+++ b/test/decorators/api-response.decorator.spec.ts
@@ -54,6 +54,29 @@ describe('ApiResponse', () => {
       });
     });
 
+    it('should attach summary metadata to a given method (OpenAPI 3.2)', () => {
+      @Controller('tests/:testId')
+      class SummaryController {
+        @Get()
+        @ApiOkResponse({ summary: 'List of cats', description: 'All cats' })
+        public get(@Param('testId') testId: string): string {
+          return testId;
+        }
+      }
+
+      const controller = new SummaryController();
+      expect(
+        Reflect.getMetadata(DECORATORS.API_RESPONSE, controller.get)
+      ).toEqual({
+        [HttpStatus.OK]: {
+          summary: 'List of cats',
+          description: 'All cats',
+          isArray: undefined,
+          type: undefined
+        }
+      });
+    });
+
     it.each([
       { decorator: ApiOkResponse, status: HttpStatus.OK },
       { decorator: ApiCreatedResponse, status: HttpStatus.CREATED },


### PR DESCRIPTION
This PR augments https://github.com/nestjs/swagger/pull/3921

Added missing summary type to the response object as well.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
When using the response type, summary is not a valid type according to TypeScript.

Issue Number: N/A


## What is the new behavior?
Summary is now a valid property.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
