### PR TITLE
fix(type-helpers): apply deep partial substitution to plugin metadata

### DIFF
--- a/lib/type-helpers/deep-partial-type.helper.ts
+++ b/lib/type-helpers/deep-partial-type.helper.ts
@@ -37,10 +37,24 @@ function isDtoClass(typeRef: unknown): typeRef is Type<unknown> {
   ) {
     return false;
   }
+  // A lazy factory that throws is handed back as-is by the caller, and an arrow
+  // function has no prototype. Bail out before `getModelProperties` dereferences
+  // it, otherwise resolving the type would throw instead of leaving it alone.
+  if (!(typeRef as Type<unknown>).prototype) {
+    return false;
+  }
   const fields = modelPropertiesAccessor.getModelProperties(
     (typeRef as Type<unknown>).prototype
   );
-  return fields.length > 0;
+  if (fields.length > 0) {
+    return true;
+  }
+  // A DTO written with the CLI plugin carries no `@ApiProperty()` metadata of
+  // its own; its properties only exist in the generated metadata factory, which
+  // is not applied to the prototype until the schema is explored.
+  return (
+    typeof (typeRef as Type<unknown>)[METADATA_FACTORY_NAME] === 'function'
+  );
 }
 
 /**
@@ -105,23 +119,14 @@ export function DeepPartialType<T>(
         mapValues(metadata, (item) => ({ ...item, required: false }))
     );
 
-    if (DeepPartialTypeClass[METADATA_FACTORY_NAME]) {
-      const pluginFields = Object.keys(
-        DeepPartialTypeClass[METADATA_FACTORY_NAME]()
-      );
-      pluginFields.forEach((key) =>
-        applyPartialDecoratorFn(DeepPartialTypeClass, key)
-      );
-    }
-
-    fields.forEach((key) => {
-      const metadata =
-        Reflect.getMetadata(
-          DECORATORS.API_MODEL_PROPERTIES,
-          classRef.prototype,
-          key
-        ) || {};
-
+    // Applies the recursive type substitution for a single property. Shared by
+    // the explicitly decorated properties and by the ones that only exist in
+    // the plugin-generated metadata factory, so both routes end up with the
+    // nested DTO wrapped in `DeepPartialType`.
+    function applyDeepPartialProperty(
+      metadata: Record<string, any>,
+      key: string
+    ) {
       // Resolve the effective type, supporting lazy factory functions
       let resolvedType = metadata.type;
       if (typeof resolvedType === 'function' && resolvedType.length === 0) {
@@ -132,7 +137,7 @@ export function DeepPartialType<T>(
         }
       }
 
-      // Unwrap array type: [SomeDto] → SomeDto. An array can be expressed
+      // Unwrap array type: [SomeDto] -> SomeDto. An array can be expressed
       // either through the `isArray` flag or by wrapping the type in a
       // single-element tuple (commonly returned from a lazy factory, e.g.
       // `type: () => [SomeDto]`). Capture the array-ness so it can be
@@ -158,8 +163,30 @@ export function DeepPartialType<T>(
         required: false
       });
       decoratorFactory(DeepPartialTypeClass.prototype, key);
+    }
+
+    fields.forEach((key) => {
+      const metadata =
+        Reflect.getMetadata(
+          DECORATORS.API_MODEL_PROPERTIES,
+          classRef.prototype,
+          key
+        ) || {};
+
+      applyDeepPartialProperty(metadata, key);
       applyPartialDecoratorFn(DeepPartialTypeClass, key);
     });
+
+    if (DeepPartialTypeClass[METADATA_FACTORY_NAME]) {
+      const pluginMetadata = DeepPartialTypeClass[METADATA_FACTORY_NAME]();
+      const pluginFields = Object.keys(pluginMetadata);
+      pluginFields.forEach((key) => {
+        if (!fields.includes(key)) {
+          applyDeepPartialProperty(pluginMetadata[key], key);
+        }
+        applyPartialDecoratorFn(DeepPartialTypeClass, key);
+      });
+    }
   }
   applyFields(fields);
 

--- a/test/type-helpers/deep-partial-type.helper.spec.ts
+++ b/test/type-helpers/deep-partial-type.helper.spec.ts
@@ -1,5 +1,6 @@
 import { DECORATORS } from '../../lib/constants';
 import { ApiProperty } from '../../lib/decorators';
+import { METADATA_FACTORY_NAME } from '../../lib/plugin/plugin-constants';
 import { ModelPropertiesAccessor } from '../../lib/services/model-properties-accessor';
 import { DeepPartialType } from '../../lib/type-helpers';
 
@@ -176,6 +177,232 @@ describe('DeepPartialType', () => {
       expect(meta.isArray).toBe(true);
       expect(meta.required).toBe(false);
       expect(meta.type).not.toBe(TagDto);
+    });
+  });
+
+  describe('plugin-generated metadata', () => {
+    class PluginAddressDto {
+      street: string;
+      city: string;
+
+      static [METADATA_FACTORY_NAME]() {
+        return {
+          street: { required: true, type: () => String },
+          city: { required: true, type: () => String }
+        };
+      }
+    }
+
+    class PluginProfileDto {
+      bio: string;
+      address: PluginAddressDto;
+
+      static [METADATA_FACTORY_NAME]() {
+        return {
+          bio: { required: true, type: () => String },
+          address: { required: true, type: () => PluginAddressDto }
+        };
+      }
+    }
+
+    class PluginUserDto {
+      name: string;
+      profile: PluginProfileDto;
+
+      static [METADATA_FACTORY_NAME]() {
+        return {
+          name: { required: true, type: () => String },
+          profile: { required: true, type: () => PluginProfileDto }
+        };
+      }
+    }
+
+    class UpdatePluginUserDto extends DeepPartialType(PluginUserDto) {}
+
+    beforeAll(() => {
+      modelPropertiesAccessor.applyMetadataFactory(
+        UpdatePluginUserDto.prototype
+      );
+    });
+
+    it('should mark plugin-declared top-level properties as optional', () => {
+      expect(getMetadata(UpdatePluginUserDto, 'name').required).toBe(false);
+      expect(getMetadata(UpdatePluginUserDto, 'profile').required).toBe(false);
+    });
+
+    it('should leave plugin-declared primitive types unchanged', () => {
+      const nameMeta = getMetadata(UpdatePluginUserDto, 'name');
+      expect(typeof nameMeta.type).toBe('function');
+      expect(nameMeta.type()).toBe(String);
+    });
+
+    it('should wrap nested DTOs declared only in the metadata factory', () => {
+      const NestedProfileType = getMetadata(
+        UpdatePluginUserDto,
+        'profile'
+      ).type;
+
+      expect(NestedProfileType).not.toBe(PluginProfileDto);
+
+      const bioMeta = Reflect.getMetadata(
+        DECORATORS.API_MODEL_PROPERTIES,
+        NestedProfileType.prototype,
+        'bio'
+      );
+      expect(bioMeta.required).toBe(false);
+    });
+
+    it('should recursively wrap deeply nested plugin DTOs', () => {
+      const NestedProfileType = getMetadata(
+        UpdatePluginUserDto,
+        'profile'
+      ).type;
+      const NestedAddressType = Reflect.getMetadata(
+        DECORATORS.API_MODEL_PROPERTIES,
+        NestedProfileType.prototype,
+        'address'
+      ).type;
+
+      expect(NestedAddressType).not.toBe(PluginAddressDto);
+
+      const streetMeta = Reflect.getMetadata(
+        DECORATORS.API_MODEL_PROPERTIES,
+        NestedAddressType.prototype,
+        'street'
+      );
+      expect(streetMeta.required).toBe(false);
+    });
+  });
+
+  describe('plugin-generated arrays', () => {
+    class PluginTagDto {
+      label: string;
+
+      static [METADATA_FACTORY_NAME]() {
+        return { label: { required: true, type: () => String } };
+      }
+    }
+
+    class PluginArticleDto {
+      tags: PluginTagDto[];
+
+      static [METADATA_FACTORY_NAME]() {
+        return { tags: { required: true, type: () => [PluginTagDto] } };
+      }
+    }
+
+    it('should preserve array-ness for a plugin-declared nested DTO array', () => {
+      class UpdatePluginArticleDto extends DeepPartialType(PluginArticleDto) {}
+      const meta = getMetadata(UpdatePluginArticleDto, 'tags');
+
+      expect(meta.isArray).toBe(true);
+      expect(meta.required).toBe(false);
+      expect(meta.type).not.toBe(PluginTagDto);
+      expect(
+        Reflect.getMetadata(
+          DECORATORS.API_MODEL_PROPERTIES,
+          meta.type.prototype,
+          'label'
+        ).required
+      ).toBe(false);
+    });
+  });
+
+  describe('lazy factory that throws', () => {
+    it('should leave the property type alone instead of propagating the error', () => {
+      class ThrowingPluginDto {
+        broken: unknown;
+
+        static [METADATA_FACTORY_NAME]() {
+          return {
+            broken: {
+              required: true,
+              type: () => {
+                throw new Error('circular import not resolved yet');
+              }
+            }
+          };
+        }
+      }
+
+      expect(() => DeepPartialType(ThrowingPluginDto)).not.toThrow();
+    });
+
+    it('should leave an explicitly decorated throwing factory alone', () => {
+      class ThrowingExplicitDto {
+        @ApiProperty({
+          type: () => {
+            throw new Error('circular import not resolved yet');
+          }
+        })
+        broken: unknown;
+      }
+
+      expect(() => DeepPartialType(ThrowingExplicitDto)).not.toThrow();
+    });
+  });
+
+  describe('mixed explicit and plugin-generated metadata', () => {
+    class MixedTagDto {
+      @ApiProperty({ type: String, required: true })
+      label: string;
+    }
+
+    class MixedSettingsDto {
+      theme: string;
+
+      static [METADATA_FACTORY_NAME]() {
+        return { theme: { required: true, type: () => String } };
+      }
+    }
+
+    class MixedAccountDto {
+      @ApiProperty({ type: () => MixedTagDto, required: true })
+      tag: MixedTagDto;
+
+      settings: MixedSettingsDto;
+
+      static [METADATA_FACTORY_NAME]() {
+        return {
+          settings: { required: true, type: () => MixedSettingsDto }
+        };
+      }
+    }
+
+    class UpdateMixedAccountDto extends DeepPartialType(MixedAccountDto) {}
+
+    beforeAll(() => {
+      modelPropertiesAccessor.applyMetadataFactory(
+        UpdateMixedAccountDto.prototype
+      );
+    });
+
+    it('should wrap the explicitly decorated nested DTO', () => {
+      const meta = getMetadata(UpdateMixedAccountDto, 'tag');
+
+      expect(meta.required).toBe(false);
+      expect(meta.type).not.toBe(MixedTagDto);
+      expect(
+        Reflect.getMetadata(
+          DECORATORS.API_MODEL_PROPERTIES,
+          meta.type.prototype,
+          'label'
+        ).required
+      ).toBe(false);
+    });
+
+    it('should wrap the plugin-declared nested DTO on the same class', () => {
+      const meta = getMetadata(UpdateMixedAccountDto, 'settings');
+
+      expect(meta.required).toBe(false);
+      expect(meta.type).not.toBe(MixedSettingsDto);
+      expect(
+        Reflect.getMetadata(
+          DECORATORS.API_MODEL_PROPERTIES,
+          meta.type.prototype,
+          'theme'
+        ).required
+      ).toBe(false);
     });
   });
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

- [x] Bugfix

## What is the current behavior?

Issue Number: N/A

`DeepPartialType` only walks properties that carry explicit `@ApiProperty()` metadata. For a DTO written with the CLI plugin, the properties live in the generated metadata factory instead, so two things go wrong:

1. The plugin branch applies the optional validation decorator but never re-applies `ApiProperty`, so nested DTOs keep their original fully required type.
2. `isDtoClass` decides whether a property type is a DTO by reading `API_MODEL_PROPERTIES_ARRAY` off the prototype. A plugin generated DTO has nothing there until the schema is explored, so nested plugin DTOs are not recognized as DTOs at all and the recursive wrapping is skipped.

The net effect is that `DeepPartialType` behaves like `PartialType` for anyone using the plugin, which is the recommended setup. Nested fields stay required.

`applyMetadataFactory` does not compensate for this. It applies the factory as `ApiProperty`, but it does not replace `type: () => Inner` with `DeepPartialType(Inner)`.

## What is the new behavior?

The plugin fields branch now applies `ApiProperty` eagerly with the same recursive type substitution used for explicitly decorated fields. This is the pattern #3822 introduced for `PartialType`, `OmitType` and `PickType`. `DeepPartialType` landed at almost the same time as that PR, so the two were in flight together and it never picked the pattern up.

`isDtoClass` also falls back to detecting the metadata factory, which is what actually enables the recursive wrapping. Reverting only that part while keeping the plugin fields branch still fails three of the new tests, and all three are the nested wrapping cases. Both changes are load bearing.

The fallback also fixes a second case that has nothing to do with the plugin branch: an explicit `@ApiProperty({ type: () => SomePluginDto })` pointing at a plugin generated DTO now gets wrapped too.

While adding the fallback I hit a crash that already exists on master. If a lazy type factory throws, for example during a circular import, the catch hands the arrow function itself back as the resolved type. Arrow functions have no prototype, so `getModelProperties` dereferences `undefined` and reflect-metadata throws out of `DeepPartialType` at class definition time. That path was reachable through explicit decorators before this PR, and the plugin branch would have widened it, since the plugin emits `type: () => X` for every property. A prototype guard in `isDtoClass` closes both.

Tests cover the plugin only nested DTO, deep recursion through two levels, plugin declared arrays, the mixed case where one class has both explicit and plugin metadata, and the throwing factory on both routes. The existing explicit decorator tests are unchanged and keep passing, which is the control.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Full suite passes at 412 tests. Reverting the source while keeping the new tests fails 5 of them.
