### PR TITLE
feat(interfaces): export full OpenAPI object-model types in public API

### DIFF
--- a/lib/interfaces/index.ts
+++ b/lib/interfaces/index.ts
@@ -1,3 +1,3 @@
-export { ApiTagOptions, OpenAPIObject } from './open-api-spec.interface';
+export * from './open-api-spec.interface';
 export * from './swagger-custom-options.interface';
 export * from './swagger-document-options.interface';

--- a/test/utils/generate-schema.util.spec.ts
+++ b/test/utils/generate-schema.util.spec.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from '../../lib/decorators';
-import { generateSchema } from '../../lib/utils/generate-schema.util';
+import { generateSchema, SchemaObject } from '../../lib';
 
 describe('generateSchema', () => {
   class AddressDto {
@@ -61,5 +61,10 @@ describe('generateSchema', () => {
     };
     expect(composedSchema.oneOf).toHaveLength(2);
     expect(composedSchema.oneOf[0]).toBe(addressSchema);
+  });
+
+  it('returned schema is assignable to the public SchemaObject type', () => {
+    const { schema }: { schema: SchemaObject } = generateSchema(AddressDto);
+    expect(schema).toBeDefined();
   });
 });


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Only `OpenAPIObject` and `ApiTagOptions` are re-exported from `lib/interfaces/index.ts`. Every other type defined in `open-api-spec.interface.ts`; `SchemaObject`, `ReferenceObject`, `ParameterObject`, `ResponseObject`, `ComponentsObject`, etc.. is internal despite being referenced in public-facing signatures such as the return type of the recently added `generateSchema()` utility.

Consumers who need to type a variable or helper against these interfaces have no supported import path and must resort to deep `dist/` imports:

```ts
import { SchemaObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface';
```

This path is undocumented, not covered by the `exports` map in `package.json`, and can break silently across releases. As a concrete example, my downstream library had to introduce local structural copies of `SchemaObject`, `ReferenceObject`, `HeaderObject`, `ParameterStyle`, and `ExampleObject` as a workaround: https://github.com/Fcmam5/nest-problem-details/pull/51

Issue Number: N/A


## What is the new behavior?

`lib/interfaces/index.ts` now uses `export *` for `open-api-spec.interface.ts`, making the full OpenAPI object model available from the package entry point:

```ts
import { SchemaObject, ReferenceObject } from '@nestjs/swagger';
```

The `generateSchema` spec is updated to import from the public entry point and includes an explicit assertion that the returned value is assignable to `SchemaObject`, so any future regression is caught immediately.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

