### PR TITLE
feat(api-header): support custom OpenAPI extensions

### DIFF
--- a/lib/decorators/api-header.decorator.ts
+++ b/lib/decorators/api-header.decorator.ts
@@ -1,4 +1,4 @@
-import { isNil, isUndefined, negate, pickBy } from 'lodash';
+import { clone, isNil, isUndefined, negate, pickBy } from 'lodash';
 import { DECORATORS } from '../constants';
 import {
   ParameterLocation,
@@ -10,6 +10,8 @@ import { createClassDecorator, createParamDecorator } from './helpers';
 
 export interface ApiHeaderOptions extends Omit<ParameterObject, 'in'> {
   enum?: SwaggerEnumType;
+  // Allow passing custom OpenAPI extensions for parameters
+  extensions?: Record<string, any>;
 }
 
 const defaultHeaderOptions: Partial<ApiHeaderOptions> = {
@@ -58,6 +60,19 @@ export function ApiHeader(
       enum: enumValues,
       type: getEnumType(enumValues)
     };
+  }
+
+  // Merge custom OpenAPI extensions into parameter metadata.
+  // Accept an `extensions` bag on the options similar to how `@ApiExtension` works
+  // (and consistent with `@ApiParam` and `@ApiQuery`).
+  const extensions = options.extensions;
+  if (extensions && typeof extensions === 'object') {
+    const cloned = clone(extensions);
+    for (const [key, value] of Object.entries(cloned)) {
+      // Ensure extension keys are prefixed with 'x-'
+      const extKey = key.startsWith('x-') ? key : `x-${key}`;
+      (param as Record<string, any>)[extKey] = value;
+    }
   }
 
   return (

--- a/test/decorators/api-header.decorator.spec.ts
+++ b/test/decorators/api-header.decorator.spec.ts
@@ -114,4 +114,109 @@ describe('ApiHeader', () => {
       ]);
     });
   });
+
+  describe('extensions support', () => {
+    it('should merge extensions into parameter metadata when provided (method level)', () => {
+      class TestAppController {
+        @ApiHeader({
+          name: 'X-Api-Key',
+          extensions: { 'x-permissions': ['test.customer.add'] }
+        })
+        @Get()
+        public get(): void {}
+      }
+
+      const controller = new TestAppController();
+      expect(
+        Reflect.getMetadata(DECORATORS.API_PARAMETERS, controller.get)
+      ).toEqual([
+        {
+          name: 'X-Api-Key',
+          in: 'header',
+          schema: { type: 'string' },
+          'x-permissions': ['test.customer.add']
+        }
+      ]);
+    });
+
+    it('should auto-prefix extension keys without x- (method level)', () => {
+      class TestAppController {
+        @ApiHeader({
+          name: 'X-Api-Key',
+          extensions: { permissions: ['test.customer.add'] }
+        })
+        @Get()
+        public get(): void {}
+      }
+
+      const controller = new TestAppController();
+      expect(
+        Reflect.getMetadata(DECORATORS.API_PARAMETERS, controller.get)
+      ).toEqual([
+        {
+          name: 'X-Api-Key',
+          in: 'header',
+          schema: { type: 'string' },
+          'x-permissions': ['test.customer.add']
+        }
+      ]);
+    });
+
+    it('should merge extensions into header metadata when provided (class level)', () => {
+      @ApiHeader({
+        name: 'X-Api-Key',
+        extensions: { 'x-permissions': ['test.customer.add'] }
+      })
+      @Controller('test')
+      class TestAppController {}
+
+      expect(
+        Reflect.getMetadata(DECORATORS.API_HEADERS, TestAppController)
+      ).toEqual([
+        {
+          name: 'X-Api-Key',
+          in: 'header',
+          schema: { type: 'string' },
+          'x-permissions': ['test.customer.add']
+        }
+      ]);
+    });
+
+    it('should not leave a raw "extensions" key in the parameter metadata', () => {
+      class TestAppController {
+        @ApiHeader({
+          name: 'X-Api-Key',
+          extensions: { 'x-permissions': ['test.customer.add'] }
+        })
+        @Get()
+        public get(): void {}
+      }
+
+      const controller = new TestAppController();
+      const metadata = Reflect.getMetadata(
+        DECORATORS.API_PARAMETERS,
+        controller.get
+      );
+      expect(metadata[0]).not.toHaveProperty('extensions');
+    });
+
+    it('should not change metadata when extensions is not provided (no-op)', () => {
+      class TestAppController {
+        @ApiHeader({ name: 'X-Api-Key' })
+        @Get()
+        public get(): void {}
+      }
+
+      const controller = new TestAppController();
+      expect(
+        Reflect.getMetadata(DECORATORS.API_PARAMETERS, controller.get)
+      ).toEqual([
+        {
+          name: 'X-Api-Key',
+          in: 'header',
+          schema: { type: 'string' }
+        }
+      ]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

`@ApiParam` and `@ApiQuery` both accept an `extensions` bag and flatten each entry into `x-*` keys on the emitted parameter object (`@ApiQuery` added in #3949). `@ApiHeader` does not, even though `ApiHeaderOptions extends Omit<ParameterObject, 'in'>` uses the same schema as the other two.

This PR mirrors that implementation in `@ApiHeader`:
- adds an optional `extensions` field to `ApiHeaderOptions`,
- merges each entry as an `x-`-prefixed key on the parameter metadata (auto-prefixing keys that don't already start with `x-`),
- works for both method-level and class-level usage.

No behaviour changes for callers that don't use `extensions`.

## Test plan

Added unit tests in `test/decorators/api-header.decorator.spec.ts`:
- merges `extensions` into parameter metadata (method level and class level),
- auto-prefixes extension keys without `x-`,
- asserts no raw `extensions` key remains on the emitted parameter,
- asserts metadata is unchanged when `extensions` is not provided.

`npm run test`, `npm run build` and `npm run lint` pass.
