### PR TITLE
fix(plugin): treat single literal types as enums

### DIFF
--- a/lib/plugin/utils/plugin-utils.ts
+++ b/lib/plugin/utils/plugin-utils.ts
@@ -515,21 +515,23 @@ function isPlainNumberLiteralType(type: ts.Type): type is ts.NumberLiteralType {
 
 /**
  * Returns the literal values from a union type like `'a' | 'b'` or `1 | 2`,
- * stripping null/undefined constituents.
+ * stripping null/undefined constituents. A single literal type such as `'a'`
+ * or `42` is treated as a one-member union and yields `['a']` / `[42]`.
  * All non-null/undefined constituents must be the same kind of literal
  * (all string or all number). TypeScript enum members are excluded.
  */
 export function getStringLiteralUnionValues(
   type: ts.Type
 ): { values: (string | number)[]; isNullable: boolean } | undefined {
-  if (!type.isUnion()) {
-    return undefined;
-  }
-  const isNullable = type.types.some((t) => hasFlag(t, ts.TypeFlags.Null));
+  const isNullable =
+    type.isUnion() && type.types.some((t) => hasFlag(t, ts.TypeFlags.Null));
 
-  const members = type.types.filter(
-    (t) => !hasFlag(t, ts.TypeFlags.Null) && !hasFlag(t, ts.TypeFlags.Undefined)
-  );
+  const members = type.isUnion()
+    ? type.types.filter(
+        (t) =>
+          !hasFlag(t, ts.TypeFlags.Null) && !hasFlag(t, ts.TypeFlags.Undefined)
+      )
+    : [type];
 
   if (members.length === 0) {
     return undefined;

--- a/test/plugin/fixtures/string-literal-union.dto.ts
+++ b/test/plugin/fixtures/string-literal-union.dto.ts
@@ -19,3 +19,23 @@ export class StringLiteralUnionDto {
   inlineNumberUnion: 1 | 2 | 3;
 }
 `;
+
+export const singleLiteralDtoText = `
+type Single = "red";
+type SingleNumber = 42;
+
+export class SingleLiteralDto {
+  @ApiProperty()
+  aliasSingle: Single;
+  @ApiProperty()
+  inlineSingle: "red";
+  @ApiProperty()
+  aliasSingleNumber: SingleNumber;
+  @ApiProperty()
+  inlineSingleNumber: 42;
+  @ApiProperty()
+  optionalSingle?: Single;
+  @ApiProperty()
+  nullableSingle: Single | null;
+}
+`;

--- a/test/plugin/fixtures/string-literal.dto.ts
+++ b/test/plugin/fixtures/string-literal.dto.ts
@@ -10,7 +10,7 @@ export class StringLiteralDto {
 export const stringLiteralDtoTextTranspiled = `import * as openapi from "@nestjs/swagger";
 export class StringLiteralDto {
     static _OPENAPI_METADATA_FACTORY() {
-        return { valueOne: { required: true, type: () => String }, valueTwo: { required: true, enum: ["one", "two"] } };
+        return { valueOne: { required: true, enum: ["one"] }, valueTwo: { required: true, enum: ["one", "two"] } };
     }
 }
 __decorate([

--- a/test/plugin/model-class-visitor.spec.ts
+++ b/test/plugin/model-class-visitor.spec.ts
@@ -62,7 +62,10 @@ import {
   booleanLiteralDtoText,
   booleanLiteralDtoTextTranspiled
 } from './fixtures/boolean-literal.dto';
-import { stringLiteralUnionDtoText } from './fixtures/string-literal-union.dto';
+import {
+  stringLiteralUnionDtoText,
+  singleLiteralDtoText
+} from './fixtures/string-literal-union.dto';
 import {
   recordDtoText,
   recordDtoTextTranspiled
@@ -875,6 +878,47 @@ describe('API model properties', () => {
       `inlineNumberUnion: { required: true, enum: [1, 2, 3] }`
     );
     expect(result.outputText).not.toContain(`type: () => Object`);
+  });
+
+  it('should produce enum metadata for single literal types', () => {
+    const options: ts.CompilerOptions = {
+      module: ts.ModuleKind.ES2022,
+      target: ts.ScriptTarget.ES2020,
+      newLine: ts.NewLineKind.LineFeed,
+      noEmitHelpers: true,
+      experimentalDecorators: true,
+      strict: true
+    };
+    const filename = 'single-literal.dto.ts';
+    const fakeProgram = ts.createProgram([filename], options);
+
+    const result = ts.transpileModule(singleLiteralDtoText, {
+      compilerOptions: options,
+      fileName: filename,
+      transformers: {
+        before: [before({}, fakeProgram)]
+      }
+    });
+
+    expect(result.outputText).toContain(
+      `aliasSingle: { required: true, enum: ["red"] }`
+    );
+    expect(result.outputText).toContain(
+      `inlineSingle: { required: true, enum: ["red"] }`
+    );
+    expect(result.outputText).toContain(
+      `aliasSingleNumber: { required: true, enum: [42] }`
+    );
+    expect(result.outputText).toContain(
+      `inlineSingleNumber: { required: true, enum: [42] }`
+    );
+    expect(result.outputText).toContain(
+      `optionalSingle: { required: false, enum: ["red"] }`
+    );
+    expect(result.outputText).toContain(
+      `nullableSingle: { required: true, nullable: true, enum: ["red"] }`
+    );
+    expect(result.outputText).not.toContain(`type: () => String`);
   });
 
   it('should emit IsIn enum metadata for literal union properties that fall back to Object', () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

Follow-up to #3964, which added string/number literal union support to the CLI plugin.

`getStringLiteralUnionValues()` returns early for any type that is not a union:

```ts
if (!type.isUnion()) {
  return undefined;
}
```

As a result a literal type with a single member never reaches the literal handling and falls back to the generic type path:

```ts
type Color = 'red' | 'blue';
type Single = 'red';

export class UserDto {
  color: Color;                  // enum: ["red", "blue"]  (works)
  single: Single;                // type: () => String     (enum is lost)
  inlineSingle: 'red';           // type: () => String     (enum is lost)
  optionalSingle?: Single;       // type: () => String     (enum is lost)
  nullableSingle: Single | null; // type: () => String     (enum is lost)
}
```

`Single | null` and `Single | undefined` are affected for the same reason: the null/undefined constituents are stripped before this function is called, so the remaining type arrives here as a bare literal type and hits the same early return.

Numeric literals such as `type SingleNum = 42` go through the same early return and lose their `enum` as well.

The resulting OpenAPI schema drops the `enum` entirely:

```json
"single":         { "type": "string" },
"inlineSingle":   { "type": "string" },
"optionalSingle": { "type": "string" },
"nullableSingle": { "type": "string", "nullable": true }
```

## What is the new behavior?

A non-union literal type is treated as a one-member union, so single literals produce `enum` metadata just like multi-member unions:

```json
"single":         { "type": "string", "enum": ["red"] },
"inlineSingle":   { "type": "string", "enum": ["red"] },
"optionalSingle": { "type": "string", "enum": ["red"] },
"nullableSingle": { "type": "string", "nullable": true, "enum": ["red"] }
```

Numeric literals are handled by the same code path, so `type SingleNum = 42` now yields `enum: [42]`.

The existing type-kind checks are unchanged, so enum members still resolve to their enum reference and plain `string` / `number` properties are unaffected.

Note: the existing `string-literal.dto.ts` fixture asserted the previous behaviour (`valueOne: { type: () => String }`) and is updated to expect `enum: ["one"]`.

## Does this PR introduce a breaking change?
- [x] Yes
- [ ] No

Single literal properties that previously emitted `type: string` now emit `enum` as well, so generated OpenAPI documents change for those properties. This aligns them with the literal union behaviour introduced in #3964.

## Other information

Verified against the built package (`nest build` through the CLI plugin, then `SwaggerModule.createDocument`), not only through unit tests.


