### PR TITLE
fix(plugin): preserve inferred responses for enum error statuses

### DIFF
--- a/lib/plugin/visitors/controller-class.visitor.ts
+++ b/lib/plugin/visitors/controller-class.visitor.ts
@@ -188,7 +188,7 @@ export class ControllerClassVisitor extends AbstractFileVisitor {
         const decoratorName = getDecoratorName(item);
         // Error factories (4xx/5xx) must not suppress the auto-inferred 2xx.
         if (decoratorName === ApiResponse.name) {
-          return this.isSuccessOrRedirectApiResponseArg(item);
+          return this.isSuccessOrRedirectApiResponseArg(item, typeChecker);
         }
         const statusNameMatch = decoratorName.match(/^Api(.+)Response$/);
         if (!statusNameMatch) return false;
@@ -760,7 +760,10 @@ export class ControllerClassVisitor extends AbstractFileVisitor {
     return relativePath;
   }
 
-  private isSuccessOrRedirectApiResponseArg(decorator: ts.Decorator): boolean {
+  private isSuccessOrRedirectApiResponseArg(
+    decorator: ts.Decorator,
+    typeChecker: ts.TypeChecker
+  ): boolean {
     const [firstArg] = getDecoratorArguments(decorator);
     if (!firstArg || !ts.isObjectLiteralExpression(firstArg)) return true;
     const statusProp = firstArg.properties.find(
@@ -780,7 +783,26 @@ export class ControllerClassVisitor extends AbstractFileVisitor {
         init.text === 'default'
       );
     }
-    // Non-literal (e.g. HttpStatus.OK) — can't evaluate at compile time; preserve pre-PR behavior.
+    if (
+      ts.isPropertyAccessExpression(init) ||
+      ts.isElementAccessExpression(init)
+    ) {
+      const constantValue = typeChecker.getConstantValue(init);
+      if (typeof constantValue === 'number') {
+        return constantValue < 400;
+      }
+      if (
+        ts.isPropertyAccessExpression(init) &&
+        ts.isIdentifier(init.expression) &&
+        init.expression.text === 'HttpStatus'
+      ) {
+        const status = HttpStatus[init.name.text as keyof typeof HttpStatus];
+        if (typeof status === 'number') {
+          return status < 400;
+        }
+      }
+    }
+    // Unknown expressions cannot be safely evaluated at compile time.
     return true;
   }
 }

--- a/test/plugin/controller-class-visitor.spec.ts
+++ b/test/plugin/controller-class-visitor.spec.ts
@@ -149,6 +149,77 @@ describe('Controller methods', () => {
     );
   });
 
+  it('should auto-infer the default 2xx response for enum error statuses', () => {
+    const options: ts.CompilerOptions = {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2021,
+      newLine: ts.NewLineKind.LineFeed,
+      noEmitHelpers: true,
+      experimentalDecorators: true
+    };
+    const filename = 'app.controller.ts';
+    const fakeProgram = ts.createProgram([filename], options);
+    const source = `import { Controller, Get, HttpStatus } from '@nestjs/common';
+import { ApiResponse } from '@nestjs/swagger';
+
+@Controller('example')
+export class AppController {
+  @Get()
+  @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Bad request' })
+  get(): string {
+    return 'ok';
+  }
+}`;
+
+    const result = ts.transpileModule(source, {
+      compilerOptions: options,
+      fileName: filename,
+      transformers: {
+        before: [before({ introspectComments: true }, fakeProgram)]
+      }
+    });
+    expect(result.outputText).toContain(
+      'openapi.ApiResponse({ status: 200, type: String })'
+    );
+    expect(result.outputText).toContain(
+      'ApiResponse)({ status: common_1.HttpStatus.BAD_REQUEST'
+    );
+  });
+
+  it('should not auto-infer a response when an enum success status is explicit', () => {
+    const options: ts.CompilerOptions = {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2021,
+      newLine: ts.NewLineKind.LineFeed,
+      noEmitHelpers: true,
+      experimentalDecorators: true
+    };
+    const filename = 'app.controller.ts';
+    const fakeProgram = ts.createProgram([filename], options);
+    const source = `import { Controller, Get, HttpStatus } from '@nestjs/common';
+import { ApiResponse } from '@nestjs/swagger';
+
+@Controller('example')
+export class AppController {
+  @Get()
+  @ApiResponse({ status: HttpStatus.CREATED, description: 'Created' })
+  get(): string {
+    return 'ok';
+  }
+}`;
+
+    const result = ts.transpileModule(source, {
+      compilerOptions: options,
+      fileName: filename,
+      transformers: {
+        before: [before({ introspectComments: true }, fakeProgram)]
+      }
+    });
+    expect(result.outputText).not.toContain(
+      'openapi.ApiResponse({ status: 200, type: String })'
+    );
+  });
+
   it('should add response based on the return value (without modifiers)', () => {
     const options: ts.CompilerOptions = {
       module: ts.ModuleKind.CommonJS,


### PR DESCRIPTION
Fixes #4009

### Problem

When `@ApiResponse` uses an enum status such as `HttpStatus.BAD_REQUEST`, the Swagger plugin does not resolve the enum value and treats it as a success response.

As a result, the automatically generated `200` response is omitted.

### Fix

Pass the TypeScript `TypeChecker` to the status check and resolve enum members with `getConstantValue()`.

This preserves the existing behavior for numeric statuses and ensures that:

- enum error statuses keep the inferred success response
- enum success statuses suppress the inferred success response

### Tests

Added regression coverage for:

- `HttpStatus.BAD_REQUEST` with an inferred `200` response
- `HttpStatus.CREATED` suppressing the inferred `200` response

Verified with:

- `pnpm test`
- `pnpm run build`
- `pnpm run lint`
