### PR TITLE
fix(plugin): rebase readonly import paths onto the output directory

### DIFF
--- a/lib/plugin/utils/plugin-utils.ts
+++ b/lib/plugin/utils/plugin-utils.ts
@@ -294,7 +294,10 @@ export function replaceImportPath(
     };
   } catch {
     const from = options?.readonly
-      ? safeDecodeURIComponent(convertPath(options.pathToSource))
+      ? rebaseToOutputDir(
+          safeDecodeURIComponent(convertPath(options.pathToSource)),
+          options
+        )
       : getOutputDir(fileName, options);
 
     const targetPath =
@@ -356,6 +359,17 @@ function getOutputDir(fileName: string, options: PluginOptions): string {
   const sourceDir = posix.dirname(
     safeDecodeURIComponent(convertPath(fileName))
   );
+  return rebaseToOutputDir(sourceDir, options);
+}
+
+/**
+ * Rebases a source-tree directory onto the output tree using outDir/rootDir,
+ * the same transform getOutputDir() applies to a compiled file's directory.
+ * Used directly by the readonly (SWC/metadata.ts) path, where the "source
+ * directory" is pathToSource rather than a per-file directory, since the
+ * generated metadata.ts lives at the output location.
+ */
+function rebaseToOutputDir(sourceDir: string, options: PluginOptions): string {
   if (options.outDir && options.rootDir) {
     const outDir = convertPath(options.outDir);
     const rootDir = convertPath(options.rootDir);

--- a/lib/plugin/visitors/readonly.visitor.ts
+++ b/lib/plugin/visitors/readonly.visitor.ts
@@ -102,6 +102,15 @@ export class ReadonlyVisitor {
 
   visit(program: ts.Program, sf: ts.SourceFile) {
     const factoryHost = { factory: ts.factory } as any;
+
+    const compilerOptions = program.getCompilerOptions();
+    if (compilerOptions.outDir) {
+      this.options.outDir ??= compilerOptions.outDir;
+    }
+    if (compilerOptions.rootDir) {
+      this.options.rootDir ??= compilerOptions.rootDir;
+    }
+
     const parsedOptions: Record<string, any> = mergePluginOptions(this.options);
 
     if (isFilenameMatched(parsedOptions.dtoFileNameSuffix, sf.fileName)) {

--- a/test/plugin/fixtures/readonly-outdir/src/nested/nested.dto.ts
+++ b/test/plugin/fixtures/readonly-outdir/src/nested/nested.dto.ts
@@ -1,0 +1,5 @@
+import { SharedDto } from '../../../shared-lib/shared.dto';
+
+export class NestedDto {
+  shared: SharedDto;
+}

--- a/test/plugin/fixtures/readonly-outdir/tsconfig.json
+++ b/test/plugin/fixtures/readonly-outdir/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "declaration": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
+    "target": "ES2021",
+    "rootDir": ".",
+    "outDir": "./dist",
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/test/plugin/fixtures/shared-lib/shared.dto.ts
+++ b/test/plugin/fixtures/shared-lib/shared.dto.ts
@@ -1,0 +1,3 @@
+export class SharedDto {
+  id: number;
+}

--- a/test/plugin/plugin-utils.spec.ts
+++ b/test/plugin/plugin-utils.spec.ts
@@ -175,6 +175,40 @@ describe('plugin-utils', () => {
       expect(result.typeReference).not.toContain('/src/');
     });
 
+    it('should adjust relative path depth in readonly mode when outDir is deeper than rootDir', () => {
+      // Readonly (SWC/metadata.ts generation) mode must rebase pathToSource
+      // through outDir/rootDir the same way normal mode rebases the source
+      // file's directory, since the generated metadata.ts effectively lives
+      // at the output location, not the source location.
+      const typeReference =
+        'import("/project/src/entities/test.entity").TestEnum';
+      const fileName = '/project/src/dto/nested/test.dto.ts';
+      const readonlyOptions = {
+        readonly: true,
+        pathToSource: '/project/src/dto/nested',
+        rootDir: '/project/src',
+        outDir: '/project/dist'
+      };
+      const nonReadonlyOptions = {
+        rootDir: '/project/src',
+        outDir: '/project/dist'
+      };
+
+      const readonlyResult = replaceImportPath(
+        typeReference,
+        fileName,
+        readonlyOptions
+      );
+      const nonReadonlyResult = replaceImportPath(
+        typeReference,
+        fileName,
+        nonReadonlyOptions
+      );
+
+      expect(readonlyResult.importPath).not.toContain('/dist/');
+      expect(readonlyResult.importPath).toBe(nonReadonlyResult.importPath);
+    });
+
     it('should fall back to source-based path when outDir/rootDir are absent', () => {
       // Baseline behaviour must be preserved when options do not include outDir/rootDir.
       const typeReference =

--- a/test/plugin/readonly-visitor-outdir.spec.ts
+++ b/test/plugin/readonly-visitor-outdir.spec.ts
@@ -1,0 +1,80 @@
+import { join } from 'path';
+import * as ts from 'typescript';
+import { ReadonlyVisitor } from '../../lib/plugin/visitors/readonly.visitor';
+
+function createTsProgram(tsconfigPath: string) {
+  const parsedCmd = ts.getParsedCommandLineOfConfigFile(
+    tsconfigPath,
+    undefined,
+    ts.sys as unknown as ts.ParseConfigFileHost
+  );
+  const { options, fileNames: rootNames } = parsedCmd!;
+  return ts.createProgram({ options, rootNames });
+}
+
+describe('ReadonlyVisitor with outDir deeper than rootDir', () => {
+  // Fixture layout (tsconfig: rootDir=".", outDir="./dist"):
+  //   src/nested/nested.dto.ts  -> imports SharedDto from '../../../shared-lib/shared.dto'
+  //
+  // shared-lib/ lives OUTSIDE the project's rootDir, so the import target is
+  // never remapped through outDir/rootDir (that remap only applies to imports
+  // within rootDir). That isolates the readonly `from` computation: a fixture
+  // where the import target also stays within rootDir gets rebased on both
+  // sides by the same amount, so a broken (un-rebased) `from` and a fixed one
+  // produce the identical relative path - the bug cancels itself out.
+  const projectDir = join(__dirname, 'fixtures', 'readonly-outdir');
+  const tsconfigPath = join(projectDir, 'tsconfig.json');
+
+  // metadata.ts is generated at pathToSource ("src", mirroring where a real
+  // project emits it before compilation) and must be rebased through
+  // outDir/rootDir just like every other compiled file, or the generated
+  // import ends up at the wrong "../" depth and breaks at runtime.
+  const CORRECT_IMPORT_PATH = '../../../shared-lib/shared.dto';
+
+  it('should generate metadata import paths rebased to outDir, matching the fixed depth', () => {
+    const program = createTsProgram(tsconfigPath);
+
+    // outDir/rootDir are intentionally NOT passed here: they must be
+    // auto-derived from the ts.Program's compiler options, mirroring
+    // compiler-plugin.ts's before() hook.
+    const visitor = new ReadonlyVisitor({
+      pathToSource: join(projectDir, 'src'),
+      dtoFileNameSuffix: ['.dto.ts']
+    });
+
+    for (const sourceFile of program.getSourceFiles()) {
+      if (!sourceFile.isDeclarationFile) {
+        visitor.visit(program, sourceFile);
+      }
+    }
+
+    const importPaths = Object.keys(visitor.typeImports);
+    expect(importPaths).toEqual([CORRECT_IMPORT_PATH]);
+  });
+
+  it('should not override an explicit outDir/rootDir with the program compiler options', () => {
+    const program = createTsProgram(tsconfigPath);
+
+    // Explicit rootDir === pathToSource (0 segments to rebase) and a
+    // differently-named outDir. If honored, the result has one fewer "../"
+    // than the tsconfig-derived depth (outDir="./dist", rootDir="." => 1
+    // segment "src" to rebase); if the caller's options get silently
+    // overwritten by the program's compilerOptions, the result reverts to
+    // the tsconfig-derived depth instead.
+    const visitor = new ReadonlyVisitor({
+      pathToSource: join(projectDir, 'src'),
+      dtoFileNameSuffix: ['.dto.ts'],
+      outDir: join(projectDir, 'explicit-dist'),
+      rootDir: join(projectDir, 'src')
+    });
+
+    for (const sourceFile of program.getSourceFiles()) {
+      if (!sourceFile.isDeclarationFile) {
+        visitor.visit(program, sourceFile);
+      }
+    }
+
+    const importPaths = Object.keys(visitor.typeImports);
+    expect(importPaths).toEqual(['../../shared-lib/shared.dto']);
+  });
+});


### PR DESCRIPTION
### What

When the CLI plugin runs in readonly mode (the metadata-generation path used by the SWC builder), generated relative imports are computed incorrectly whenever `outDir` is deeper than `rootDir`: the output directory leaks into the emitted relative path and the import fails to resolve.

For example, with `rootDir: "."` and `outDir: "./dist"`, an import that should be `../../entities/entity.dto` is emitted as `../../../dist/entities/entity.dto`.

### Why

`replaceImportPath()` computes the `from` side differently per mode:

```ts
const from = options?.readonly
  ? safeDecodeURIComponent(convertPath(options.pathToSource))
  : getOutputDir(fileName, options);
```

The non-readonly branch rebases `from` onto `outDir` (added in #3847), and the import target was later rebased as well (#3858). The readonly branch, however, keeps the raw `pathToSource` while the target side still goes through the rebase, so the two are compared in different coordinate spaces.

The second half of the problem is that even once the readonly branch rebases `from`, no real caller supplies `outDir`/`rootDir` in readonly mode: `nest-cli`'s metadata generator constructs `ReadonlyVisitor` without them.

### Fix

1. Rebase the readonly `from` path through the same output-directory logic as the non-readonly path (extracted into a shared helper reused by `getOutputDir`).
2. Have `ReadonlyVisitor.visit()` derive `outDir`/`rootDir` from `program.getCompilerOptions()` when the caller did not pass them, mirroring how `compiler-plugin.ts`'s `before()` hook already does it. Explicit options passed by a caller still take precedence.

### Tests

- A unit test in `plugin-utils.spec.ts` comparing readonly vs non-readonly output for a nested `outDir`, asserting no output-directory leak.
- `readonly-visitor-outdir.spec.ts`, modelled on the existing `readonly-visitor-project-refs.spec.ts`: it builds a real `ts.Program` from a fixture whose import target lives outside `rootDir` (so the rebase is not accidentally cancelled out), constructs `ReadonlyVisitor` without explicit `outDir`/`rootDir`, and asserts the emitted import path is correct. Reverting either part of the fix independently makes this test fail. A second case asserts that an explicit `outDir` passed to the visitor is not overwritten by the program's compiler options.

Full unit suite passes (406 tests).