### PR TITLE
fix(plugin): handle decorators with property access expressions in getIdentifierFromName

### DIFF
--- a/lib/plugin/utils/ast-utils.ts
+++ b/lib/plugin/utils/ast-utils.ts
@@ -52,8 +52,7 @@ export function getTypeArguments(type: Type) {
 
 export function isBoolean(type: Type) {
   return (
-    hasFlag(type, TypeFlags.Boolean) ||
-    hasFlag(type, TypeFlags.BooleanLiteral)
+    hasFlag(type, TypeFlags.Boolean) || hasFlag(type, TypeFlags.BooleanLiteral)
   );
 }
 
@@ -368,7 +367,7 @@ export function getNamedParamDecoratorArg(
 
 function getIdentifierFromName(expression: LeftHandSideExpression) {
   const identifier = getNameFromExpression(expression);
-  if (expression && expression.kind !== SyntaxKind.Identifier) {
+  if (identifier && identifier.kind !== SyntaxKind.Identifier) {
     throw new Error();
   }
   return identifier;

--- a/test/plugin/model-class-visitor.spec.ts
+++ b/test/plugin/model-class-visitor.spec.ts
@@ -721,4 +721,38 @@ describe('API model properties', () => {
       `gender: { required: true, type: () => Object, enum: ['a', 1] }`
     );
   });
+
+  it('should handle decorators that use namepsace imports', () => {
+    const options: ts.CompilerOptions = {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      newLine: ts.NewLineKind.LineFeed,
+      noEmitHelpers: true,
+      experimentalDecorators: true,
+      strict: true
+    };
+    const filename = 'decorator-with-namespace-import.dto.ts';
+    const fakeProgram = ts.createProgram([filename], options);
+
+    const dtoText = `
+      import * as class_validator from 'class-validator';
+
+      export class HasNamespaceImportDecoratorDto {
+        @class_validator.IsIn(["red", "green", "blue"])
+        color: string;
+      }
+    `;
+
+    const result = ts.transpileModule(dtoText, {
+      compilerOptions: options,
+      fileName: filename,
+      transformers: {
+        before: [before({ classValidatorShim: true }, fakeProgram)]
+      }
+    });
+
+    expect(result.outputText).toContain(
+      `color: { required: true, type: () => String, enum: ["red", "green", "blue"] }`
+    );
+  });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

When the plugin inspects decorators that use a property access expression, such as with a namespace import in the below example, the `getIdentifierFromName()` utility function throws and the decorator is not handled.

```
import * as class_validator from "class-validator"

class TestDto {
  @class_validator.IsIn(["red", "green", "blue"])
  color: string;
}
```

Issue Number: N/A


## What is the new behavior?

The decorator name identifier is returned, `IsIn` in the above example, and the decorator is handled.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information
Since `getNameFromExpression` right below has explicit support for property access expressions, I believe this is was a simple typo. (checking `expression` instead of `identifier` return by `getNameFromExpression`, which is then returned). 

I ran into this issue while developing a different NestJS CLI plugin, which I want to run _before_ the `@nestjs/swagger` one, which is generating class-validator and class-transformer decorators based on typescript types. Without using namespace imports, typescript strips the necessary import declarations when emitting, which I believe is why this plugin uses the same technique in `abstract.visitor.ts`.

This is my first PR in this repo, so if I'm not following correct patterns, let me know and I'll happily adjust.