### PR TITLE
fix(): rewrite nullable schemas for OpenAPI 3.1 documents

### DIFF
--- a/lib/swagger-module.ts
+++ b/lib/swagger-module.ts
@@ -19,6 +19,7 @@ import {
 import { assignTwoLevelsDeep } from './utils/assign-two-levels-deep.js';
 import { getGlobalPrefix } from './utils/get-global-prefix.js';
 import { isOas31OrLater } from './utils/is-oas31-or-later.util.js';
+import { rewriteNullableForOas31 } from './utils/rewrite-nullable-for-oas31.util.js';
 import { normalizeRelPath } from './utils/normalize-rel-path.js';
 import { resolvePath } from './utils/resolve-path.util.js';
 import { validateGlobalPrefix } from './utils/validate-global-prefix.util.js';
@@ -76,19 +77,23 @@ export class SwaggerModule {
       ...documentWithoutWebhooks
     };
 
-    if (shouldIncludeWebhooks) {
-      return {
-        ...baseDocument,
-        ...(mergedWebhooks ? { webhooks: mergedWebhooks } : {})
-      };
+    const documentForVersion = shouldIncludeWebhooks
+      ? {
+          ...baseDocument,
+          ...(mergedWebhooks ? { webhooks: mergedWebhooks } : {})
+        }
+      : {
+          ...baseDocument,
+          paths: webhookPaths
+            ? assignTwoLevelsDeep({}, baseDocument.paths || {}, webhookPaths)
+            : baseDocument.paths
+        };
+
+    if (isOas31OrLater(documentForVersion.openapi ?? '3.0.0')) {
+      rewriteNullableForOas31(documentForVersion);
     }
 
-    return {
-      ...baseDocument,
-      paths: webhookPaths
-        ? assignTwoLevelsDeep({}, baseDocument.paths || {}, webhookPaths)
-        : baseDocument.paths
-    };
+    return documentForVersion;
   }
 
   public static async loadPluginMetadata(

--- a/lib/utils/rewrite-nullable-for-oas31.util.ts
+++ b/lib/utils/rewrite-nullable-for-oas31.util.ts
@@ -1,0 +1,42 @@
+/**
+ * OpenAPI 3.1 uses JSON Schema 2020-12, which dropped the `nullable` keyword.
+ * Convert 3.0-style `{ type: T, nullable: true }` into 3.1 unions.
+ */
+export function rewriteNullableForOas31(value: unknown): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      rewriteNullableForOas31(item);
+    }
+    return;
+  }
+  if (!value || typeof value !== 'object') {
+    return;
+  }
+
+  const obj = value as Record<string, unknown>;
+  for (const nested of Object.values(obj)) {
+    rewriteNullableForOas31(nested);
+  }
+
+  if (obj.nullable !== true) {
+    return;
+  }
+  delete obj.nullable;
+
+  if (typeof obj.type === 'string') {
+    obj.type = [obj.type, 'null'];
+    return;
+  }
+  if (Array.isArray(obj.type)) {
+    if (!obj.type.includes('null')) {
+      obj.type = [...obj.type, 'null'];
+    }
+    return;
+  }
+
+  const rest = { ...obj };
+  for (const key of Object.keys(obj)) {
+    delete obj[key];
+  }
+  obj.oneOf = [rest, { type: 'null' }];
+}

--- a/test/utils/rewrite-nullable-for-oas31.util.spec.ts
+++ b/test/utils/rewrite-nullable-for-oas31.util.spec.ts
@@ -1,0 +1,64 @@
+import { rewriteNullableForOas31 } from '../../lib/utils/rewrite-nullable-for-oas31.util';
+
+describe('rewriteNullableForOas31', () => {
+  it('converts a scalar type plus nullable into a type union', () => {
+    const schema: any = { type: 'string', nullable: true };
+
+    rewriteNullableForOas31(schema);
+
+    expect(schema).toEqual({ type: ['string', 'null'] });
+    expect(schema.nullable).toBeUndefined();
+  });
+
+  it('appends null to an existing type array', () => {
+    const schema: any = { type: ['string', 'number'], nullable: true };
+
+    rewriteNullableForOas31(schema);
+
+    expect(schema.type).toEqual(['string', 'number', 'null']);
+  });
+
+  it('rewrites nested property schemas', () => {
+    const schemas: any = {
+      User: {
+        type: 'object',
+        properties: {
+          deletedAt: { type: 'string', format: 'date-time', nullable: true },
+          name: { type: 'string' }
+        }
+      }
+    };
+
+    rewriteNullableForOas31(schemas);
+
+    expect(schemas.User.properties.deletedAt).toEqual({
+      type: ['string', 'null'],
+      format: 'date-time'
+    });
+    expect(schemas.User.properties.name).toEqual({ type: 'string' });
+  });
+
+  it('represents a nullable $ref/allOf schema as oneOf with null', () => {
+    const schema: any = {
+      nullable: true,
+      allOf: [{ $ref: '#/components/schemas/Profile' }]
+    };
+
+    rewriteNullableForOas31(schema);
+
+    expect(schema).toEqual({
+      oneOf: [
+        { allOf: [{ $ref: '#/components/schemas/Profile' }] },
+        { type: 'null' }
+      ]
+    });
+  });
+
+  it('leaves 3.0-compatible schemas without nullable unchanged', () => {
+    const schema: any = { type: 'string' };
+
+    rewriteNullableForOas31(schema);
+
+    expect(schema).toEqual({ type: 'string' });
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

\`DocumentBuilder.setOpenAPIVersion('3.1.0')\` sets \`openapi: 3.1.0\`, but schema properties still emit the OpenAPI 3.0 \`nullable\` keyword:

\`\`\`ts
@ApiProperty({ type: String, nullable: true })
// { \"type\": \"string\", \"nullable\": true }
\`\`\`

OpenAPI 3.1 uses JSON Schema 2020-12, which removed \`nullable\`. Strict 3.1 consumers therefore treat the property as a non-nullable string.

Issue Number: #4063

## What is the new behavior?

When the document version is 3.1 or later, \`SwaggerModule.createDocument\` rewrites:

- \`{ type: \"string\", nullable: true }\` to \`{ type: [\"string\", \"null\"] }\`
- nested property schemas the same way
- \`{ nullable: true, allOf: [{ \$ref }] }\` to \`{ oneOf: [allOf, { type: \"null\" }] }\`

3.0 documents are unchanged.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

Only 3.1+ documents change, and only to match the 3.1 schema language.

## Other information

Unit tests cover scalar unions, type arrays, nested properties, and nullable \`$ref\`/\`allOf\` schemas.
