### PR TITLE
fix(plugin): generate object examples from @example doc tags

### DIFF
--- a/lib/plugin/utils/ast-utils.ts
+++ b/lib/plugin/utils/ast-utils.ts
@@ -422,10 +422,24 @@ export function createPrimitiveLiteral(
 export function createLiteralFromAnyValue(
   factory: ts.NodeFactory,
   item: unknown
-) {
-  return Array.isArray(item)
-    ? factory.createArrayLiteralExpression(
-        item.map((item) => createLiteralFromAnyValue(factory, item))
+): ts.Expression {
+  if (Array.isArray(item)) {
+    return factory.createArrayLiteralExpression(
+      item.map((item) => createLiteralFromAnyValue(factory, item))
+    );
+  }
+  if (item === null) {
+    return factory.createNull();
+  }
+  if (typeof item === 'object') {
+    return factory.createObjectLiteralExpression(
+      Object.entries(item).map(([key, value]) =>
+        factory.createPropertyAssignment(
+          factory.createStringLiteral(key),
+          createLiteralFromAnyValue(factory, value)
+        )
       )
-    : createPrimitiveLiteral(factory, item);
+    );
+  }
+  return createPrimitiveLiteral(factory, item);
 }

--- a/test/plugin/fixtures/create-cat-alt2.dto.ts
+++ b/test/plugin/fixtures/create-cat-alt2.dto.ts
@@ -83,6 +83,13 @@ export abstract class Audit {
   testNumber: number;
 
   /**
+   * testObject
+   *
+   * @example { "Content-Type": "video/mp4", "key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" }
+   */
+  testObject: Record<string, string>;
+
+  /**
    * privateProperty
    * @example 'secret'
    */
@@ -102,7 +109,7 @@ export class Audit {
         _Audit_privateProperty.set(this, void 0);
     }
     static _OPENAPI_METADATA_FACTORY() {
-        return { createdAt: { required: true, type: () => Object, description: "test on createdAt" }, updatedAt: { required: true, type: () => Object }, version: { required: true, type: () => String, description: "test\\nversion", example: "version 123" }, testVersion: { required: true, type: () => Object, description: "testVersion", examples: ["0.0.1", "0.0.2"], deprecated: true }, testVersion2: { required: true, type: () => Object, description: "testVersion2", examples: ["0.0.1", "0.0.2"], deprecated: true }, testVersionArray: { required: true, type: () => [String], description: "testVersionArray", example: ["0.0.1", "0.0.2"] }, testVersionArray2: { required: true, type: () => [String], description: "testVersionArray", example: ["version 123", "version 321"] }, testVersionArray3: { required: true, type: () => [Number], description: "testVersionArray", example: [123, 321] }, testBoolean: { required: true, type: () => Boolean, description: "testBoolean", example: true }, testNumber: { required: true, type: () => Number, description: "testNumber", examples: [1, 5] } };
+        return { createdAt: { required: true, type: () => Object, description: "test on createdAt" }, updatedAt: { required: true, type: () => Object }, version: { required: true, type: () => String, description: "test\\nversion", example: "version 123" }, testVersion: { required: true, type: () => Object, description: "testVersion", examples: ["0.0.1", "0.0.2"], deprecated: true }, testVersion2: { required: true, type: () => Object, description: "testVersion2", examples: ["0.0.1", "0.0.2"], deprecated: true }, testVersionArray: { required: true, type: () => [String], description: "testVersionArray", example: ["0.0.1", "0.0.2"] }, testVersionArray2: { required: true, type: () => [String], description: "testVersionArray", example: ["version 123", "version 321"] }, testVersionArray3: { required: true, type: () => [Number], description: "testVersionArray", example: [123, 321] }, testBoolean: { required: true, type: () => Boolean, description: "testBoolean", example: true }, testNumber: { required: true, type: () => Number, description: "testNumber", examples: [1, 5] }, testObject: { required: true, type: "object", additionalProperties: { type: "string" }, description: "testObject", example: { "Content-Type": "video/mp4", "key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" } } };
     }
 }
 _Audit_privateProperty = new WeakMap();


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

With `introspectComments` enabled, an `@example` doc tag holding a JSON object is parsed successfully, but `createLiteralFromAnyValue` only handles arrays and primitives and returns `undefined` for objects. The resulting exception is swallowed by the property visitor, so the entire property (including `required` and `type`) is dropped from `_OPENAPI_METADATA_FACTORY`:

```ts
export class PresignedPostDto {
  /**
   * @example { "Content-Type": "video/mp4", "key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" }
   */
  fields!: Record<string, string>;
}
```

```js
// generated
static _OPENAPI_METADATA_FACTORY() {
    return {};
}
```

Issue Number: N/A


## What is the new behavior?

`createLiteralFromAnyValue` now handles plain objects (and `null`) recursively, emitting object literal expressions with string literal keys so that non-identifier keys such as `"Content-Type"` work:

```js
// generated
static _OPENAPI_METADATA_FACTORY() {
    return { fields: { required: true, type: "object", additionalProperties: { type: "string" }, example: { "Content-Type": "video/mp4", "key": "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" } } };
}
```

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

- Added coverage in `test/plugin/fixtures/create-cat-alt2.dto.ts` for an object `@example` on a `Record<string, string>` property.