### PR TITLE
fix(plugin): use namespace imports for ESM metadata type references

### DIFF
--- a/lib/plugin/utils/plugin-utils.ts
+++ b/lib/plugin/utils/plugin-utils.ts
@@ -342,6 +342,7 @@ export function replaceImportPath(
         convertToAsyncImport(typeReference);
       return {
         typeReference: `(${typeImportStatement}).${typeName}`,
+        typeName,
         importPath: relativePath
       };
     }

--- a/lib/plugin/utils/type-reference-to-identifier.util.ts
+++ b/lib/plugin/utils/type-reference-to-identifier.util.ts
@@ -77,9 +77,8 @@ export function typeReferenceToIdentifier(
     importPath &&
     typeName
   ) {
-    // ESM has no synchronous `require`, and the generated metadata is read
-    // synchronously, so the referenced module is hoisted to a namespace import
-    // instead of being awaited inline.
+    // The metadata is read synchronously, so the module is hoisted to a
+    // namespace import rather than awaited inline.
     const namespace = registerEsmTypeImport(importPath, typeImports);
 
     let ref = `${namespace}.${typeName}`;
@@ -100,7 +99,7 @@ export function typeReferenceToIdentifier(
 function registerEsmTypeImport(
   importPath: string,
   typeImports: Record<string, string>
-) {
+): string {
   if (!typeImports[importPath]) {
     const index = Object.keys(typeImports).length;
     typeImports[importPath] = `${OPENAPI_NAMESPACE}_import_${index}`;

--- a/lib/plugin/utils/type-reference-to-identifier.util.ts
+++ b/lib/plugin/utils/type-reference-to-identifier.util.ts
@@ -1,6 +1,7 @@
 import { posix } from 'path';
 import * as ts from 'typescript';
 import { PluginOptions } from '../merge-options.js';
+import { OPENAPI_NAMESPACE } from '../plugin-constants.js';
 import { pluginDebugLogger } from '../plugin-debug-logger.js';
 import {
   convertPath,
@@ -70,6 +71,22 @@ export function typeReferenceToIdentifier(
       ref = wrapTypeInArray(ref, typeReferenceDescriptor.arrayDepth);
     }
     identifier = factory.createIdentifier(ref);
+  } else if (
+    !options.readonly &&
+    options.esmCompatible &&
+    importPath &&
+    typeName
+  ) {
+    // ESM has no synchronous `require`, and the generated metadata is read
+    // synchronously, so the referenced module is hoisted to a namespace import
+    // instead of being awaited inline.
+    const namespace = registerEsmTypeImport(importPath, typeImports);
+
+    let ref = `${namespace}.${typeName}`;
+    if (typeReferenceDescriptor.isArray) {
+      ref = wrapTypeInArray(ref, typeReferenceDescriptor.arrayDepth);
+    }
+    identifier = factory.createIdentifier(ref);
   } else {
     let ref = typeReference;
     if (typeReferenceDescriptor.isArray) {
@@ -78,6 +95,17 @@ export function typeReferenceToIdentifier(
     identifier = factory.createIdentifier(ref);
   }
   return identifier;
+}
+
+function registerEsmTypeImport(
+  importPath: string,
+  typeImports: Record<string, string>
+) {
+  if (!typeImports[importPath]) {
+    const index = Object.keys(typeImports).length;
+    typeImports[importPath] = `${OPENAPI_NAMESPACE}_import_${index}`;
+  }
+  return typeImports[importPath];
 }
 
 /**

--- a/lib/plugin/visitors/abstract.visitor.ts
+++ b/lib/plugin/visitors/abstract.visitor.ts
@@ -47,6 +47,39 @@ export class AbstractFileVisitor {
     });
   }
 
+  /**
+   * Hoists the modules referenced by the generated metadata into namespace
+   * imports, so that those references can be resolved synchronously in ESM
+   * output, where `require()` is not available.
+   */
+  protected prependEsmTypeImports(
+    sourceFile: ts.SourceFile,
+    factory: ts.NodeFactory,
+    typeImports: Record<string, string>
+  ): ts.SourceFile {
+    const importPaths = Object.keys(typeImports);
+    if (!importPaths.length) {
+      return sourceFile;
+    }
+    const importDeclarations = importPaths.map((importPath) =>
+      factory.createImportDeclaration(
+        undefined,
+        factory.createImportClause(
+          false,
+          undefined,
+          factory.createNamespaceImport(
+            factory.createIdentifier(typeImports[importPath])
+          )
+        ),
+        factory.createStringLiteral(importPath)
+      )
+    );
+    return factory.updateSourceFile(sourceFile, [
+      ...importDeclarations,
+      ...sourceFile.statements
+    ]);
+  }
+
   updateImports(
     sourceFile: ts.SourceFile,
     factory: ts.NodeFactory | undefined,

--- a/lib/plugin/visitors/abstract.visitor.ts
+++ b/lib/plugin/visitors/abstract.visitor.ts
@@ -55,8 +55,12 @@ export class AbstractFileVisitor {
   protected prependEsmTypeImports(
     sourceFile: ts.SourceFile,
     factory: ts.NodeFactory,
-    typeImports: Record<string, string>
+    typeImports: Record<string, string>,
+    options: PluginOptions
   ): ts.SourceFile {
+    if (options.readonly) {
+      return sourceFile;
+    }
     const importPaths = Object.keys(typeImports);
     if (!importPaths.length) {
       return sourceFile;

--- a/lib/plugin/visitors/controller-class.visitor.ts
+++ b/lib/plugin/visitors/controller-class.visitor.ts
@@ -119,18 +119,11 @@ export class ControllerClassVisitor extends AbstractFileVisitor {
         return ts.visitEachChild(node, visitNode, ctx);
       }
     };
-    const updatedSourceFile = ts.visitNode(
-      sourceFile,
-      visitNode
-    ) as ts.SourceFile;
-
-    if (options.readonly) {
-      return updatedSourceFile;
-    }
     return this.prependEsmTypeImports(
-      updatedSourceFile,
+      ts.visitNode(sourceFile, visitNode) as ts.SourceFile,
       ctx.factory,
-      this._typeImports
+      this._typeImports,
+      options
     );
   }
 

--- a/lib/plugin/visitors/controller-class.visitor.ts
+++ b/lib/plugin/visitors/controller-class.visitor.ts
@@ -39,7 +39,7 @@ export class ControllerClassVisitor extends AbstractFileVisitor {
     string,
     Record<string, ClassMetadata>
   > = {};
-  private readonly _typeImports: Record<string, string> = {};
+  private _typeImports: Record<string, string> = {};
 
   get typeImports() {
     return this._typeImports;
@@ -64,6 +64,7 @@ export class ControllerClassVisitor extends AbstractFileVisitor {
     );
     const typeChecker = program.getTypeChecker();
     if (!options.readonly) {
+      this._typeImports = {};
       sourceFile = this.updateImports(sourceFile, ctx.factory, program, options);
     }
 
@@ -118,7 +119,19 @@ export class ControllerClassVisitor extends AbstractFileVisitor {
         return ts.visitEachChild(node, visitNode, ctx);
       }
     };
-    return ts.visitNode(sourceFile, visitNode);
+    const updatedSourceFile = ts.visitNode(
+      sourceFile,
+      visitNode
+    ) as ts.SourceFile;
+
+    if (options.readonly) {
+      return updatedSourceFile;
+    }
+    return this.prependEsmTypeImports(
+      updatedSourceFile,
+      ctx.factory,
+      this._typeImports
+    );
   }
 
   addDecoratorToNode(

--- a/lib/plugin/visitors/model-class.visitor.ts
+++ b/lib/plugin/visitors/model-class.visitor.ts
@@ -147,18 +147,11 @@ export class ModelClassVisitor extends AbstractFileVisitor {
         return ts.visitEachChild(node, visitClassNode, ctx);
       }
     };
-    const updatedSourceFile = ts.visitNode(
-      sourceFile,
-      visitClassNode
-    ) as ts.SourceFile;
-
-    if (options.readonly) {
-      return updatedSourceFile;
-    }
     return this.prependEsmTypeImports(
-      updatedSourceFile,
+      ts.visitNode(sourceFile, visitClassNode) as ts.SourceFile,
       ctx.factory,
-      this._typeImports
+      this._typeImports,
+      options
     );
   }
 

--- a/lib/plugin/visitors/model-class.visitor.ts
+++ b/lib/plugin/visitors/model-class.visitor.ts
@@ -40,7 +40,7 @@ import { AbstractFileVisitor } from './abstract.visitor.js';
 type ClassMetadata = Record<string, ts.ObjectLiteralExpression>;
 
 export class ModelClassVisitor extends AbstractFileVisitor {
-  private readonly _typeImports: Record<string, string> = {};
+  private _typeImports: Record<string, string> = {};
   private readonly _collectedMetadata: Record<string, ClassMetadata> = {};
 
   get typeImports() {
@@ -63,6 +63,9 @@ export class ModelClassVisitor extends AbstractFileVisitor {
       program.getCompilerOptions()
     );
     const typeChecker = program.getTypeChecker();
+    if (!options.readonly) {
+      this._typeImports = {};
+    }
     sourceFile = this.updateImports(sourceFile, ctx.factory, program, options);
 
     const propertyNodeVisitorFactory =
@@ -144,7 +147,19 @@ export class ModelClassVisitor extends AbstractFileVisitor {
         return ts.visitEachChild(node, visitClassNode, ctx);
       }
     };
-    return ts.visitNode(sourceFile, visitClassNode);
+    const updatedSourceFile = ts.visitNode(
+      sourceFile,
+      visitClassNode
+    ) as ts.SourceFile;
+
+    if (options.readonly) {
+      return updatedSourceFile;
+    }
+    return this.prependEsmTypeImports(
+      updatedSourceFile,
+      ctx.factory,
+      this._typeImports
+    );
   }
 
   visitPropertyNodeDeclaration(

--- a/test/plugin/fixtures/esm-enum/create-user.dto.ts
+++ b/test/plugin/fixtures/esm-enum/create-user.dto.ts
@@ -1,0 +1,6 @@
+import { Role } from './role.enum.js';
+
+export class CreateUserDto {
+  name: string;
+  role: Role;
+}

--- a/test/plugin/fixtures/esm-enum/role.enum.ts
+++ b/test/plugin/fixtures/esm-enum/role.enum.ts
@@ -1,0 +1,4 @@
+export enum Role {
+  Admin = 'admin',
+  User = 'user'
+}

--- a/test/plugin/fixtures/esm-enum/update-user.dto.ts
+++ b/test/plugin/fixtures/esm-enum/update-user.dto.ts
@@ -1,0 +1,5 @@
+import { Role } from './role.enum.js';
+
+export class UpdateUserDto {
+  role: Role;
+}

--- a/test/plugin/fixtures/parameter-property.dto.ts
+++ b/test/plugin/fixtures/parameter-property.dto.ts
@@ -25,10 +25,13 @@ export class ItemDto {
 export const parameterPropertyDtoTextTranspiled = (esmCompatible?: boolean) => {
   const fileName = 'parameter-property.dto';
   const fileImport = esmCompatible
-    ? `(await import("./${fileName}${getOutputExtension(fileName)}"))`
+    ? 'openapi_import_0'
     : `require("./${fileName}")`;
+  const typeImport = esmCompatible
+    ? `import * as openapi_import_0 from "./${fileName}${getOutputExtension(fileName)}";\n`
+    : '';
 
-  return `import * as openapi from "@nestjs/swagger";
+  return `${typeImport}import * as openapi from "@nestjs/swagger";
 export class ParameterPropertyDto {
     constructor(readonlyValue, privateValue, publicValue, regularParameter, protectedValue = '1234') {
         this.readonlyValue = readonlyValue;

--- a/test/plugin/model-class-visitor.spec.ts
+++ b/test/plugin/model-class-visitor.spec.ts
@@ -418,7 +418,7 @@ describe('API model properties', () => {
       options
     });
 
-    let outputText: string;
+    let outputText = '';
     program.emit(
       program.getSourceFile(dtoPath),
       (_fileName, text) => {
@@ -434,6 +434,52 @@ describe('API model properties', () => {
     );
     expect(outputText).toContain('enum: openapi_import_0.Role');
     expect(outputText).not.toContain('await');
+  });
+
+  it('should restart namespace import numbering for every emitted file', () => {
+    const options: ts.CompilerOptions = {
+      module: ts.ModuleKind.NodeNext,
+      moduleResolution: ts.ModuleResolutionKind.NodeNext,
+      target: ts.ScriptTarget.ES2022,
+      newLine: ts.NewLineKind.LineFeed,
+      noEmitHelpers: true,
+      experimentalDecorators: true
+    };
+    const createUserDtoPath = resolve(
+      __dirname,
+      'fixtures/esm-enum/create-user.dto.ts'
+    );
+    const updateUserDtoPath = resolve(
+      __dirname,
+      'fixtures/esm-enum/update-user.dto.ts'
+    );
+    const enumPath = resolve(__dirname, 'fixtures/esm-enum/role.enum.ts');
+    const program = ts.createProgram({
+      rootNames: [createUserDtoPath, updateUserDtoPath, enumPath],
+      options
+    });
+    const transformers = {
+      before: [before({ esmCompatible: true }, program)]
+    };
+
+    const outputTexts: string[] = [];
+    for (const dtoPath of [createUserDtoPath, updateUserDtoPath]) {
+      program.emit(
+        program.getSourceFile(dtoPath),
+        (_fileName, text) => {
+          outputTexts.push(text);
+        },
+        undefined,
+        false,
+        transformers
+      );
+    }
+
+    for (const outputText of outputTexts) {
+      expect(outputText).toContain(
+        'import * as openapi_import_0 from "./role.enum.js";'
+      );
+    }
   });
 
   it('should emit the CommonJS openapi import when esmCompatible is explicitly disabled', () => {

--- a/test/plugin/model-class-visitor.spec.ts
+++ b/test/plugin/model-class-visitor.spec.ts
@@ -402,6 +402,40 @@ describe('API model properties', () => {
     expect(isEsmOutputFile(sourceFile, options)).toBe(true);
   });
 
+  it('should reference cross-file types through a namespace import in ESM output', () => {
+    const options: ts.CompilerOptions = {
+      module: ts.ModuleKind.NodeNext,
+      moduleResolution: ts.ModuleResolutionKind.NodeNext,
+      target: ts.ScriptTarget.ES2022,
+      newLine: ts.NewLineKind.LineFeed,
+      noEmitHelpers: true,
+      experimentalDecorators: true
+    };
+    const dtoPath = resolve(__dirname, 'fixtures/esm-enum/create-user.dto.ts');
+    const enumPath = resolve(__dirname, 'fixtures/esm-enum/role.enum.ts');
+    const program = ts.createProgram({
+      rootNames: [dtoPath, enumPath],
+      options
+    });
+
+    let outputText: string;
+    program.emit(
+      program.getSourceFile(dtoPath),
+      (_fileName, text) => {
+        outputText = text;
+      },
+      undefined,
+      false,
+      { before: [before({ esmCompatible: true }, program)] }
+    );
+
+    expect(outputText).toContain(
+      'import * as openapi_import_0 from "./role.enum.js";'
+    );
+    expect(outputText).toContain('enum: openapi_import_0.Role');
+    expect(outputText).not.toContain('await');
+  });
+
   it('should emit the CommonJS openapi import when esmCompatible is explicitly disabled', () => {
     const options: ts.CompilerOptions = {
       module: ts.ModuleKind.NodeNext,


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: closes #4079

When the plugin emits ESM, a property whose type lives in another file is rewritten to `(await import("./role.enum.js")).Role`, and that expression lands inside the synchronous `static _OPENAPI_METADATA_FACTORY()`:

```js
static _OPENAPI_METADATA_FACTORY() {
    return { role: { required: true, enum: (await import("./role.enum.js")).Role } };
}
```

Node throws `SyntaxError: Unexpected reserved word` when the file loads, so the app never boots.

That `(await import(...))` form comes from `convertToAsyncImport()`, which readonly mode needs because the generated `metadata.ts` awaits its imports inside an async function. Transform mode has no async context to place it in. `_OPENAPI_METADATA_FACTORY` is called synchronously by `ModelPropertiesAccessor`, the explorers and the type helpers, so marking the method `async` would hand all of them a promise in place of the metadata object.

## What is the new behavior?

In ESM output each referenced module is hoisted to a namespace import at the top of the file, and the metadata reads the binding off it, which keeps the lookup synchronous:

```js
import * as openapi_import_0 from "./role.enum.js";
...
    static _OPENAPI_METADATA_FACTORY() {
        return { role: { required: true, enum: openapi_import_0.Role } };
    }
```

That is the ESM equivalent of the `require("./role.enum")` the CommonJS output already emits. It also covers the same expression in generated controller decorators, which sit outside the factory method and so would not have been helped by an `async` modifier.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

A new case in `model-class-visitor.spec.ts` builds a real `ts.Program` over a two-file fixture and asserts the emitted DTO carries the namespace import and no `await`. The `parameter-property.dto` fixture had the broken output baked into its expectation, so it is updated to match.
