### PR TITLE
fix(plugin): keep the source package specifier for workspace imports

### DIFF
--- a/lib/plugin/utils/plugin-utils.ts
+++ b/lib/plugin/utils/plugin-utils.ts
@@ -257,7 +257,8 @@ export function getOutputExtension(fileName: string): string {
 export function replaceImportPath(
   typeReference: string,
   fileName: string,
-  options: PluginOptions
+  options: PluginOptions,
+  sourceSpecifier?: string
 ) {
   if (!typeReference.includes('import')) {
     return { typeReference, importPath: null };
@@ -335,6 +336,17 @@ export function replaceImportPath(
     const normalizedPath = normalizePackagePath(relativePath);
     if (normalizedPath !== relativePath) {
       relativePath = normalizedPath;
+    } else if (sourceSpecifier) {
+      // The path leads outside the project without passing through
+      // node_modules, so `normalizePackagePath` cannot turn it back into a
+      // package specifier: this is a workspace package, which TypeScript
+      // resolves to the real file that declares the type. The relative path
+      // that would be emitted here reaches into that package's internals and
+      // holds only while the output stays at its current offset on disk, so a
+      // deployed application no longer resolves it. The specifier the visited
+      // file already imports the type through does resolve, at compile time
+      // and at run time alike.
+      relativePath = sourceSpecifier;
     } else if (options.esmCompatible) {
       // Add appropriate extension for non-node_modules imports
       const extension = getOutputExtension(fileName);
@@ -606,6 +618,61 @@ export function safeDecodeURIComponent(path: string) {
  *   ../node_modules/@amk/utils/src/dto/order.dto  →  @amk/utils/src/dto/order.dto
  *   ../../../packages/product-warehouse/dist/index  (no node_modules) → unchanged
  */
+/**
+ * Collects the package specifiers a file imports its types through, keyed by
+ * the symbol each import resolves to.
+ *
+ * Only bare specifiers are collected. A relative specifier is already rebased
+ * onto the output directory by `replaceImportPath`, so it needs no help here;
+ * a package specifier is the one piece of information that cannot be recovered
+ * from the resolved file path, because TypeScript resolves a package to the
+ * real file that declares the type and drops the entry point it went through.
+ */
+export function collectSourceImportSpecifiers(
+  sourceFile: ts.SourceFile,
+  typeChecker: ts.TypeChecker
+): Map<ts.Symbol, string> {
+  const specifiers = new Map<ts.Symbol, string>();
+  for (const statement of sourceFile.statements) {
+    if (
+      !ts.isImportDeclaration(statement) ||
+      !ts.isStringLiteral(statement.moduleSpecifier) ||
+      !statement.importClause
+    ) {
+      continue;
+    }
+    const specifier = statement.moduleSpecifier.text;
+    if (specifier.startsWith('.') || isAbsolute(specifier)) {
+      continue;
+    }
+
+    const { name, namedBindings } = statement.importClause;
+    const importedNames: ts.Identifier[] = name ? [name] : [];
+    if (namedBindings && ts.isNamedImports(namedBindings)) {
+      // A namespace import (`import * as ns`) resolves to the module itself
+      // rather than to any single type, so it is left out on purpose.
+      for (const element of namedBindings.elements) {
+        importedNames.push(element.name);
+      }
+    }
+
+    for (const importedName of importedNames) {
+      const localSymbol = typeChecker.getSymbolAtLocation(importedName);
+      if (!localSymbol) {
+        continue;
+      }
+      const symbol =
+        localSymbol.flags & ts.SymbolFlags.Alias
+          ? typeChecker.getAliasedSymbol(localSymbol)
+          : localSymbol;
+      if (!specifiers.has(symbol)) {
+        specifiers.set(symbol, specifier);
+      }
+    }
+  }
+  return specifiers;
+}
+
 export function normalizePackagePath(importPath: string): string {
   const nodeModulesText = 'node_modules';
   const nodeModulePos = importPath.indexOf(nodeModulesText);

--- a/lib/plugin/utils/type-reference-to-identifier.util.ts
+++ b/lib/plugin/utils/type-reference-to-identifier.util.ts
@@ -20,7 +20,8 @@ export function typeReferenceToIdentifier(
   factory: ts.NodeFactory,
   type: ts.Type,
   typeImports: Record<string, string>,
-  hoistedTypeImports?: Map<string, string>
+  hoistedTypeImports?: Map<string, string>,
+  sourceImportSpecifiers?: Map<ts.Symbol, string>
 ) {
   if (options.readonly) {
     assertReferenceableType(
@@ -34,7 +35,12 @@ export function typeReferenceToIdentifier(
   const { typeReference, importPath, typeName } = replaceImportPath(
     typeReferenceDescriptor.typeName,
     hostFilename,
-    options
+    options,
+    resolveSourceSpecifier(
+      type,
+      typeReferenceDescriptor.arrayDepth,
+      sourceImportSpecifiers
+    )
   );
 
   let identifier: ts.Identifier;
@@ -109,6 +115,30 @@ export function typeReferenceToIdentifier(
     identifier = factory.createIdentifier(ref);
   }
   return identifier;
+}
+
+/**
+ * Returns the specifier the visited file imports `type` through, if any. Array
+ * types are unwrapped first, so `Status[]` is matched on `Status`.
+ */
+function resolveSourceSpecifier(
+  type: ts.Type,
+  arrayDepth: number | undefined,
+  sourceImportSpecifiers: Map<ts.Symbol, string> | undefined
+): string | undefined {
+  if (!sourceImportSpecifiers?.size || !type) {
+    return undefined;
+  }
+  let elementType = type;
+  for (let depth = arrayDepth ?? 0; depth > 0; depth--) {
+    const arrayTuple = extractTypeArgumentIfArray(elementType);
+    if (!arrayTuple) {
+      break;
+    }
+    elementType = arrayTuple.type;
+  }
+  const symbol = elementType.aliasSymbol ?? elementType.symbol;
+  return symbol ? sourceImportSpecifiers.get(symbol) : undefined;
 }
 
 /**

--- a/lib/plugin/visitors/abstract.visitor.ts
+++ b/lib/plugin/visitors/abstract.visitor.ts
@@ -3,6 +3,7 @@ import { PluginOptions } from '../merge-options.js';
 import { OPENAPI_NAMESPACE, OPENAPI_PACKAGE_NAME } from '../plugin-constants.js';
 import { isEsmOutputFile } from '../utils/module-format.util.js';
 import {
+  collectSourceImportSpecifiers,
   getOutputExtension,
   normalizePackagePath
 } from '../utils/plugin-utils.js';
@@ -25,6 +26,28 @@ export class AbstractFileVisitor {
    * `insertHoistedTypeImports`.
    */
   protected readonly _hoistedTypeImports = new Map<string, string>();
+
+  /**
+   * Package specifiers (resolved symbol -> specifier) the currently visited
+   * file imports its types through. Refreshed per file by
+   * `refreshSourceImportSpecifiers` and read by `typeReferenceToIdentifier`.
+   */
+  protected _sourceImportSpecifiers = new Map<ts.Symbol, string>();
+
+  /**
+   * Reads the visited file's own import declarations, so that a type coming
+   * from another package is emitted through the specifier the file already
+   * uses instead of the path of the file that declares it.
+   */
+  protected refreshSourceImportSpecifiers(
+    sourceFile: ts.SourceFile,
+    typeChecker: ts.TypeChecker
+  ) {
+    this._sourceImportSpecifiers = collectSourceImportSpecifiers(
+      sourceFile,
+      typeChecker
+    );
+  }
 
   /**
    * Prepends the import declarations collected in `_hoistedTypeImports` to the

--- a/lib/plugin/visitors/controller-class.visitor.ts
+++ b/lib/plugin/visitors/controller-class.visitor.ts
@@ -64,6 +64,7 @@ export class ControllerClassVisitor extends AbstractFileVisitor {
     );
     const typeChecker = program.getTypeChecker();
     this._hoistedTypeImports.clear();
+    this.refreshSourceImportSpecifiers(sourceFile, typeChecker);
     if (!options.readonly) {
       sourceFile = this.updateImports(sourceFile, ctx.factory, program, options);
     }
@@ -796,7 +797,8 @@ export class ControllerClassVisitor extends AbstractFileVisitor {
       factory,
       type,
       this._typeImports,
-      this._hoistedTypeImports
+      this._hoistedTypeImports,
+      this._sourceImportSpecifiers
     );
     return factory.createPropertyAssignment('type', identifier);
   }

--- a/lib/plugin/visitors/model-class.visitor.ts
+++ b/lib/plugin/visitors/model-class.visitor.ts
@@ -64,6 +64,7 @@ export class ModelClassVisitor extends AbstractFileVisitor {
     );
     const typeChecker = program.getTypeChecker();
     this._hoistedTypeImports.clear();
+    this.refreshSourceImportSpecifiers(sourceFile, typeChecker);
     sourceFile = this.updateImports(sourceFile, ctx.factory, program, options);
 
     const propertyNodeVisitorFactory =
@@ -611,7 +612,8 @@ export class ModelClassVisitor extends AbstractFileVisitor {
       factory,
       type,
       this._typeImports,
-      this._hoistedTypeImports
+      this._hoistedTypeImports,
+      this._sourceImportSpecifiers
     );
 
     const initializer = factory.createArrowFunction(
@@ -826,7 +828,8 @@ export class ModelClassVisitor extends AbstractFileVisitor {
       factory,
       type,
       this._typeImports,
-      this._hoistedTypeImports
+      this._hoistedTypeImports,
+      this._sourceImportSpecifiers
     );
 
     const enumProperty = factory.createPropertyAssignment(key, enumIdentifier);

--- a/test/plugin/fixtures/workspace-package/app/src/item.dto.ts
+++ b/test/plugin/fixtures/workspace-package/app/src/item.dto.ts
@@ -1,0 +1,6 @@
+import { ItemStatus } from '@fixture/shared/messages';
+
+export class ItemDto {
+  id: string;
+  status: ItemStatus;
+}

--- a/test/plugin/fixtures/workspace-package/shared/build/messages/entry.d.ts
+++ b/test/plugin/fixtures/workspace-package/shared/build/messages/entry.d.ts
@@ -1,0 +1,1 @@
+export * from './item.js';

--- a/test/plugin/fixtures/workspace-package/shared/build/messages/item.d.ts
+++ b/test/plugin/fixtures/workspace-package/shared/build/messages/item.d.ts
@@ -1,0 +1,4 @@
+export declare enum ItemStatus {
+  ACTIVE = 'active',
+  INACTIVE = 'inactive'
+}

--- a/test/plugin/fixtures/workspace-package/tsconfig.json
+++ b/test/plugin/fixtures/workspace-package/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "rootDir": "./app/src",
+    "outDir": "./app/dist",
+    "paths": {
+      "@fixture/shared/messages": ["./shared/build/messages/entry.js"]
+    },
+    "strictPropertyInitialization": false,
+    "skipLibCheck": true
+  },
+  "include": ["app/src/**/*"]
+}

--- a/test/plugin/plugin-utils.spec.ts
+++ b/test/plugin/plugin-utils.spec.ts
@@ -1,11 +1,61 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import * as ts from 'typescript';
 import {
+  collectSourceImportSpecifiers,
   convertPath,
   replaceImportPath,
   safeDecodeURIComponent
 } from '../../lib/plugin/utils/plugin-utils';
+
+describe('collectSourceImportSpecifiers', () => {
+  function collect(sourceText: string) {
+    const fileName = '/repo/apps/api/src/items/item.dto.ts';
+    const host = ts.createCompilerHost({});
+    const originalGetSourceFile = host.getSourceFile.bind(host);
+    host.getSourceFile = (name, languageVersion, ...rest) =>
+      name === fileName
+        ? ts.createSourceFile(name, sourceText, languageVersion, true)
+        : originalGetSourceFile(name, languageVersion, ...rest);
+    host.fileExists = (name) => name === fileName;
+    host.readFile = (name) => (name === fileName ? sourceText : undefined);
+
+    const program = ts.createProgram([fileName], {}, host);
+    const sourceFile = program.getSourceFile(fileName)!;
+    return {
+      specifiers: collectSourceImportSpecifiers(
+        sourceFile,
+        program.getTypeChecker()
+      ),
+      sourceFile
+    };
+  }
+
+  it('should collect a named import from a package specifier', () => {
+    const { specifiers } = collect(
+      `import { ItemStatus } from '@repo/shared/messages';\nexport class ItemDto { status: ItemStatus; }`
+    );
+
+    expect([...specifiers.values()]).toEqual(['@repo/shared/messages']);
+  });
+
+  it('should ignore relative imports, which are rebased onto the output directory anyway', () => {
+    const { specifiers } = collect(
+      `import { ItemStatus } from './item-status';\nexport class ItemDto { status: ItemStatus; }`
+    );
+
+    expect(specifiers.size).toBe(0);
+  });
+
+  it('should ignore namespace imports, which resolve to the module rather than a type', () => {
+    const { specifiers } = collect(
+      `import * as shared from '@repo/shared/messages';\nexport class ItemDto { status: shared.ItemStatus; }`
+    );
+
+    expect(specifiers.size).toBe(0);
+  });
+});
 
 describe('plugin-utils', () => {
   describe('convertPath', () => {
@@ -57,6 +107,53 @@ describe('plugin-utils', () => {
   });
 
   describe('replaceImportPath', () => {
+    it('should keep the package specifier the source file imports the type through', () => {
+      // A workspace package: TypeScript resolved the type to the file that
+      // declares it, which sits outside the project and is reached without
+      // passing through node_modules.
+      const typeReference =
+        'import("/repo/packages/shared/dist/messages/item").ItemStatus';
+      const fileName = '/repo/apps/api/src/items/item.dto.ts';
+
+      const result = replaceImportPath(
+        typeReference,
+        fileName,
+        {},
+        '@repo/shared/messages'
+      );
+
+      expect(result.typeReference).toBe(
+        'require("@repo/shared/messages").ItemStatus'
+      );
+      expect(result.importPath).toBe('@repo/shared/messages');
+    });
+
+    it('should keep the package specifier without appending a file extension in esm output', () => {
+      const typeReference =
+        'import("/repo/packages/shared/dist/messages/item").ItemStatus';
+      const fileName = '/repo/apps/api/src/items/item.dto.ts';
+
+      const result = replaceImportPath(typeReference, fileName, {
+        esmCompatible: true
+      }, '@repo/shared/messages');
+
+      expect(result.importPath).toBe('@repo/shared/messages');
+      expect(result.typeReference).not.toContain('.js');
+    });
+
+    it('should still fold a node_modules path into its package name, ignoring the source specifier', () => {
+      // node_modules paths already carry the package name, and the subpath
+      // that normalizePackagePath keeps is more precise than the specifier
+      // the file happens to import from.
+      const typeReference =
+        'import("/repo/node_modules/@scope/pkg/dist/types").SomeType';
+      const fileName = '/repo/src/dto/test.dto.ts';
+
+      const result = replaceImportPath(typeReference, fileName, {}, '@scope/pkg');
+
+      expect(result.importPath).toBe('@scope/pkg/dist/types');
+    });
+
     it('should produce relative path when import path contains URL-encoded non-ASCII characters', () => {
       // Simulates what TypeScript produces when the project path contains non-ASCII chars.
       // TypeScript may URL-encode the path in the type reference string.

--- a/test/plugin/workspace-package-imports.spec.ts
+++ b/test/plugin/workspace-package-imports.spec.ts
@@ -1,0 +1,63 @@
+import { join } from 'path';
+import * as ts from 'typescript';
+import { before } from '../../lib/plugin/compiler-plugin';
+
+// Fixture layout (tsconfig: rootDir="./app/src", outDir="./app/dist"):
+//   app/src/item.dto.ts               imports ItemStatus from '@fixture/shared/messages'
+//   shared/build/messages/entry.d.ts   re-exports './item.js'
+//   shared/build/messages/item.d.ts    declares ItemStatus
+//
+// The package is reached through a tsconfig "paths" mapping, which produces
+// the same shape a workspace package has once TypeScript has resolved it: the
+// type is found in the file that *declares* it, outside the project's rootDir
+// and without passing through node_modules. A symlinked workspace package
+// resolves identically, because TypeScript follows the link to the real path,
+// so `normalizePackagePath` has no node_modules segment to fold back into a
+// package specifier.
+const projectDir = join(__dirname, 'fixtures', 'workspace-package');
+const packageSpecifier = '@fixture/shared/messages';
+
+function transpileFixture(compilerOptionsOverrides: ts.CompilerOptions = {}) {
+  const parsedCmd = ts.getParsedCommandLineOfConfigFile(
+    join(projectDir, 'tsconfig.json'),
+    compilerOptionsOverrides,
+    ts.sys as unknown as ts.ParseConfigFileHost
+  );
+  const { options, fileNames: rootNames } = parsedCmd!;
+  const program = ts.createProgram({ options, rootNames });
+
+  const sourceFile = program.getSourceFile(
+    join(projectDir, 'app', 'src', 'item.dto.ts')
+  )!;
+
+  let output = '';
+  program.emit(
+    sourceFile,
+    (_fileName, text) => {
+      output = text;
+    },
+    undefined,
+    false,
+    { before: [before({ dtoFileNameSuffix: ['.dto.ts'] }, program)] }
+  );
+  return output;
+}
+
+describe('CLI plugin with a type imported from a workspace package', () => {
+  it('should hoist the import under the specifier the source file uses', () => {
+    const output = transpileFixture();
+
+    expect(output).toContain(`import * as openapi_import_1 from "${packageSpecifier}"`);
+    expect(output).toContain('enum: openapi_import_1.ItemStatus');
+  });
+
+  it('should not reach into the producing package with a filesystem path', () => {
+    // The path emitted here before only resolved while the output stayed at
+    // its original offset on disk, so the application stopped starting as soon
+    // as it was deployed without its sibling packages at the same offset.
+    const output = transpileFixture();
+
+    expect(output).not.toContain('shared/build/messages/item');
+    expect(output).not.toMatch(/\.\.\/\.\.\//);
+  });
+});


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #4071 (earlier report: #3937)

When a DTO takes a type from a sibling workspace package, the metadata factory points at the file that *declares* the type instead of the entry point the source *imports*:

```ts
// apps/api/src/items/item.dto.ts
import { ItemStatus } from '@repro/shared/messages';

export class ItemDto {
  id!: string;
  status!: ItemStatus;
}
```

```js
// apps/api/dist/items/item.dto.js, @nestjs/swagger 12.0.1
import * as openapi_import_1 from "../../../../packages/shared/dist/messages/item.js";
```

TypeScript resolves a workspace package to the real path of the declaring file, so the emitted specifier never passes through `node_modules` and `normalizePackagePath()` has nothing to fold back into a package name. The relative path that is emitted instead only resolves while the compiled app sits at its original offset on disk.

I reproduced this on 12.0.1 against the reporter's [reproduction repository](https://github.com/datageo-cz/datageo-swagger-plugin-error-reproduction), using `pnpm deploy --filter @repro/api --prod` (the standard way to produce a self-contained bundle):

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/private/packages/shared/dist/messages/item.js'
imported from /private/tmp/deploy-v12/dist/items/item.dto.js
```

Two notes on the current state, since the issue predates 12.0.1:

- The `await import()` inside the synchronous factory that the reporter also described is **already fixed** by 8980a54 ("fix: esm hoist static imports"), released in 12.0.1. They tested master at de89f82, five days earlier. `node --check` passes today.
- That fix does, however, change the severity of the remaining bug. In 11.4.7 the bad path sat inside `_OPENAPI_METADATA_FACTORY()` as a `require()`, so it only threw when `SwaggerModule.createDocument` walked the DTO. It is now a static top-level import, so a deployed application fails while loading the module, before Nest starts.

It is also not specific to pnpm's injected workspace packages: removing `injectWorkspacePackages` and installing with plain symlinks produces byte-identical output, because TypeScript follows the link to the real path either way.

## What is the new behavior?

When the emitted path cannot be folded back into a package specifier, the plugin falls back to the specifier the visited file already imports the type through:

```js
import * as openapi_import_1 from "@repro/shared/messages";
```

The specifier is read from the file's own import declarations, matched by resolved symbol rather than by name, and recorded per file next to the existing hoisted-import bookkeeping. So it is exactly what the source resolves, at compile time and at run time alike, and the package's `exports` map keeps doing its job. There is nothing to reverse-engineer out of `package.json`, and no specifier can be invented that the file could not already resolve.

Deliberately narrow:

- Paths that go through `node_modules` keep their current handling, including the subpath `normalizePackagePath()` preserves.
- Relative specifiers are ignored; they are already rebased onto `outDir`.
- Namespace imports (`import * as ns`) are ignored, since they resolve to the module rather than to a type.
- A type the visited file does not import directly keeps the previous behaviour.

Verified end to end on the reproduction repository with this branch packed and installed: the deployed bundle now starts, and `/docs-json` returns the enum as declared.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

## Other information

`npm run build`, `npm test` (506 tests, 47 files) and `npm run test:e2e` (133 tests) pass; `oxlint lib/` reports the same 15 warnings as master. The seven added tests each fail on master and pass here.

I did not reuse the approach from #3938, which was closed without comment: it derived the specifier by walking up to the producing `package.json` and reversing its `exports` map, which is a second module resolver inside the plugin. Reading the specifier the source already wrote seemed like the smaller thing to maintain, but I am happy to take direction if the other shape is preferred.
