### PR TITLE
fix: avoid inline PickType schema collisions

### DIFF
--- a/lib/type-helpers/mapped-types.utils.ts
+++ b/lib/type-helpers/mapped-types.utils.ts
@@ -2,6 +2,30 @@ import { Type } from '@nestjs/common';
 import { identity } from 'lodash';
 import { METADATA_FACTORY_NAME } from '../plugin/plugin-constants';
 
+function capitalizeFirstLetter(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function sanitizeTypeNameSegment(value: string | number | symbol): string {
+  return String(value).replace(/[^A-Za-z0-9_$]/g, '_');
+}
+
+export function setMappedTypeClassName<T, K extends keyof T>(
+  target: Function,
+  prefix: string,
+  classRef: Type<T>,
+  keys: readonly K[] = []
+) {
+  const parentTypeName = classRef.name || 'Anonymous';
+  const mappedProperties = keys
+    .map((key) => capitalizeFirstLetter(sanitizeTypeNameSegment(key)))
+    .join('');
+
+  Object.defineProperty(target, 'name', {
+    value: `${prefix}${parentTypeName}${mappedProperties}`
+  });
+}
+
 export function clonePluginMetadataFactory(
   target: Type<unknown>,
   parent: Type<unknown>,

--- a/lib/type-helpers/omit-type.helper.ts
+++ b/lib/type-helpers/omit-type.helper.ts
@@ -10,7 +10,10 @@ import { ApiProperty } from '../decorators';
 import { MetadataLoader } from '../plugin/metadata-loader';
 import { METADATA_FACTORY_NAME } from '../plugin/plugin-constants';
 import { ModelPropertiesAccessor } from '../services/model-properties-accessor';
-import { clonePluginMetadataFactory } from './mapped-types.utils';
+import {
+  clonePluginMetadataFactory,
+  setMappedTypeClassName
+} from './mapped-types.utils';
 
 const modelPropertiesAccessor = new ModelPropertiesAccessor();
 
@@ -32,6 +35,7 @@ export function OmitType<T, K extends keyof T>(
       inheritPropertyInitializers(this, classRef, isInheritedPredicate);
     }
   }
+  setMappedTypeClassName(OmitTypeClass, 'Omit', classRef, keys);
 
   inheritValidationMetadata(classRef, OmitTypeClass, isInheritedPredicate);
   inheritTransformationMetadata(classRef, OmitTypeClass, isInheritedPredicate);

--- a/lib/type-helpers/partial-type.helper.ts
+++ b/lib/type-helpers/partial-type.helper.ts
@@ -12,7 +12,10 @@ import { ApiProperty } from '../decorators';
 import { MetadataLoader } from '../plugin/metadata-loader';
 import { METADATA_FACTORY_NAME } from '../plugin/plugin-constants';
 import { ModelPropertiesAccessor } from '../services/model-properties-accessor';
-import { clonePluginMetadataFactory } from './mapped-types.utils';
+import {
+  clonePluginMetadataFactory,
+  setMappedTypeClassName
+} from './mapped-types.utils';
 
 const modelPropertiesAccessor = new ModelPropertiesAccessor();
 
@@ -45,6 +48,7 @@ export function PartialType<T>(
       inheritPropertyInitializers(this, classRef);
     }
   }
+  setMappedTypeClassName(PartialTypeClass, 'Partial', classRef);
   const keysWithValidationConstraints = inheritValidationMetadata(
     classRef,
     PartialTypeClass

--- a/lib/type-helpers/pick-type.helper.ts
+++ b/lib/type-helpers/pick-type.helper.ts
@@ -14,6 +14,26 @@ import { clonePluginMetadataFactory } from './mapped-types.utils';
 
 const modelPropertiesAccessor = new ModelPropertiesAccessor();
 
+function capitalizeFirstLetter(value: string): string {
+  return value.charAt(0).toUpperCase() + value.slice(1);
+}
+
+function sanitizeTypeNameSegment(value: string | number | symbol): string {
+  return String(value).replace(/[^A-Za-z0-9_$]/g, '_');
+}
+
+function getPickTypeClassName<T, K extends keyof T>(
+  classRef: Type<T>,
+  keys: readonly K[]
+): string {
+  const parentTypeName = classRef.name || 'Anonymous';
+  const pickedProperties = keys
+    .map((key) => capitalizeFirstLetter(sanitizeTypeNameSegment(key)))
+    .join('');
+
+  return `Pick${parentTypeName}${pickedProperties}`;
+}
+
 /**
  * @publicApi
  */
@@ -33,6 +53,9 @@ export function PickType<T, K extends keyof T>(
       inheritPropertyInitializers(this, classRef, isInheritedPredicate);
     }
   }
+  Object.defineProperty(PickTypeClass, 'name', {
+    value: getPickTypeClassName(classRef, keys)
+  });
 
   inheritValidationMetadata(classRef, PickTypeClass, isInheritedPredicate);
   inheritTransformationMetadata(classRef, PickTypeClass, isInheritedPredicate);

--- a/lib/type-helpers/pick-type.helper.ts
+++ b/lib/type-helpers/pick-type.helper.ts
@@ -10,29 +10,12 @@ import { ApiProperty } from '../decorators';
 import { MetadataLoader } from '../plugin/metadata-loader';
 import { METADATA_FACTORY_NAME } from '../plugin/plugin-constants';
 import { ModelPropertiesAccessor } from '../services/model-properties-accessor';
-import { clonePluginMetadataFactory } from './mapped-types.utils';
+import {
+  clonePluginMetadataFactory,
+  setMappedTypeClassName
+} from './mapped-types.utils';
 
 const modelPropertiesAccessor = new ModelPropertiesAccessor();
-
-function capitalizeFirstLetter(value: string): string {
-  return value.charAt(0).toUpperCase() + value.slice(1);
-}
-
-function sanitizeTypeNameSegment(value: string | number | symbol): string {
-  return String(value).replace(/[^A-Za-z0-9_$]/g, '_');
-}
-
-function getPickTypeClassName<T, K extends keyof T>(
-  classRef: Type<T>,
-  keys: readonly K[]
-): string {
-  const parentTypeName = classRef.name || 'Anonymous';
-  const pickedProperties = keys
-    .map((key) => capitalizeFirstLetter(sanitizeTypeNameSegment(key)))
-    .join('');
-
-  return `Pick${parentTypeName}${pickedProperties}`;
-}
 
 /**
  * @publicApi
@@ -53,9 +36,7 @@ export function PickType<T, K extends keyof T>(
       inheritPropertyInitializers(this, classRef, isInheritedPredicate);
     }
   }
-  Object.defineProperty(PickTypeClass, 'name', {
-    value: getPickTypeClassName(classRef, keys)
-  });
+  setMappedTypeClassName(PickTypeClass, 'Pick', classRef, keys);
 
   inheritValidationMetadata(classRef, PickTypeClass, isInheritedPredicate);
   inheritTransformationMetadata(classRef, PickTypeClass, isInheritedPredicate);

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -9,6 +9,7 @@ import { ModelPropertiesAccessor } from '../../lib/services/model-properties-acc
 import { ParamWithTypeMetadata } from '../../lib/services/parameter-metadata-accessor';
 import { SchemaObjectFactory } from '../../lib/services/schema-object-factory';
 import { SwaggerTypesMapper } from '../../lib/services/swagger-types-mapper';
+import { PickType } from '../../lib/type-helpers';
 import { CreateUserDto } from './fixtures/create-user.dto';
 
 describe('SchemaObjectFactory', () => {
@@ -347,6 +348,80 @@ describe('SchemaObjectFactory', () => {
       expect(loggerWarnSpy).not.toHaveBeenCalled();
 
       loggerWarnSpy.mockRestore();
+    });
+
+    it('should keep inline PickType schemas distinct', () => {
+      class ActivityContentDto {
+        @ApiProperty()
+        title: string;
+
+        @ApiProperty()
+        description: string;
+
+        @ApiProperty({ isArray: true, type: String })
+        categories: string[];
+      }
+
+      class UserDto {
+        @ApiProperty()
+        id: string;
+
+        @ApiProperty()
+        name: string;
+      }
+
+      class ActivityResponseDto {
+        @ApiProperty({
+          type: PickType(ActivityContentDto, [
+            'title',
+            'description',
+            'categories'
+          ])
+        })
+        content: Pick<
+          ActivityContentDto,
+          'title' | 'description' | 'categories'
+        >;
+
+        @ApiProperty({ type: PickType(UserDto, ['id', 'name']) })
+        organizer: Pick<UserDto, 'id' | 'name'>;
+      }
+
+      const schemas: Record<string, SchemasObject> = {};
+      schemaObjectFactory.exploreModelSchema(ActivityResponseDto, schemas);
+
+      expect(schemas.ActivityResponseDto).toEqual({
+        type: 'object',
+        properties: {
+          content: {
+            $ref: '#/components/schemas/PickActivityContentDtoTitleDescriptionCategories'
+          },
+          organizer: {
+            $ref: '#/components/schemas/PickUserDtoIdName'
+          }
+        },
+        required: ['content', 'organizer']
+      });
+      expect(schemas.PickActivityContentDtoTitleDescriptionCategories).toEqual({
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          description: { type: 'string' },
+          categories: {
+            type: 'array',
+            items: { type: 'string' }
+          }
+        },
+        required: ['title', 'description', 'categories']
+      });
+      expect(schemas.PickUserDtoIdName).toEqual({
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' }
+        },
+        required: ['id', 'name']
+      });
     });
 
     it('should create openapi schema', () => {

--- a/test/services/schema-object-factory.spec.ts
+++ b/test/services/schema-object-factory.spec.ts
@@ -9,7 +9,7 @@ import { ModelPropertiesAccessor } from '../../lib/services/model-properties-acc
 import { ParamWithTypeMetadata } from '../../lib/services/parameter-metadata-accessor';
 import { SchemaObjectFactory } from '../../lib/services/schema-object-factory';
 import { SwaggerTypesMapper } from '../../lib/services/swagger-types-mapper';
-import { PickType } from '../../lib/type-helpers';
+import { OmitType, PartialType, PickType } from '../../lib/type-helpers';
 import { CreateUserDto } from './fixtures/create-user.dto';
 
 describe('SchemaObjectFactory', () => {
@@ -421,6 +421,114 @@ describe('SchemaObjectFactory', () => {
           name: { type: 'string' }
         },
         required: ['id', 'name']
+      });
+    });
+
+    it('should keep inline OmitType schemas distinct', () => {
+      class ActivityContentDto {
+        @ApiProperty()
+        title: string;
+
+        @ApiProperty()
+        description: string;
+
+        @ApiProperty({ isArray: true, type: String })
+        categories: string[];
+      }
+
+      class UserDto {
+        @ApiProperty()
+        id: string;
+
+        @ApiProperty()
+        name: string;
+      }
+
+      class ActivityResponseDto {
+        @ApiProperty({ type: OmitType(ActivityContentDto, ['description']) })
+        content: Omit<ActivityContentDto, 'description'>;
+
+        @ApiProperty({ type: OmitType(UserDto, ['name']) })
+        organizer: Omit<UserDto, 'name'>;
+      }
+
+      const schemas: Record<string, SchemasObject> = {};
+      schemaObjectFactory.exploreModelSchema(ActivityResponseDto, schemas);
+
+      expect(schemas.ActivityResponseDto.properties).toEqual({
+        content: {
+          $ref: '#/components/schemas/OmitActivityContentDtoDescription'
+        },
+        organizer: { $ref: '#/components/schemas/OmitUserDtoName' }
+      });
+      expect(schemas.OmitActivityContentDtoDescription).toEqual({
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          categories: {
+            type: 'array',
+            items: { type: 'string' }
+          }
+        },
+        required: ['title', 'categories']
+      });
+      expect(schemas.OmitUserDtoName).toEqual({
+        type: 'object',
+        properties: {
+          id: { type: 'string' }
+        },
+        required: ['id']
+      });
+    });
+
+    it('should keep inline PartialType schemas distinct', () => {
+      class ActivityContentDto {
+        @ApiProperty()
+        title: string;
+
+        @ApiProperty({ isArray: true, type: String })
+        categories: string[];
+      }
+
+      class UserDto {
+        @ApiProperty()
+        id: string;
+
+        @ApiProperty()
+        name: string;
+      }
+
+      class ActivityResponseDto {
+        @ApiProperty({ type: PartialType(ActivityContentDto) })
+        content: Partial<ActivityContentDto>;
+
+        @ApiProperty({ type: PartialType(UserDto) })
+        organizer: Partial<UserDto>;
+      }
+
+      const schemas: Record<string, SchemasObject> = {};
+      schemaObjectFactory.exploreModelSchema(ActivityResponseDto, schemas);
+
+      expect(schemas.ActivityResponseDto.properties).toEqual({
+        content: { $ref: '#/components/schemas/PartialActivityContentDto' },
+        organizer: { $ref: '#/components/schemas/PartialUserDto' }
+      });
+      expect(schemas.PartialActivityContentDto).toEqual({
+        type: 'object',
+        properties: {
+          title: { type: 'string' },
+          categories: {
+            type: 'array',
+            items: { type: 'string' }
+          }
+        }
+      });
+      expect(schemas.PartialUserDto).toEqual({
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          name: { type: 'string' }
+        }
       });
     });
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Inline `PickType(...)` classes all use the helper class name `PickTypeClass`, so multiple inline picked schemas can collide in the generated OpenAPI components.

Issue Number: Fixes #3970

## What is the new behavior?

`PickType(...)` now gives the generated helper class a deterministic name based on the source DTO and selected fields, keeping distinct inline picked schemas from overwriting each other.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Validation:

- `npx vitest run test/services/schema-object-factory.spec.ts -t "should keep inline PickType schemas distinct"`
- `npx vitest run test/services/schema-object-factory.spec.ts`
- `npx vitest run test/type-helpers/pick-type.helper.spec.ts`
- `npm run lint`
- `npm run build`
- `npx vitest run --test-timeout 10000`
- `git diff --check HEAD~1..HEAD`
