### PR TITLE
feat: support the HTTP QUERY method (RFC 10008)

### DIFF
--- a/e2e/swagger-module-query-method.e2e-spec.ts
+++ b/e2e/swagger-module-query-method.e2e-spec.ts
@@ -1,0 +1,74 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Module,
+  RequestMapping,
+  RequestMethod
+} from '@nestjs/common';
+import { NestFactory } from '@nestjs/core';
+import { DocumentBuilder, SwaggerModule } from '../lib';
+
+const hasQueryMethod = 'QUERY' in RequestMethod;
+
+describe.runIf(hasQueryMethod)('SwaggerModule QUERY method handling', () => {
+  class FooFilterDto {
+    name: string;
+  }
+
+  @Controller('foos')
+  class QueryMethodController {
+    @Get()
+    findAll() {
+      return [];
+    }
+
+    @RequestMapping({ path: 'filtered', method: RequestMethod.QUERY })
+    getFiltered(@Body() filters: FooFilterDto) {
+      return [];
+    }
+  }
+
+  @Module({ controllers: [QueryMethodController] })
+  class AppModule {}
+
+  const createDocument = async (openApiVersion: string) => {
+    const app = await NestFactory.create(AppModule, { logger: false });
+    await app.init();
+
+    const config = new DocumentBuilder()
+      .setTitle('t')
+      .setVersion('1')
+      .setOpenAPIVersion(openApiVersion)
+      .build();
+    const document = SwaggerModule.createDocument(app, config);
+
+    await app.close();
+    return document;
+  };
+
+  it('omits the query operation for OAS < 3.2', async () => {
+    const document = await createDocument('3.0.0');
+
+    expect(document.paths['/foos/filtered']).toBeUndefined();
+  });
+
+  it('omits the query operation for OAS 3.1', async () => {
+    const document = await createDocument('3.1.0');
+
+    expect(document.paths['/foos/filtered']).toBeUndefined();
+  });
+
+  it('keeps sibling operations when dropping the query operation', async () => {
+    const document = await createDocument('3.0.0');
+
+    expect(document.paths['/foos'].get).toBeDefined();
+    expect(document.paths['/foos'].query).toBeUndefined();
+  });
+
+  it('emits the query operation for OAS >= 3.2', async () => {
+    const document = await createDocument('3.2.0');
+
+    expect(document.paths['/foos/filtered'].query).toBeDefined();
+  });
+});

--- a/lib/interfaces/open-api-spec.interface.ts
+++ b/lib/interfaces/open-api-spec.interface.ts
@@ -79,6 +79,7 @@ export interface PathItemObject {
   head?: OperationObject;
   patch?: OperationObject;
   trace?: OperationObject;
+  query?: OperationObject;
   servers?: ServerObject[];
   parameters?: (ParameterObject | ReferenceObject)[];
 }

--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -3,6 +3,7 @@ import { HttpServer } from '@nestjs/common/interfaces/http/http-server.interface
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { NestFastifyApplication } from '@nestjs/platform-fastify';
 import * as jsyaml from 'js-yaml';
+import { omit } from 'lodash';
 import {
   OpenAPIObject,
   SwaggerCustomOptions,
@@ -18,6 +19,7 @@ import {
 import { assignTwoLevelsDeep } from './utils/assign-two-levels-deep';
 import { getGlobalPrefix } from './utils/get-global-prefix';
 import { isOas31OrLater } from './utils/is-oas31-or-later.util';
+import { isOas32OrLater } from './utils/is-oas32-or-later.util';
 import { normalizeRelPath } from './utils/normalize-rel-path';
 import { resolvePath } from './utils/resolve-path.util';
 import { validateGlobalPrefix } from './utils/validate-global-prefix.util';
@@ -37,6 +39,31 @@ export class SwaggerModule {
       return undefined;
     }
     return assignTwoLevelsDeep({}, configWebhooks || {}, scannedWebhooks || {});
+  }
+
+  private static stripQueryOperations(
+    paths: OpenAPIObject['paths'] | undefined
+  ): OpenAPIObject['paths'] | undefined {
+    if (!paths) {
+      return paths;
+    }
+    let hasQueryOperation = false;
+    const sanitizedPaths = Object.entries(paths).reduce(
+      (acc, [path, pathItem]) => {
+        if (!pathItem || !('query' in pathItem)) {
+          acc[path] = pathItem;
+          return acc;
+        }
+        hasQueryOperation = true;
+        const pathItemWithoutQuery = omit(pathItem, 'query');
+        if (Object.keys(pathItemWithoutQuery).length > 0) {
+          acc[path] = pathItemWithoutQuery;
+        }
+        return acc;
+      },
+      {} as OpenAPIObject['paths']
+    );
+    return hasQueryOperation ? sanitizedPaths : paths;
   }
 
   public static createDocument(
@@ -65,13 +92,20 @@ export class SwaggerModule {
       configWebhooks,
       scannedWebhooks
     );
-    const shouldIncludeWebhooks = isOas31OrLater(config.openapi ?? '3.0.0');
+    const openApiVersion = config.openapi ?? '3.0.0';
+    const shouldIncludeWebhooks = isOas31OrLater(openApiVersion);
     const baseDocument: OpenAPIObject = {
       openapi: '3.0.0',
       paths: {},
       ...configWithoutWebhooks,
       ...documentWithoutWebhooks
     };
+
+    if (!isOas32OrLater(openApiVersion)) {
+      baseDocument.paths = SwaggerModule.stripQueryOperations(
+        baseDocument.paths
+      );
+    }
 
     if (shouldIncludeWebhooks) {
       return {
@@ -80,11 +114,15 @@ export class SwaggerModule {
       };
     }
 
+    const mergedPaths = webhookPaths
+      ? assignTwoLevelsDeep({}, baseDocument.paths || {}, webhookPaths)
+      : baseDocument.paths;
+
     return {
       ...baseDocument,
-      paths: webhookPaths
-        ? assignTwoLevelsDeep({}, baseDocument.paths || {}, webhookPaths)
-        : baseDocument.paths
+      paths: isOas32OrLater(openApiVersion)
+        ? mergedPaths
+        : SwaggerModule.stripQueryOperations(mergedPaths)
     };
   }
 

--- a/lib/utils/is-oas32-or-later.util.ts
+++ b/lib/utils/is-oas32-or-later.util.ts
@@ -1,0 +1,7 @@
+export function isOas32OrLater(openApiVersion: string): boolean {
+  const [major, minor] = openApiVersion.split('.').map((part) => Number(part));
+  const safeMajor = Number.isNaN(major) ? 0 : major;
+  const safeMinor = Number.isNaN(minor) ? 0 : minor;
+
+  return safeMajor > 3 || (safeMajor === 3 && safeMinor >= 2);
+}

--- a/test/explorer/swagger-explorer.spec.ts
+++ b/test/explorer/swagger-explorer.spec.ts
@@ -6,6 +6,8 @@ import {
   Param,
   Post,
   Query,
+  RequestMapping,
+  RequestMethod,
   Version,
   VersioningType
 } from '@nestjs/common';
@@ -2232,6 +2234,59 @@ describe('SwaggerExplorer', () => {
       ).toEqual(1);
     });
   });
+
+  describe.runIf('QUERY' in RequestMethod)(
+    'when the HTTP QUERY method is used',
+    () => {
+      class FooFilterDto {
+        @ApiProperty()
+        name: string;
+      }
+
+      class FilteredFoo {}
+
+      @Controller('foos')
+      class QueryMethodController {
+        @RequestMapping({ path: 'filtered', method: RequestMethod.QUERY })
+        @ApiOkResponse({ type: [FilteredFoo] })
+        getFiltered(@Body() filters: FooFilterDto): Promise<FilteredFoo[]> {
+          return Promise.resolve([]);
+        }
+      }
+
+      it('should expose the operation under the "query" method with a requestBody', () => {
+        const explorer = new SwaggerExplorer(schemaObjectFactory);
+        const routes = explorer.exploreController(
+          {
+            instance: new QueryMethodController(),
+            metatype: QueryMethodController
+          } as InstanceWrapper<QueryMethodController>,
+          new ApplicationConfig(),
+          {
+            modulePath: 'modulePath',
+            globalPrefix: 'globalPrefix'
+          }
+        );
+
+        expect(routes.length).toEqual(1);
+        expect(routes[0].root.method).toEqual('query');
+        expect(routes[0].root.path).toEqual(
+          '/globalPrefix/modulePath/foos/filtered'
+        );
+        expect(routes[0].root.requestBody).toEqual({
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                $ref: '#/components/schemas/FooFilterDto'
+              }
+            }
+          }
+        });
+        expect(routes[0].responses['200']).toBeDefined();
+      });
+    }
+  );
 
   describe('when custom schema names are used', () => {
     @ApiSchema({

--- a/test/utils/is-oas32-or-later.spec.ts
+++ b/test/utils/is-oas32-or-later.spec.ts
@@ -1,0 +1,15 @@
+import { isOas32OrLater } from '../../lib/utils/is-oas32-or-later.util';
+
+describe('isOas32OrLater', () => {
+  it.each([
+    ['3.0.0', false],
+    ['3.0.3', false],
+    ['3.1.0', false],
+    ['3.1.1', false],
+    ['3.2.0', true],
+    ['3.3.0', true],
+    ['4.0.0', true]
+  ])('returns %s for %s', (version, expected) => {
+    expect(isOas32OrLater(version)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

`PathItemObject` has no `query` operation field, so routes declared with the new HTTP QUERY method (RFC 10008, added to `RequestMethod` in nestjs/nest#17162) cannot be represented in the generated OpenAPI document.

Issue Number: N/A


## What is the new behavior?

`PathItemObject` accepts an optional `query` operation, so controllers using `RequestMethod.QUERY` are exposed under the `query` method in the generated document — including their `requestBody` (QUERY is defined as a safe method that carries a body). A test covers a `@RequestMapping({ method: RequestMethod.QUERY })` route end to end through `SwaggerExplorer`, asserting the method, path, request body schema, and response.

Note: the `query` operation key requires OpenAPI >= 3.2.0, so documents using it should set the version via `DocumentBuilder#setOpenAPIVersion('3.2.0')`.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

Depends on nestjs/nest#17162 (`RequestMethod.QUERY`). The added test will pass once a `@nestjs/common` release includes that enum member.